### PR TITLE
Scope the add_repo standing allow to the continuity state repo

### DIFF
--- a/.claude/hooks/guard-add-repo.sh
+++ b/.claude/hooks/guard-add-repo.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# PreToolUse guard for mcp__Claude_Code_Remote__add_repo.
+#
+# The continuity state repo must attach silently in every cold cloud session,
+# including auto mode -- that was the point of allowing add_repo at all. But a
+# bare allow rule can't see arguments, so it also let ANY repo attach with
+# push credentials, no prompt, on the say-so of whatever text steered the
+# session. This hook keeps the standing allow for exactly the one repo the
+# continuity hooks need and lets every other add_repo fall through to the
+# normal permission flow (a prompt when Mark is present, a refusal in auto).
+set -uo pipefail
+
+command -v jq >/dev/null 2>&1 || exit 0
+input=$(cat)
+
+owner=$(jq -r '.tool_input.owner // ""' <<<"$input")
+repo=$(jq -r '.tool_input.repo // ""' <<<"$input")
+
+if [ "$owner" = "mark-brannan" ] && [ "$repo" = "claude_prompts_scratch" ]; then
+  jq -n '{hookSpecificOutput:{hookEventName:"PreToolUse",
+          permissionDecision:"allow",
+          permissionDecisionReason:"continuity state repo -- standing allow"}}'
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,12 +24,20 @@
       "Bash(git branch -d *)",
       "Bash(git branch -D *)",
       "Bash(git push origin --delete *)",
-      "Bash(git push --delete *)",
-      "mcp__Claude_Code_Remote__add_repo"
+      "Bash(git push --delete *)"
     ]
   },
   "hooks": {
     "PreToolUse": [
+      {
+        "matcher": "mcp__Claude_Code_Remote__add_repo",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "h=\"$HOME/.claude/hooks/guard-add-repo.sh\"; [ -f \"$h\" ] || h=\"$CLAUDE_PROJECT_DIR/.claude/hooks/guard-add-repo.sh\"; [ -f \"$h\" ] && bash \"$h\" || true"
+          }
+        ]
+      },
       {
         "matcher": "mcp__.*__(send_later|create_trigger)",
         "hooks": [


### PR DESCRIPTION
Review of the cloud-session repo-additions work (landed on main as 2b46fcb and 0adb912) found one risk: the bare `mcp__Claude_Code_Remote__add_repo` allow rule lets **any** repo attach with push credentials, silently, in every session — permission rules cannot match MCP tool arguments, so the rule couldn't be narrowed in place.

This replaces the allow rule with a PreToolUse guard hook (`guard-add-repo.sh`) that:

- silently allows `mark-brannan/claude_prompts_scratch` — the one repo the continuity hooks need attached in every cold cloud session, including auto mode;
- emits nothing for any other repo, so those fall through to the normal permission flow (a prompt when Mark is present, a refusal in auto mode) — exactly the pre-2b46fcb behavior.

Both paths verified locally by piping sample PreToolUse JSON through the hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013WEjEBNh2MfxdRbDc9Rcgk

---
_Generated by [Claude Code](https://claude.ai/code/session_013WEjEBNh2MfxdRbDc9Rcgk)_