### PR TITLE
Adopt the space-weather interaction pattern (#93, #95) for global state

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -181,16 +181,33 @@ redo that by hand and don't wait to be asked. What's left to judgment:
   only you can record what it meant and what should happen next. On "wrap
   up" / "log it", write that to `log/YYYY-MM-DD-<slug>.md`. The machine one
   is evidence, not a substitute.
-- **Capture ≠ activation.** Something off-goal but real → one board line
-  at wrap-up; trivial → drop it. Never a new workstream mid-session.
+- **Write the card when the loop is found, not at wrap-up.** By the end of a
+  session the context has been compacted, so the link, the timestamp and the
+  exact wording are gone and what's left is unactionable. Discovery is the
+  last moment the evidence still exists. Capture is still not activation:
+  the card is written now, the decision about it waits. Trivial → drop it;
+  never a new workstream mid-session.
 - **New sessions open by pulling from a board.** WIP limit ~2–3.
+- **One card contract, every board** (adopted 2026-08-20, rationale in
+  [space-weather#95](https://github.com/mark-brannan/signalk-noaa-space-weather/pull/95)).
+  One file, two sections — `## Yours` and `## Claude's`, because the cards
+  block each other and split files show both lists clear while the work
+  sits deadlocked. One checkbox line per card: the action in the
+  imperative, then a link. The link is never optional — a card only its
+  author can resolve is not a card. `blocked:` plus the dependency only
+  when blocked. Cards die when done. Checkboxes, never a table.
+- **End with the follow-up prompt, not a status bullet.** When a session
+  ends with work left, end with the prompt that would start it —
+  pasteable, naming the branch, PR or file. Anything only I can do is a
+  card, referenced by link. Both written so someone who wasn't in the
+  session can act on them a week later.
 - **Ask early or not at all.** A question before the first file is written
   is cheap — context is fresh and a wrong assumption would have cost the
   whole session. The same question mid-flight makes me reload context I
   haven't been carrying. Front-load them; ask inline only when the answer
-  blocks the current task; board the rest for batch accept/edit/delete at
-  wrap-up. The decision log types every ask this way, so the ratio is
-  checkable rather than remembered.
+  blocks the current task; card the rest as they come up and bring them for
+  batch accept/edit/delete at wrap-up. The decision log types every ask
+  this way, so the ratio is checkable rather than remembered.
 - **Where state lands, settled 2026-08-19:** a project's session state
   stays in that project's own repo. Symphony's is
   `~/symphony/intermediate_files/claude_slop/` (kanban.md + log.md); its
@@ -201,8 +218,10 @@ redo that by hand and don't wait to be asked. What's left to judgment:
   `state/global/kanban.md` and `state/global/log/`; so does state for any
   project with no private repo of its own. Work on `main` there; `git pull
   --rebase` before pushing. **Never into dotfiles** — it is public, and
-  session notes name boats, hosts and services. Never stage one project's
-  work under another's.
+  session notes name boats, hosts and services. Dotfiles therefore has no
+  board of its own: its cards sit on the global board, and anything with a
+  question in it becomes a dotfiles issue the card links to. Never stage
+  one project's work under another's.
 
 ## Maintenance
 

--- a/.claude/rules/code.md
+++ b/.claude/rules/code.md
@@ -2,6 +2,7 @@
 paths:
   - "**/*.{py,js,ts,jsx,tsx,go,rs,rb,php,java,c,h,cpp,hpp,cs,sh,sql}"
   - "**/*.{json,yaml,yml,toml}"
+  - "**/*.md"
   - "**/{Makefile,Dockerfile,docker-compose*,*.tf}"
 ---
 
@@ -79,11 +80,21 @@ project-specific facts belong in that project's own CLAUDE.md.
 
 ## PR ownership: draft → ready is mine
 
-- When I open a PR as a draft, driving it to ready is my job, not something
-  to wait on. Resolve bot/reviewer comments, fix CI failures, and flip it
-  out of draft the moment CI is green and comments are addressed — don't
-  wait to be asked, and don't leave a green, comment-free PR sitting in
-  draft for a human to notice and un-draft.
+- **Draft is a working state, not a resting state.** A draft gets no review
+  at all — CodeRabbit and claude-review both skip drafts — so a PR parked
+  in draft makes Mark the first reader instead of the last. Open as draft if
+  you like, then mark it ready **the moment the session's own work is done**:
+  pushed, building, formatter and tests green locally. Don't wait for CI or
+  for bot comments to decide — on a draft they aren't coming. Marking ready
+  is my call, never handed upward; a PR waiting on a human to flip it is
+  waiting for nothing. (Corrected 2026-08-20 from "flip it out of draft the
+  moment CI is green and comments are addressed", which was a deadlock:
+  those never arrive while it's a draft. Ported from
+  [space-weather#93](https://github.com/mark-brannan/signalk-noaa-space-weather/pull/93).)
+- **Ready is not the end of the turn.** After it, CI failures, bot findings
+  and merge conflicts are mine, round after round, until every check is
+  green and every automated thread is answered or resolved. A red check is
+  never handed over as a status report.
 - "Looks good" / "I'm signing off" said before CI finishes isn't a stall —
   it's pre-authorization: push (and mark ready) the moment CI comes back
   green, without circling back to re-confirm.
@@ -108,6 +119,17 @@ project-specific facts belong in that project's own CLAUDE.md.
   before subscribing or scheduling.
 - **Batch review responses.** Address every open thread in one pass, then
   push once — don't wake per comment.
+- **Tell Mark once, when it's actually his turn.** He signs off last;
+  everything that can finish without him finishes first. No "CI is
+  running", no "two jobs left", no asking whether to fix a failure I can
+  diagnose myself, no reminders to look at something still in progress —
+  that traffic costs a read and returns nothing actionable. One message,
+  when the PR is green and the automated reviews have been dealt with. The
+  two exceptions both end in a decision only he can make: a blocker I
+  can't resolve, or a design question where guessing wrong means redoing
+  the work — lay out the options and ask, don't narrate. (Ported
+  2026-08-20 from
+  [space-weather#93](https://github.com/mark-brannan/signalk-noaa-space-weather/pull/93).)
 - **Long agentic loops, not long conversations, are the real expense.**
   Every tool call re-sends the full context, so a tool-dense task (PR
   review, CI chasing, branch cleanup) costs far more than its wall-clock


### PR DESCRIPTION
Ports the interaction pattern settled in [signalk-noaa-space-weather#95](https://github.com/mark-brannan/signalk-noaa-space-weather/pull/95) and [#93](https://github.com/mark-brannan/signalk-noaa-space-weather/pull/93) into the standing orders, so the boards and PR conventions that dotfiles, `claude_prompts_scratch` and (next) symphony share all follow one contract.

## `.claude/CLAUDE.md` — the board (from #95)

- **One card contract, every board.** One file, `## Yours` / `## Claude's`; one checkbox line per card — imperative action then a mandatory link; `blocked:` only when blocked; cards deleted when done; checkboxes, never a table.
- **Cards are written at discovery, not at wrap-up.** This replaces the old "one board line at wrap-up" bullet, which #95 directly contradicts: by the end of a session the context has been compacted and the link, timestamp and exact wording are gone. Batching still applies to *asking* — the "Ask early or not at all" bullet keeps its batch review at wrap-up — just not to capture.
- **Sessions with work left end with a pasteable follow-up prompt,** naming the branch, PR or file — not a status bullet.
- **Where dotfiles cards go.** Dotfiles is public and holds no board of its own, so its cards sit on the global board and anything with a question in it becomes a dotfiles issue the card links to.

## `.claude/rules/code.md` — PR readiness (from #93)

- **Fixes a deadlock in the existing rule.** It said to flip a PR out of draft "the moment CI is green and comments are addressed" — but CodeRabbit and claude-review both skip drafts, so neither ever arrives while it sits in draft. Ready now gates on the session's own work being pushed and passing locally; the review automation runs after.
- **Ready is not the end of the turn** — CI failures, bot findings and conflicts stay the session's, round after round.
- **Tell Mark once, when it's actually his turn.** No CI narration, no asking about failures the session can diagnose itself. One message when green and the automated reviews are handled; two narrow exceptions that end in a decision only he can make.
- **`paths` now includes `**/*.md`.** These are git and PR conventions that apply to every repo edit, and a docs-only PR — exactly what this one is — matched none of the previous globs, so the rules never loaded for the sessions that most needed them.

## Notes

- This closes the space-weather card "paste the closing-message rule into `~/.claude/CLAUDE.md`", modulo that card assuming a real machine.
- `claude_prompts_scratch` still needs its board re-headed to `## Yours` / `## Claude's`; `add_repo` for it was denied by the auto-mode classifier in this session, so it is untouched here. `session-start-continuity.sh`'s awk already prints per-`##` sections, so no hook change is needed for the new headings.