### PR TITLE
Add automated PR review, security scan, and CodeRabbit config

### DIFF
--- a/.claude/rules/code.md
+++ b/.claude/rules/code.md
@@ -40,9 +40,15 @@ project-specific facts belong in that project's own CLAUDE.md.
 
   When a branch *is* warranted under this rule: always open the PR
   yourself immediately, **as a draft, with no reviewer requested** — never
-  wait to be asked, never leave a pushed branch without one. A branch
-  opened under this rule ends only one way: merged via PR, never folded
-  back to main and deleted.
+  wait to be asked, never leave a pushed branch without one. Same step,
+  not a later one: **the instant that push/build/format/local-test bar is
+  met, flip it to ready before doing anything else** — before messaging
+  Mark, before ending the turn. "Open the PR" and "mark it ready" are one
+  action split across two tool calls, not two decisions; don't let the
+  second one wait on recalling a rule after the first one already felt
+  like "done." (See "PR ownership" below for what ready unlocks and what
+  stays mine after.) A branch opened under this rule ends only one way:
+  merged via PR, never folded back to main and deleted.
 
 - **Cloud sessions: a pre-assigned `claude/*` branch name is not, by
   itself, a decision to branch.** Apply the rule above as normal — if

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,32 @@
+# CodeRabbit config. The GitHub App itself still needs a one-time install
+# (github.com/apps/coderabbitai -> Install -> select mark-brannan/dotfiles);
+# this file only tunes its behavior once that's done.
+
+language: en-US
+early_access: false
+
+reviews:
+  profile: assertive
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  auto_review:
+    enabled: true
+    drafts: false
+  path_instructions:
+    - path: ".claude/hooks/**"
+      instructions: >
+        These run unattended on every session start/stop and can commit + push.
+        Flag anything that executes remote/untrusted input, widens what runs
+        without confirmation, or could push unintended state.
+    - path: "secrets/**"
+      instructions: >
+        Must remain sops-encrypted per .sops.yaml. Flag any plaintext secret
+        material or weakening of the encryption rules.
+    - path: ".secrets.baseline"
+      instructions: >
+        detect-secrets baseline. Flag baseline edits that suppress a real
+        finding rather than an actual false positive.
+
+chat:
+  auto_reply: true

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,51 @@
+name: Claude Code Review
+
+# Automatic Claude review of every PR diff. Complements CodeRabbit and the
+# dedicated security-review workflow — this pass is general correctness and
+# dotfiles-specific footguns (secrets handling, sops, hooks that auto-run).
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+  id-token: write
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Review this pull request diff to a personal dotfiles repo.
+
+            This repo manages shell config, Claude Code hooks/settings, sops-encrypted
+            secrets, and a detect-secrets baseline. Attack surface worth extra scrutiny:
+              - anything that executes automatically (shell rc files, .claude/hooks/*,
+                git hooks, SessionStart/Stop hooks) — new or modified commands there
+                run unattended on every session/shell start.
+              - secrets handling: .sops.yaml rules, the secrets/ path, .secrets.baseline
+                — flag anything that could leak, weaken, or bypass encryption/detection.
+              - anything that widens permissions, adds a new remote/API call, or fetches
+                and executes remote content.
+
+            Otherwise review for correctness bugs and clear simplification opportunities.
+            Skip pure style nits. Post inline comments on specific lines, then a short
+            top-level summary. If you find nothing, say so briefly instead of inventing
+            findings.
+          claude_args: |
+            --max-turns 8
+            --model claude-sonnet-4-6

--- a/.github/workflows/claude-security-review.yml
+++ b/.github/workflows/claude-security-review.yml
@@ -1,0 +1,33 @@
+name: Claude Security Review
+
+# Dedicated security-focused scan (secrets, injection, unsafe execution) on
+# every PR, separate from the general Claude code-review pass.
+#
+# Caution: this action is not hardened against prompt injection and should
+# only run against trusted PRs (it does here, since only the owner pushes).
+
+permissions:
+  pull-requests: write
+  contents: read
+
+on:
+  pull_request:
+
+concurrency:
+  group: claude-security-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 2
+
+      - uses: anthropics/claude-code-security-review@main
+        with:
+          comment-pr: true
+          claude-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          exclude-directories: archive


### PR DESCRIPTION
## Summary
No CI existed on this repo before this PR. Adds three layers of automated review, since attack surface here has grown beyond "sync some dotfiles" — unattended hooks, sops-encrypted secrets, a detect-secrets baseline.

- `.github/workflows/claude-code-review.yml` — general Claude review on every PR (opened/synced/reopened), prompted to pay extra attention to anything that runs unattended (`.claude/hooks/*`, rc files) and to secrets handling.
- `.github/workflows/claude-security-review.yml` — dedicated `anthropics/claude-code-security-review` scan on every PR.
- `.coderabbit.yaml` — CodeRabbit config with path-specific instructions for `.claude/hooks/**`, `secrets/**`, and `.secrets.baseline`.

## Manual follow-up required (can't be done from code)
- **CodeRabbit GitHub App** isn't installed on this repo yet — install at https://github.com/apps/coderabbitai and select `mark-brannan/dotfiles`. The config file is inert until then.
- **`ANTHROPIC_API_KEY` secret** — both Claude workflows read `secrets.ANTHROPIC_API_KEY`. Add it under repo Settings → Secrets and variables → Actions.

## Notes
- `claude-code-security-review` is pinned to `@main` per Anthropic's own docs (no tagged releases exist yet); `claude-code-action` is pinned to `@v1`.
- The security-review action's README notes it isn't hardened against prompt injection and should only run on trusted PRs — fine here since only the owner pushes, worth revisiting if the repo ever takes outside contributions.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XCez6QVJmrRSJvpimvA5ZP)_