### PR TITLE
Add merge/ship-it terminology mapping to standing orders

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -157,6 +157,12 @@ irritation; missing it costs me a decision I have to live with.
 - **Give yourself a way to verify.** Tests, a diff, a re-read, a browser, a
   second pass. Closing your own feedback loop matters more than any
   instruction here.
+- **My "merge" means pull + rebase + push to origin/main, never `git
+  merge`.** I'm trying to say "land on main" instead; treat that as the
+  same order. **"Ship it"** means whatever the actual next move is for the
+  work in front of us — push straight to main, push the branch and open
+  the PR, or push and merge/close an existing PR. Pick the one that fits;
+  don't ask which.
 
 ## Continuity
 


### PR DESCRIPTION
Adds a bullet to the Execution section of `.claude/CLAUDE.md`:

- "merge" → pull + rebase + push to origin/main, never `git merge`
- "land on main" → same order, the term being migrated to
- "ship it" → whichever of push-to-main / push+PR / push+merge-PR is the actual next move

---
_Generated by [Claude Code](https://claude.ai/code/session_013tA9pEeuQgXBwrjKVTTeHk)_