### PR TITLE
Flip branch-vs-main polarity to default-main + threshold triggers

### DIFF
--- a/.claude/hooks/log-commit.sh
+++ b/.claude/hooks/log-commit.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Appends one JSON line per real git commit, so commits are traceable back
+# to the session and machine that made them.
+#
+# Fires on PostToolUse for Bash and returns immediately unless the command
+# actually committed something. Filters on the command text, not the
+# matcher (see measure-cherry-pick.sh for why matcher-side filtering
+# doesn't work here).
+set -euo pipefail
+
+input=$(cat)
+tool=$(printf '%s' "$input" | jq -r '.tool_name // ""')
+[ "$tool" = "Bash" ] || exit 0
+
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
+printf '%s' "$cmd" | grep -qE '\bgit\b.*\bcommit\b' || exit 0
+
+cwd=$(printf '%s' "$input" | jq -r '.cwd // ""')
+[ -n "$cwd" ] && cd "$cwd" 2>/dev/null || exit 0
+git rev-parse --git-dir >/dev/null 2>&1 || exit 0
+
+commit=$(git rev-parse HEAD 2>/dev/null || echo "")
+[ -n "$commit" ] || exit 0
+
+repo=$(basename "$(git rev-parse --show-toplevel 2>/dev/null || echo "$cwd")")
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+sid=$(printf '%s' "$input" | jq -r '.session_id // env.CLAUDE_CODE_SESSION_ID // ""')
+
+# Same placement rule as log-decisions.sh / measure-cherry-pick.sh: this is
+# session content, and dotfiles is public. Fall back to a gitignored local
+# dir when the private state repo isn't cloned on this machine.
+log_dir="$HOME/claude_prompts_scratch/state/global"
+[ -d "$HOME/claude_prompts_scratch/.git" ] || log_dir="$HOME/.claude/journal"
+mkdir -p "$log_dir"
+
+jq -nc \
+  --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --arg session_id "$sid" \
+  --arg remote_session_id "${CLAUDE_CODE_REMOTE_SESSION_ID:-}" \
+  --arg repo "$repo" --arg branch "$branch" --arg commit "$commit" \
+  --arg version "${CLAUDE_CODE_VERSION:-}" \
+  '{ts:$ts, session_id:$session_id, remote_session_id:$remote_session_id, repo:$repo, branch:$branch, commit:$commit, claude_code_version:$version}' \
+  >> "$log_dir/commits.jsonl"
+
+exit 0

--- a/.claude/rules/code.md
+++ b/.claude/rules/code.md
@@ -21,15 +21,27 @@ project-specific facts belong in that project's own CLAUDE.md.
   surgery; it may have moved since session start.
 - Prefer `rm` or an edit over `git rm` for files being replaced, so deletions
   stay unstaged until I commit them.
-- **Commit to main. A branch requires Mark's explicit ask.** A branch
-  demands a PR, and a PR is a high-cost decision pushed onto Mark; log any
-  PR you create as high cost / low decision quality. "I didn't touch main
-  out of caution" is the failure mode, not the safe mode — parked branches
-  pile up unmerged and Mark has to untangle them. If a branch is genuinely
-  warranted and approved, finish it with a PR; never fold it back into
-  main and delete it. (Hardened 2026-08-19 after five stranded claude/*
-  branches; originally added same day for
-  `claude/rules-config-recovery-7paovw`.)
+- **Work on main by default. Branch-vs-main is a rule, not a judgment
+  call — don't ask.** Commit straight to main in small, verified commits,
+  pushed early and often, unless one of these triggers:
+  - **Explicit phrase** — I say "make this a feature," "make this a
+    branch," or "this needs review." Skip the metric check; branch
+    immediately.
+  - **Metric threshold crossed** (placeholders, tune later): **>50 lines
+    of code changed** (excluding docs), **>200 lines of docs changed**,
+    **session >100k tokens**, or **session >30 min wall clock**.
+
+  Everything else — small fixes, doc edits, config tweaks — goes straight
+  to main, no branch, no asking. Reversed 2026-08-19 from the prior
+  deny-by-default polarity ("commit to main requires no branch reason");
+  the old rule produced five stranded `claude/*` branches from excess
+  caution, which was the actual failure mode, not landing on main.
+
+  When a branch *is* warranted under this rule: always open the PR
+  yourself immediately, **as a draft, with no reviewer requested** — never
+  wait to be asked, never leave a pushed branch without one. A branch
+  opened under this rule ends only one way: merged via PR, never folded
+  back to main and deleted.
 
 ## Publishing
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -56,6 +56,10 @@
           {
             "type": "command",
             "command": "bash \"$HOME/.claude/hooks/measure-cherry-pick.sh\" 2>/dev/null || true"
+          },
+          {
+            "type": "command",
+            "command": "bash \"$HOME/.claude/hooks/log-commit.sh\" 2>/dev/null || true"
           }
         ]
       }


### PR DESCRIPTION
## What changed

Reverses the git-hygiene branch/PR rule in `.claude/rules/code.md` from
deny-by-default ("commit to main requires no branch reason") to
default-main-with-triggers, matching a resolution reached in a separate
git-hygiene chat:

- **Work on main by default.** Branch only when an explicit phrase ("make
  this a feature/branch", "this needs review") or a metric threshold fires
  (placeholders: >50 LOC changed excl. docs, >200 doc-lines, >100k tokens,
  >30 min wall clock — all tunable later).
- **Once branched, always self-open the PR as a draft with no reviewer**,
  immediately, never asked.
- Also adds `.claude/hooks/log-commit.sh`, a new `PostToolUse` hook that
  appends one JSONL line per real commit — session id, remote session id,
  time, repo, branch, commit SHA, `CLAUDE_CODE_VERSION` — to
  `claude_prompts_scratch/state/global/commits.jsonl` (or a local
  gitignored fallback), for commit traceability/metrics. Wired into
  `.claude/settings.json` alongside the existing cherry-pick hook.

Companion edit in `symphony/CLAUDE.md` (pushed straight to main there,
per that repo's own rule) adds the same explicit-phrase/metric criteria
to its existing branch-vs-main section.

## Explicitly out of scope (see follow-up)

The deeper conflict between this session's own "never push off the
assigned branch" contract and the target rule's "land on main even when
the harness pre-assigns a branch" is not resolved here — flagged for a
follow-up session.

## Verification

- `bash -n` on the new hook; dry-run against a scratch repo confirmed all
  seven JSONL fields and the fallback log path.
- Grepped both edited rule files to confirm no leftover old-polarity text.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQxWkJSjWVQoRotk1w5rug)_