### PR TITLE
Show session metrics live in the statusline

### DIFF
--- a/.claude/hooks/metrics-live.sh
+++ b/.claude/hooks/metrics-live.sh
@@ -25,6 +25,12 @@ command -v jq >/dev/null 2>&1 || exit 0
 
 EVENT="${1:-tool}"          # prompt | question | git | stop | statusline
 MAX_AGE="${2:-0}"           # seconds; >0 means "skip if cache is fresher"
+SHOW="${3:-}"               # "show" -> also print a systemMessage block
+
+# `show` on an event that Claude can read would make the block context, not
+# display. Only PreToolUse/PostToolUse/Stop keep systemMessage display-only;
+# on UserPromptSubmit and SessionStart the model sees it, so those never show.
+case "$EVENT" in prompt|statusline) SHOW="" ;; esac
 
 input=$(cat 2>/dev/null || echo '{}')
 tp=$(printf '%s' "$input" | jq -r '.transcript_path // empty')
@@ -84,4 +90,18 @@ printf '%s\n' "$metrics" | jq -c \
   '.session + {last_event: $ev, updated_at: $now,
                dirty: $d, unpushed: $u, commits: $c}' > "$tmp" 2>/dev/null \
   && mv -f "$tmp" "$OUT" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+
+# ------------------------------------------------------------ event block
+# Shown to Mark at the moments that matter -- a question put to him, a git
+# event, the end of the session -- and never sent to the model, so the
+# running decision count costs nothing to display.
+[ "$SHOW" = show ] && [ -f "$OUT" ] && jq -c '
+  def k: if . >= 1000 then "\(. / 1000 | floor)k" else "\(.)" end;
+  def evname: {question: "decision point", git: "git event", stop: "session end"}[.last_event] // .last_event;
+  {systemMessage: (
+     "⛁ \(evname) · \(.repo)@\(.branch // "?")\n"
+   + "  decisions \(.decisions.total)  (\(.decisions.scoping) scoping · \(.decisions.inline) inline · \(.decisions.gate) gate)\n"
+   + "  cost      \(.output_tokens | k) out · ctx peak \(.context_peak | k) · \(.user_turns) prompts · \(.tool_calls) tools\n"
+   + "  work      \(.commits) commits · \(.dirty) dirty · \(.unpushed) unpushed"
+   + (if .unpushed > 0 then "  ← not safe to kill" else "" end))}' "$OUT" 2>/dev/null
 exit 0

--- a/.claude/hooks/metrics-live.sh
+++ b/.claude/hooks/metrics-live.sh
@@ -32,10 +32,12 @@ SHOW="${3:-}"               # "show" -> also print a systemMessage block
 # on UserPromptSubmit and SessionStart the model sees it, so those never show.
 case "$EVENT" in prompt|statusline) SHOW="" ;; esac
 
+# One jq for all three fields: the statusline reaches this code on every
+# render, and three spawns before the staleness check was most of its cost.
 input=$(cat 2>/dev/null || echo '{}')
