### PR TITLE
Correct the cold-session fix advice in the continuity brief

### DIFF
--- a/.claude/hooks/session-start-continuity.sh
+++ b/.claude/hooks/session-start-continuity.sh
@@ -36,9 +36,13 @@ checkpoints and the metrics are all missing, and `stop-continuity.sh` will
 write to `~/.claude/state/global` (local, unpushed, lost when this container
 is reclaimed).
 
-To fix in this session: `mcp__Claude_Code_Remote__add_repo` with owner
-`mark-brannan`, repo `claude_prompts_scratch`, access `push`, then clone it.
-To fix permanently: add it as a second source on this cloud environment.
+Fix it now: `mcp__Claude_Code_Remote__add_repo` with owner `mark-brannan`,
+repo `claude_prompts_scratch`, access `push`, then clone it to
+`/workspace/claude_prompts_scratch` -- a path `state_repo` already searches.
+Do this every cold session; there is no environment setting that does it for
+you. Cloud environments configure only name, network access, environment
+variables and a setup script -- repositories attach per session, and the
+GitHub proxy 403s any repo not attached, so a setup script cannot clone this.
 MSG
   exit 0
 fi


### PR DESCRIPTION
The "state repo NOT available" brief ended with:

> To fix permanently: add it as a second source on this cloud environment.

That setting does not exist. Verified against the docs:

- The cloud environment dialog has exactly four fields — **Name**, **Network access**, **Environment variables**, **Setup script**. There is no repository or source list. (`cloud-environments` §Configure your environment)
- Repositories attach **per session**, not per environment: "GitHub API and release-asset requests reach only repositories attached to the session, so a setup script that downloads release assets from an unattached repository gets a 403." (§GitHub proxy)

So a setup script can't clone `claude_prompts_scratch` either — the proxy refuses an unattached repo, and setup-script output is filesystem-snapshotted for ~7 days, which is the wrong staleness profile for a state repo regardless.

The per-session `add_repo` + clone is the entire fix. This rewrites the message to say so, names `/workspace/claude_prompts_scratch` as the target (a path `state_repo()` in `lib-state.sh` already searches, so the Stop hook picks it up with no further wiring), and states plainly that it recurs every cold session instead of promising a permanent cure that isn't available.

Verified in this session: `add_repo` → clone to `/workspace/claude_prompts_scratch` → `state_repo()` resolves it → board and metrics are readable and the Stop hook has a pushable repo. `bash -n` passes on the edited hook.

Also assessed and found dead: `claude/continuity-hooks-cold-session-86qfn1`, which added a SessionStart hook that clones the private state repo over unauthenticated HTTPS. That can't work (`git ls-remote` on the repo without credentials → `could not read Username`) and it contradicts the deliberate "Never clones" design already merged in #3. It should be deleted rather than merged; the delete push was blocked by the permission classifier in this session. Recovery sha if wanted: `8211586b0520e52584ce65a0d823bcd85b17c503`.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Dv1BFRMuuYGcXmHUVppJb)_