### PR TITLE
Add branch-cleanup convention to git-hygiene rules

### DIFF
--- a/.claude/rules/code.md
+++ b/.claude/rules/code.md
@@ -55,6 +55,17 @@ project-specific facts belong in that project's own CLAUDE.md.
   it — that instruction is for that session only and takes precedence;
   finish that branch with a PR as usual.
 
+- **Branch cleanup: merged means deleted.** Keep "Automatically delete head
+  branches" ticked on every repo (dotfiles: on, confirmed 2026-08-19 when
+  PR #5's head vanished on merge) so the common case needs no sweep. Beyond
+  that, a branch whose commits are all ancestors of `main` is garbage —
+  delete it on sight, no ceremony, no asking. A branch with commits *not* in
+  main is real unlanded work: don't delete it, surface it to Mark instead.
+  Cloud sessions often can't delete remote branches (`git push --delete` is
+  blocked by the auto-mode classifier and there is no MCP equivalent), so
+  the sweep is a nucbox job; from a cloud session, just list what should go.
+  (Decided 2026-08-19.)
+
 ## Publishing
 
 - **npm publish: no OTP.** My npm account uses browser 2FA with a passkey.


### PR DESCRIPTION
Follow-up to #5, closing its "Out of scope, still open" list.

## What this does

Adds one bullet to `.claude/rules/code.md`: merged means deleted. Keep GitHub's "Automatically delete head branches" ticked (dotfiles already has it — #5's head branch vanished on merge); a branch fully contained in `main` is garbage and gets deleted on sight; a branch with commits *not* in main is unlanded work and gets surfaced to Mark, never deleted. Notes that the sweep itself is a nucbox job, since `git push --delete` is blocked by the cloud auto-mode classifier and the GitHub MCP server has no delete-branch tool.

## Done elsewhere in the same session

- Grant ported into `symphony/CLAUDE.md` (pushed straight to symphony `main`), replacing the older "fold it back to main, no PR" bullet that resolved the same situation oppositely.
- `claude_prompts_scratch/CLAUDE.md` reconciled — its main-only rule was already consistent, but its forced-branch parenthetical now points at the standing grant.
- Checkpoint at `claude_prompts_scratch/state/global/log/2026-08-19-git-hygiene-followups.md`, including the classified branch list for the sweep.

This PR exists rather than a push to main because this session's dispatch pins `claude/git-hygiene-branch-rules-i90ixw` — the carve-out the grant itself names.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAK6xzNAVJf55uL3SLL6XJ)_