-tp=$(printf '%s' "$input" | jq -r '.transcript_path // empty')
-sid=$(printf '%s' "$input" | jq -r '.session_id // empty')
-cwd=$(printf '%s' "$input" | jq -r '.cwd // .workspace.current_dir // empty')
+IFS=$'\t' read -r tp sid cwd <<<"$(printf '%s' "$input" | jq -r \
+  '[(.transcript_path // ""), (.session_id // ""),
+    (.cwd // .workspace.current_dir // "")] | @tsv')"
 [ -n "$tp" ] && [ -f "$tp" ] && [ -n "$sid" ] || exit 0
 [ -n "$cwd" ] || cwd=$PWD
 
@@ -73,13 +75,21 @@ metrics=$(jq -s \
 [ -n "$metrics" ] || exit 0
 
 # Git state, the part that decides whether the chat is safe to kill.
-dirty=0; unpushed=0; ncommits=0
+dirty=0; unpushed=0; ncommits=0; start_sha=""
 if [ -n "$work_root" ]; then
   dirty=$(git -C "$work_root" status --porcelain 2>/dev/null | wc -l | tr -d ' ')
   unpushed=$(git -C "$work_root" rev-list --count '@{u}..HEAD' 2>/dev/null || echo 0)
-  started=$(printf '%s' "$metrics" | jq -r '.session.started_at // empty')
-  ncommits=$(git -C "$work_root" rev-list --count \
-    --since="${started:-1 day ago}" HEAD 2>/dev/null || echo 0)
+  # Commits counted from the SHA this session started at, not by timestamp.
+  # `--since=<start>` counts everything in the window whatever wrote it, so a
+  # fresh clone whose history landed today reports a session's commits as 13
+  # when it made none -- and a number that is persistently wrong on screen is
+  # worse than no number, because you stop reading the field.
+  start_sha=$(jq -r '.start_sha // ""' "$OUT" 2>/dev/null)
+  [ -n "$start_sha" ] \
+    || start_sha=$(git -C "$work_root" rev-parse HEAD 2>/dev/null || echo "")
+  if [ -n "$start_sha" ]; then
+    ncommits=$(git -C "$work_root" rev-list --count "$start_sha..HEAD" 2>/dev/null || echo 0)
+  fi
 fi
 
 mkdir -p "$LIVE" 2>/dev/null || exit 0
@@ -87,7 +97,8 @@ tmp="$OUT.$$"
 printf '%s\n' "$metrics" | jq -c \
   --arg ev "$EVENT" --arg now "$now" \
   --argjson d "${dirty:-0}" --argjson u "${unpushed:-0}" --argjson c "${ncommits:-0}" \
-  '.session + {last_event: $ev, updated_at: $now,
+  --arg sha "$start_sha" \
+  '.session + {last_event: $ev, updated_at: $now, start_sha: $sha,
                dirty: $d, unpushed: $u, commits: $c}' > "$tmp" 2>/dev/null \
   && mv -f "$tmp" "$OUT" 2>/dev/null || rm -f "$tmp" 2>/dev/null
 
@@ -100,7 +111,9 @@ printf '%s\n' "$metrics" | jq -c \
   def evname: {question: "decision point", git: "git event", stop: "session end"}[.last_event] // .last_event;
   {systemMessage: (
      "⛁ \(evname) · \(.repo)@\(.branch // "?")\n"
-   + "  decisions \(.decisions.total)  (\(.decisions.scoping) scoping · \(.decisions.inline) inline · \(.decisions.gate) gate)\n"
+   + "  decisions \(.decisions.total)"
+   + (if .last_event == "question" then " (+1 being asked now)" else "" end)
+   + "  (\(.decisions.scoping) scoping · \(.decisions.inline) inline · \(.decisions.gate) gate)\n"
    + "  cost      \(.output_tokens | k) out · ctx peak \(.context_peak | k) · \(.user_turns) prompts · \(.tool_calls) tools\n"
    + "  work      \(.commits) commits · \(.dirty) dirty · \(.unpushed) unpushed"
    + (if .unpushed > 0 then "  ← not safe to kill" else "" end))}' "$OUT" 2>/dev/null

--- a/.claude/hooks/metrics-live.sh
+++ b/.claude/hooks/metrics-live.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Recompute the session's metrics NOW and cache them where the statusline can
+# read them without paying for the computation itself.
+#
+# Why a cache file at all: `session-metrics.jq` slurps the whole transcript,
+# which is fine once at Stop but not on every statusline render (those fire
+# several times a second). So the expensive part runs only on the events that
+# actually change the numbers -- a prompt, a question put to Mark, a git
+# event -- and the statusline just prints what is already on disk.
+#
+# One file per session, keyed by session_id: parallel sessions are normal
+# here, and per-session paths mean two of them never write the same file.
+# The rollup that merges them (`metrics/metrics.json`) is *generated*, never
+# hand-merged, so a push can't conflict on it in a way that needs resolving.
+#
+# stdin: any hook payload carrying transcript_path/session_id/cwd.
+# Always exits 0.
+set -uo pipefail
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib-state.sh
+. "$HOOK_DIR/lib-state.sh"
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+EVENT="${1:-tool}"          # prompt | question | git | stop | statusline
+MAX_AGE="${2:-0}"           # seconds; >0 means "skip if cache is fresher"
+
+input=$(cat 2>/dev/null || echo '{}')
+tp=$(printf '%s' "$input" | jq -r '.transcript_path // empty')
+sid=$(printf '%s' "$input" | jq -r '.session_id // empty')
+cwd=$(printf '%s' "$input" | jq -r '.cwd // .workspace.current_dir // empty')
+[ -n "$tp" ] && [ -f "$tp" ] && [ -n "$sid" ] || exit 0
+[ -n "$cwd" ] || cwd=$PWD
+
+# A git event means an actual git-state change, not every Bash call: the jq
+# pass is too expensive to run after `ls`.
+if [ "$EVENT" = git ]; then
+  printf '%s' "$input" \
+    | jq -r '.tool_input.command // .tool_name // ""' \
+    | grep -qE '\bgit\s+(commit|push|merge|rebase|cherry-pick|checkout|switch|tag)\b|create_pull_request' \
+    || exit 0
+fi
+
+JQPROG="$HOOK_DIR/session-metrics.jq"
+[ -f "$JQPROG" ] || exit 0
+
+LIVE="$(state_dir)/metrics/live"
+OUT="$LIVE/$sid.json"
+
+# Throttle: the statusline asks constantly, events ask rarely. An event
+# always recomputes; the statusline only does so if the cache has gone stale.
+if [ "$MAX_AGE" -gt 0 ] && [ -f "$OUT" ]; then
+  age=$(( $(date +%s) - $(stat -c %Y "$OUT" 2>/dev/null || stat -f %m "$OUT" 2>/dev/null || echo 0) ))
+  [ "$age" -lt "$MAX_AGE" ] && exit 0
+fi
+
+now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+work_root=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || echo "")
+work_repo=$([ -n "$work_root" ] && basename "$work_root" || basename "$cwd")
+work_branch=$(git -C "$cwd" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+
+metrics=$(jq -s \
+  --arg sid "$sid" --arg repo "$work_repo" --arg branch "$work_branch" \
+  --arg cwd "$cwd" --arg now "$now" \
+  -f "$JQPROG" "$tp" 2>/dev/null) || exit 0
+[ -n "$metrics" ] || exit 0
+
+# Git state, the part that decides whether the chat is safe to kill.
+dirty=0; unpushed=0; ncommits=0
+if [ -n "$work_root" ]; then
+  dirty=$(git -C "$work_root" status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+  unpushed=$(git -C "$work_root" rev-list --count '@{u}..HEAD' 2>/dev/null || echo 0)
+  started=$(printf '%s' "$metrics" | jq -r '.session.started_at // empty')
+  ncommits=$(git -C "$work_root" rev-list --count \
+    --since="${started:-1 day ago}" HEAD 2>/dev/null || echo 0)
+fi
+
+mkdir -p "$LIVE" 2>/dev/null || exit 0
+tmp="$OUT.$$"
+printf '%s\n' "$metrics" | jq -c \
+  --arg ev "$EVENT" --arg now "$now" \
+  --argjson d "${dirty:-0}" --argjson u "${unpushed:-0}" --argjson c "${ncommits:-0}" \
+  '.session + {last_event: $ev, updated_at: $now,
+               dirty: $d, unpushed: $u, commits: $c}' > "$tmp" 2>/dev/null \
+  && mv -f "$tmp" "$OUT" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+exit 0

--- a/.claude/hooks/metrics-rollup.sh
+++ b/.claude/hooks/metrics-rollup.sh
@@ -19,8 +19,14 @@ M="$(state_dir)/metrics"
 # rollup keeps counting that half-session's tokens in every future total.
 # 14 days is well past any session that is still going to finish.
 find "$M/live" -name '*.json' -mtime +14 -delete 2>/dev/null
-files=$(ls "$M"/sessions/*.json "$M"/live/*.json 2>/dev/null) || exit 0
-[ -n "$files" ] || exit 0
+# Globbing, not `ls`: with an unmatched pattern `ls` exits 2, and the old
+# `|| exit 0` then aborted the rollup even when the other glob had matched.
+# That is the normal case -- stop-continuity.sh deletes this session's live
+# file immediately before calling here, so `live/` is usually empty and
+# metrics.json was simply never regenerated.
+shopt -s nullglob
+files=( "$M"/sessions/*.json "$M"/live/*.json )
+[ "${#files[@]}" -gt 0 ] || exit 0
 
 # A finished session (sessions/) wins over its own live snapshot.
 # shellcheck disable=SC2086
@@ -38,7 +44,7 @@ jq -s '
        tool_calls:   (map(.tool_calls // 0) | add),
        decisions:    (map(.decisions.total // 0) | add),
        gates:        (map(.decisions.gate // 0) | add)
-     }}' $files > "$M/metrics.json.$$" 2>/dev/null \
+     }}' "${files[@]}" > "$M/metrics.json.$$" 2>/dev/null \
   && mv -f "$M/metrics.json.$$" "$M/metrics.json" 2>/dev/null \
   || rm -f "$M/metrics.json.$$" 2>/dev/null
 exit 0

--- a/.claude/hooks/metrics-rollup.sh
+++ b/.claude/hooks/metrics-rollup.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Regenerate metrics/metrics.json from the per-session files.
+#
+# Generated, never edited: two sessions pushing at once both regenerate the
+# same derived file from conflict-free per-session inputs, so a rebase can
+# always take "theirs" and re-run this. That is the collision handling --
+# there is no merge to get wrong.
+set -uo pipefail
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib-state.sh
+. "$HOOK_DIR/lib-state.sh"
+command -v jq >/dev/null 2>&1 || exit 0
+
+M="$(state_dir)/metrics"
+[ -d "$M" ] || exit 0
+files=$(ls "$M"/sessions/*.json "$M"/live/*.json 2>/dev/null) || exit 0
+[ -n "$files" ] || exit 0
+
+# A finished session (sessions/) wins over its own live snapshot.
+# shellcheck disable=SC2086
+jq -s '
+  map(select(.session_id != null))
+  | group_by(.session_id)
+  | map( (map(select(.ended_at != null and .last_event == null)) | last)
+         // (sort_by(.updated_at // .ts // "") | last) )
+  | sort_by(.started_at // "")
+  | {generated_at: (max_by(.updated_at // .ts // "").updated_at // ""),
+     sessions: .,
+     totals: {
+       sessions: length,
+       output_tokens: (map(.output_tokens // 0) | add),
+       tool_calls:   (map(.tool_calls // 0) | add),
+       decisions:    (map(.decisions.total // 0) | add),
+       gates:        (map(.decisions.gate // 0) | add)
+     }}' $files > "$M/metrics.json.$$" 2>/dev/null \
+  && mv -f "$M/metrics.json.$$" "$M/metrics.json" 2>/dev/null \
+  || rm -f "$M/metrics.json.$$" 2>/dev/null
+exit 0

--- a/.claude/hooks/metrics-rollup.sh
+++ b/.claude/hooks/metrics-rollup.sh
@@ -13,6 +13,12 @@ command -v jq >/dev/null 2>&1 || exit 0
 
 M="$(state_dir)/metrics"
 [ -d "$M" ] || exit 0
+
+# Prune live snapshots that Stop never came back for. A container reclaimed
+# mid-session leaves its live file behind forever, and without this the
+# rollup keeps counting that half-session's tokens in every future total.
+# 14 days is well past any session that is still going to finish.
+find "$M/live" -name '*.json' -mtime +14 -delete 2>/dev/null
 files=$(ls "$M"/sessions/*.json "$M"/live/*.json 2>/dev/null) || exit 0
 [ -n "$files" ] || exit 0
 

--- a/.claude/hooks/statusline-metrics.sh
+++ b/.claude/hooks/statusline-metrics.sh
@@ -14,13 +14,24 @@ HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 command -v jq >/dev/null 2>&1 || exit 0
 
 input=$(cat 2>/dev/null || echo '{}')
-sid=$(printf '%s' "$input" | jq -r '.session_id // empty' 2>/dev/null)
-[ -n "$sid" ] || exit 0
+IFS=$'\t' read -r sid model <<<"$(printf '%s' "$input" \
+  | jq -r '[(.session_id // ""), (.model.display_name // "")] | @tsv' 2>/dev/null)"
+[ -n "${sid:-}" ] || exit 0
 
 printf '%s' "$input" | bash "$HOOK_DIR/metrics-live.sh" statusline 15
 
+# A custom statusline replaces the default row, so the model name it used to
+# carry has to come back from here.
+[ -n "${model:-}" ] && printf '%s  ' "$model"
+
 F="$(state_dir)/metrics/live/$sid.json"
 [ -f "$F" ] || { printf '⛁ warming up'; exit 0; }
+
+# A cache written before these fields existed, or one caught mid-write, used
+# to render "null@? ... null dec": jq succeeds on null, so interpolation
+# printed the nulls and the `||` fallback never fired. Check the shape first.
+jq -e '.decisions.total != null and .output_tokens != null' "$F" >/dev/null 2>&1 \
+  || { printf '⛁ warming up'; exit 0; }
 
 jq -r '
   def k: if . >= 1000 then "\(. / 1000 | floor)k" else "\(.)" end;

--- a/.claude/hooks/statusline-metrics.sh
+++ b/.claude/hooks/statusline-metrics.sh
@@ -10,6 +10,9 @@ HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib-state.sh
 . "$HOOK_DIR/lib-state.sh"
 
+# No jq means no readout rather than a broken statusline row.
+command -v jq >/dev/null 2>&1 || exit 0
+
 input=$(cat 2>/dev/null || echo '{}')
 sid=$(printf '%s' "$input" | jq -r '.session_id // empty' 2>/dev/null)
 [ -n "$sid" ] || exit 0

--- a/.claude/hooks/statusline-metrics.sh
+++ b/.claude/hooks/statusline-metrics.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# statusLine: the always-on readout. Reads the cache `metrics-live.sh` wrote;
+# recomputes only when that cache has gone stale, so the jq pass over the
+# transcript happens on the order of once per 15s rather than per render.
+#
+# Free in context terms: statusline output is never sent to the model.
+set -uo pipefail
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib-state.sh
+. "$HOOK_DIR/lib-state.sh"
+
+input=$(cat 2>/dev/null || echo '{}')
+sid=$(printf '%s' "$input" | jq -r '.session_id // empty' 2>/dev/null)
+[ -n "$sid" ] || exit 0
+
+printf '%s' "$input" | bash "$HOOK_DIR/metrics-live.sh" statusline 15
+
+F="$(state_dir)/metrics/live/$sid.json"
+[ -f "$F" ] || { printf '⛁ warming up'; exit 0; }
+
+jq -r '
+  def k: if . >= 1000 then "\(. / 1000 | floor)k" else "\(.)" end;
+  [ "⛁ \(.repo)@\(.branch // "?")",
+    "◆ \(.decisions.total) dec (\(.decisions.scoping)s/\(.decisions.inline)i/\(.decisions.gate)g)",
+    "↑ \(.output_tokens | k) out · ctx \(.context_peak | k)",
+    "⇢ \(.user_turns)p/\(.tool_calls)t",
+    (if .commits > 0 or .dirty > 0 or .unpushed > 0
+     then "⎇ \(.commits)c" + (if .dirty > 0 then " \(.dirty)~" else "" end)
+                            + (if .unpushed > 0 then " \(.unpushed)↑unpushed" else "" end)
+     else empty end)
+  ] | join("  ")' "$F" 2>/dev/null || printf '⛁ —'

--- a/.claude/hooks/stop-continuity.sh
+++ b/.claude/hooks/stop-continuity.sh
@@ -67,6 +67,11 @@ printf '%s\n' "$metrics" \
   > "$SD/metrics/sessions/$sid.json"
 printf '%s\n' "$metrics" | jq -c '.decisions[]' > "$SD/metrics/decisions/$sid.jsonl"
 
+# The live snapshot has served its purpose; the finished session file
+# supersedes it, so drop it rather than leaving two records of one session.
+rm -f "$SD/metrics/live/$sid.json" 2>/dev/null
+bash "$HOOK_DIR/metrics-rollup.sh" 2>/dev/null || true
+
 # ---------------------------------------------------------------- checkpoint
 ckpt="$SD/log/auto/$today-$work_repo-${sid:0:8}.md"
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -43,12 +43,20 @@
         "hooks": [
           {
             "type": "command",
-            "command": "h=\"$HOME/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] || h=\"$CLAUDE_PROJECT_DIR/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] && bash \"$h\" question 2>/dev/null || true"
+            "command": "h=\"$HOME/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] || h=\"$CLAUDE_PROJECT_DIR/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] && bash \"$h\" question 0 show 2>/dev/null || true"
           }
         ]
       }
     ],
     "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "h=\"$HOME/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] || h=\"$CLAUDE_PROJECT_DIR/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] && bash \"$h\" stop 0 show 2>/dev/null || true"
+          }
+        ]
+      },
       {
         "hooks": [
           {
@@ -73,7 +81,7 @@
           },
           {
             "type": "command",
-            "command": "h=\"$HOME/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] || h=\"$CLAUDE_PROJECT_DIR/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] && bash \"$h\" git 2>/dev/null || true"
+            "command": "h=\"$HOME/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] || h=\"$CLAUDE_PROJECT_DIR/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] && bash \"$h\" git 0 show 2>/dev/null || true"
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -37,6 +37,15 @@
             "command": "h=\"$HOME/.claude/hooks/no-persistent-polling.sh\"; [ -f \"$h\" ] || h=\"$CLAUDE_PROJECT_DIR/.claude/hooks/no-persistent-polling.sh\"; [ -f \"$h\" ] && bash \"$h\" || true"
           }
         ]
+      },
+      {
+        "matcher": "AskUserQuestion",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "h=\"$HOME/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] || h=\"$CLAUDE_PROJECT_DIR/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] && bash \"$h\" question 2>/dev/null || true"
+          }
+        ]
       }
     ],
     "Stop": [
@@ -61,6 +70,10 @@
           {
             "type": "command",
             "command": "h=\"$HOME/.claude/hooks/log-commit.sh\"; [ -f \"$h\" ] || h=\"$CLAUDE_PROJECT_DIR/.claude/hooks/log-commit.sh\"; [ -f \"$h\" ] && bash \"$h\" 2>/dev/null || true"
+          },
+          {
+            "type": "command",
+            "command": "h=\"$HOME/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] || h=\"$CLAUDE_PROJECT_DIR/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] && bash \"$h\" git 2>/dev/null || true"
           }
         ]
       }
@@ -71,6 +84,16 @@
           {
             "type": "command",
             "command": "h=\"$HOME/.claude/hooks/session-start-continuity.sh\"; [ -f \"$h\" ] || h=\"$CLAUDE_PROJECT_DIR/.claude/hooks/session-start-continuity.sh\"; [ -f \"$h\" ] && bash \"$h\" || true"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "h=\"$HOME/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] || h=\"$CLAUDE_PROJECT_DIR/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] && bash \"$h\" prompt 2>/dev/null || true"
           }
         ]
       }
@@ -104,5 +127,10 @@
     {
       "serverName": "Google_Calendar"
     }
-  ]
+  ],
+  "statusLine": {
+    "type": "command",
+    "command": "h=\"$HOME/.claude/hooks/statusline-metrics.sh\"; [ -f \"$h\" ] || h=\"$CLAUDE_PROJECT_DIR/.claude/hooks/statusline-metrics.sh\"; bash \"$h\" 2>/dev/null",
+    "padding": 0
+  }
 }


### PR DESCRIPTION
Metrics were computed only at Stop, so decision load, token cost, and "is this chat safe to kill" were visible only after it was too late to act on them. This puts them on screen as the session runs, at zero context cost — neither surface sends anything to the model.

## Two surfaces

**Always-on statusline**

```
Opus 5  ⛁ dotfiles@claude/session-metrics  ◆ 2 dec (1s/1i/0g)  ↑ 1k out · ctx 60k  ⇢ 2p/2t  ⎇ 0c 3~
```

**An interrupting block** at the three moments that matter — a question being put to Mark, a git event, session end:

```
⛁ decision point · dotfiles@claude/session-metrics-display
  decisions 2 (+1 being asked now)  (1 scoping · 1 inline · 0 gate)
  cost      1k out · ctx peak 60k · 2 prompts · 2 tools
  work      0 commits · 3 dirty · 1 unpushed        ← not safe to kill
```

## What's here

- **`hooks/metrics-live.sh`** — recomputes `session-metrics.jq` and caches the result to `metrics/live/<sid>.json`, plus dirty/unpushed/commit counts. Fires on `UserPromptSubmit`, `PreToolUse` on `AskUserQuestion`, and `PostToolUse` on Bash *filtered to real git commands* (the jq pass is too expensive to run after `ls`). With `show`, it also prints the block as a hook `systemMessage`.
- **`hooks/statusline-metrics.sh`** — renders the cache; recomputes only when it is >15s stale.
- **`hooks/metrics-rollup.sh`** — regenerates `metrics/metrics.json` from the per-session files and prunes live snapshots older than 14 days. Generated, never hand-merged: parallel sessions write conflict-free per-session inputs, so a rebase can always take theirs and re-run it.
- **`hooks/stop-continuity.sh`** — drops the live snapshot once the finished session file exists, then runs the rollup before the commit/push.
- **`settings.json`** — wires the statusLine and four hook entries. The Stop entry is ordered before `stop-continuity.sh` so the block renders from the live snapshot before the checkpoint hook deletes it.

## Why systemMessage, and where it does not fire

`systemMessage` reaches Mark and not the model — but only on `PreToolUse`/`PostToolUse`/`Stop`. The docs say `UserPromptSubmit` and `SessionStart` deliver it to the model, so the emitter refuses to print on those rather than quietly turning a display into context. Raw stdout is not an option at all: a successful hook's stdout goes to the debug log, never the transcript.

## Fixed under review

Every one reproduced failing before the fix:

1. **The rollup never ran.** `ls sessions/*.json live/*.json` passes an unmatched glob through literally, `ls` exits 2, and `|| exit 0` aborted even when the other glob matched — the normal case, since `stop-continuity.sh` deletes the live file on the line before calling it. Now a nullglob array.
2. **The statusline rendered `null@? ◆ null dec`** from a cache written before these fields existed: jq succeeds on null, so the fallback never fired. Shape is checked first; degrades to `⛁ warming up`.
3. **Orphaned live snapshots inflated every future total.** A reclaimed container never reaches Stop. Pruned at 14 days.
4. **`commits` counted anyone's commits in a time window** — a fresh clone whose history landed today reported 13 for a session that made none. Counted from the session's start SHA instead.
5. `label` is a jq keyword, so the first event block compiled to nothing; the statusline assumed `jq` was installed; the model name is restored to the row a custom statusline displaces; `PreToolUse` blocks say `+1 being asked now` rather than reporting a count whose treatment of the pending question is unverified.

## Verification

Every script run against a synthetic transcript exercising both decision mechanisms (prose ask and `AskUserQuestion`) and a heredoc write; checked by hand — 2 decisions (1 scoping, 1 inline), 1 file written, context peak 60030. Event matrix: question/git/stop blocks render as valid hook JSON, `ls` produces nothing, `prompt` stays silent. Rollup: single-session case now writes `metrics.json`; dedupe against a live snapshot still correct; a file backdated 30 days pruned while a fresh one survived. Statusline: malformed cache degrades, normal render correct, 5 warm renders in 187ms. `bash -n` clean on all four scripts; `settings.json` valid JSON.

Consolidating the stdin parse from three `jq` calls to one changed the measured render time by 1ms — the spawn count was not the cost, process startup was. Kept for the simpler code, not for speed.

## Not done

No context injection. Measured at ~120 tokens per event, ~1.2k per session — real, but not what drives the 100k sessions. Left out until the display proves the numbers are worth acting on.

Unverified: whether the desktop app renders the statusline for a session running in a remote container. The `systemMessage` blocks do not depend on that.