### PR TITLE
security: pin hooks to $HOME, drop remote-delete allows, fail-closed polling guard

### DIFF
--- a/.claude/hooks/no-persistent-polling.sh
+++ b/.claude/hooks/no-persistent-polling.sh
@@ -19,6 +19,17 @@
 set -euo pipefail
 
 input=$(cat)
+
+# Fail closed. This guard exists only to deny; its job is safety, not
+# function. If jq is missing we cannot parse the request to judge it, and the
+# settings.json matcher ends in `|| true`, so a non-zero exit here would be
+# silently swallowed into an ALLOW. Emit an explicit deny with hand-written
+# JSON instead of relying on jq to build it.
+if ! command -v jq >/dev/null 2>&1; then
+  printf '%s\n' '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Blocked by no-persistent-polling.sh: jq is unavailable, so the scheduled-wakeup request cannot be evaluated. Denying to fail closed. Install jq, or use subscribe_pr_activity to wake on real events."}}'
+  exit 0
+fi
+
 tool=$(printf '%s' "$input" | jq -r '.tool_name // ""')
 
 deny() {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,8 +23,6 @@
     "allow": [
       "Bash(git branch -d *)",
       "Bash(git branch -D *)",
-      "Bash(git push origin --delete *)",
-      "Bash(git push --delete *)",
       "mcp__Claude_Code_Remote__add_repo"
     ]
   },
@@ -35,7 +33,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "for d in \"$HOME\" \"${CLAUDE_PROJECT_DIR:-}\" \"$PWD\"; do h=\"$d/.claude/hooks/guard-add-repo.sh\"; [ -n \"$d\" ] && [ -f \"$h\" ] && { bash \"$h\"; break; }; done; true"
+            "command": "h=\"$HOME/.claude/hooks/guard-add-repo.sh\"; [ -f \"$h\" ] && bash \"$h\"; true"
           }
         ]
       },
@@ -44,7 +42,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "h=\"$HOME/.claude/hooks/no-persistent-polling.sh\"; [ -f \"$h\" ] || h=\"$CLAUDE_PROJECT_DIR/.claude/hooks/no-persistent-polling.sh\"; [ -f \"$h\" ] && bash \"$h\" || true"
+            "command": "h=\"$HOME/.claude/hooks/no-persistent-polling.sh\"; [ -f \"$h\" ] && bash \"$h\" || true"
           }
         ]
       },
@@ -53,7 +51,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "h=\"$HOME/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] || h=\"$CLAUDE_PROJECT_DIR/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] && bash \"$h\" question 0 show 2>/dev/null || true"
+            "command": "h=\"$HOME/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] && bash \"$h\" question 0 show 2>/dev/null || true"
           }
         ]
       }
@@ -63,7 +61,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "h=\"$HOME/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] || h=\"$CLAUDE_PROJECT_DIR/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] && bash \"$h\" stop 0 show 2>/dev/null || true"
+            "command": "h=\"$HOME/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] && bash \"$h\" stop 0 show 2>/dev/null || true"
           }
         ]
       },
@@ -71,7 +69,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "h=\"$HOME/.claude/hooks/stop-continuity.sh\"; [ -f \"$h\" ] || h=\"$CLAUDE_PROJECT_DIR/.claude/hooks/stop-continuity.sh\"; [ -f \"$h\" ] && bash \"$h\" 2>/dev/null || true",
+            "command": "h=\"$HOME/.claude/hooks/stop-continuity.sh\"; [ -f \"$h\" ] && bash \"$h\" 2>/dev/null || true",
             "timeout": 180
           }
         ]
@@ -83,15 +81,15 @@
         "hooks": [
           {
             "type": "command",
-            "command": "h=\"$HOME/.claude/hooks/measure-git-events.sh\"; [ -f \"$h\" ] || h=\"$CLAUDE_PROJECT_DIR/.claude/hooks/measure-git-events.sh\"; [ -f \"$h\" ] && bash \"$h\" 2>/dev/null || true"
+            "command": "h=\"$HOME/.claude/hooks/measure-git-events.sh\"; [ -f \"$h\" ] && bash \"$h\" 2>/dev/null || true"
           },
           {
             "type": "command",
-            "command": "h=\"$HOME/.claude/hooks/log-commit.sh\"; [ -f \"$h\" ] || h=\"$CLAUDE_PROJECT_DIR/.claude/hooks/log-commit.sh\"; [ -f \"$h\" ] && bash \"$h\" 2>/dev/null || true"
+            "command": "h=\"$HOME/.claude/hooks/log-commit.sh\"; [ -f \"$h\" ] && bash \"$h\" 2>/dev/null || true"
           },
           {
             "type": "command",
-            "command": "h=\"$HOME/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] || h=\"$CLAUDE_PROJECT_DIR/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] && bash \"$h\" git 0 show 2>/dev/null || true"
+            "command": "h=\"$HOME/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] && bash \"$h\" git 0 show 2>/dev/null || true"
           }
         ]
       }
@@ -101,11 +99,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "h=\"$HOME/.claude/hooks/session-start-continuity.sh\"; [ -f \"$h\" ] || h=\"$CLAUDE_PROJECT_DIR/.claude/hooks/session-start-continuity.sh\"; [ -f \"$h\" ] && bash \"$h\" || true"
+            "command": "h=\"$HOME/.claude/hooks/session-start-continuity.sh\"; [ -f \"$h\" ] && bash \"$h\" || true"
           },
           {
             "type": "command",
-            "command": "h=\"$HOME/.claude/hooks/connector-budget.sh\"; [ -f \"$h\" ] || h=\"$CLAUDE_PROJECT_DIR/.claude/hooks/connector-budget.sh\"; [ -f \"$h\" ] && bash \"$h\" || true"
+            "command": "h=\"$HOME/.claude/hooks/connector-budget.sh\"; [ -f \"$h\" ] && bash \"$h\" || true"
           }
         ]
       }
@@ -115,7 +113,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "h=\"$HOME/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] || h=\"$CLAUDE_PROJECT_DIR/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] && bash \"$h\" prompt 2>/dev/null || true"
+            "command": "h=\"$HOME/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] && bash \"$h\" prompt 2>/dev/null || true"
           }
         ]
       }
@@ -155,7 +153,7 @@
   ],
   "statusLine": {
     "type": "command",
-    "command": "h=\"$HOME/.claude/hooks/statusline-metrics.sh\"; [ -f \"$h\" ] || h=\"$CLAUDE_PROJECT_DIR/.claude/hooks/statusline-metrics.sh\"; bash \"$h\" 2>/dev/null",
+    "command": "h=\"$HOME/.claude/hooks/statusline-metrics.sh\"; [ -f \"$h\" ] && bash \"$h\" 2>/dev/null",
     "padding": 0
   }
 }

--- a/.local/bin/cloud-session-setup.sh
+++ b/.local/bin/cloud-session-setup.sh
@@ -35,6 +35,12 @@ DRY_RUN=no
 # --- what to install -----------------------------------------------------
 # Repo-relative paths, files or directories, copied to the same path under
 # $HOME. Expand deliberately: every line lands in every cloud session.
+# Every hook that settings.json references (directly or transitively) MUST be
+# listed here. settings.json now runs hooks from $HOME ONLY -- the old
+# $CLAUDE_PROJECT_DIR fallback was removed because in a cloud session on a
+# third-party repo it executed THAT repo's .claude/hooks/*.sh under user-scope
+# trust. Fail-closed is only safe if $HOME is complete: an omission here means
+# the hook silently stops running, not that a stranger's copy runs instead.
 INSTALL="
 .claude/settings.json
 .claude/CLAUDE.md
@@ -46,6 +52,12 @@ INSTALL="
 .claude/hooks/stop-continuity.sh
 .claude/hooks/measure-git-events.sh
 .claude/hooks/no-persistent-polling.sh
+.claude/hooks/guard-add-repo.sh
+.claude/hooks/metrics-live.sh
+.claude/hooks/metrics-rollup.sh
+.claude/hooks/log-commit.sh
+.claude/hooks/statusline-metrics.sh
+.claude/hooks/connector-budget.sh
 "
 
 # --- what to prune -------------------------------------------------------


### PR DESCRIPTION
Hardens the config attack surface flagged in the security posture review. Local-config only — no GitHub-side branch/push protection here, deliberately deferred until after the planned `archive/signalk-pi` history rewrite (branch protection would block that force-push).

## What & why

**1. Hooks pinned to `$HOME` (the RCE fix).** Every hook command in `settings.json` fell back to `$CLAUDE_PROJECT_DIR`/`$PWD` when the `$HOME` copy was absent. Because `settings.json` is seeded to *user* scope on cloud VMs, a cloud session opened on any third-party repo executed *that repo's* `.claude/hooks/*.sh` automatically, under user-scope trust, with no project-trust prompt. A hostile `guard-add-repo.sh` could even emit `permissionDecision: allow` for arbitrary `add_repo` calls with push credentials in auto mode. Fallbacks removed everywhere (incl. the statusline); hooks now run from `$HOME` only and fail closed when absent.

**2. Cloud seeder completed.** `cloud-session-setup.sh`'s `INSTALL` list seeded only 6 of the hooks `settings.json` references — the gap is what forced the fallback. Added `guard-add-repo`, `metrics-live`, `metrics-rollup`, `log-commit`, `statusline-metrics`, and `connector-budget` so `$HOME` is complete and removing the fallback causes no cloud regression.

**3. Dropped `git push --delete` allows.** `permissions.allow` pre-approved `git push --delete *` and `git push origin --delete *` — prompt injection (a README, an issue body) could delete remote branches with zero prompt in auto mode. The auto-mode classifier blocks these commands regardless, so the allows were pure downside. Local `git branch -d`/`-D` retained (local-only, reflog-recoverable, used by the branch-cleanup workflow).

**4. Fail-closed polling guard.** `no-persistent-polling.sh` used `jq` under `set -euo pipefail`; a missing `jq` exited non-zero, and the matcher's trailing `|| true` turned that into a silent *allow*. It now emits an explicit `deny` (hand-written JSON) when `jq` is unavailable.

## Rebase note

Rebased onto `main` @ 34d402c. Two conflicts in `settings.json`, both adjacent-line rather than semantic: `main` added the `mcp__Claude_Code_Remote__add_repo` permission (kept) alongside the dropped push-delete allows, and added a `connector-budget.sh` SessionStart hook (kept, pinned to `$HOME` like the rest).

That second one surfaced a live regression the rebase would otherwise have shipped: `connector-budget.sh` is referenced by `settings.json` but arrived on `main` after this branch was written, so it was not in the `INSTALL` list. With the fallback removed it would have silently stopped running in every cloud session — precisely the failure mode this PR exists to close. Added to `INSTALL`.

## Verification

- `settings.json` parses as JSON; zero `CLAUDE_PROJECT_DIR`/`PWD` references remain.
- `bash -n` clean on both edited scripts.
- Polling guard: with only `jq` removed from PATH → `deny` (fail closed); normal `send_later` → `deny` (unchanged).
- Cross-checked every hook `settings.json` references against the `INSTALL` list — all 9 present, no omissions.

## Not included (carded, follow-up)

- GitHub push protection + branch protection (deferred behind the history rewrite).
- `guard-add-repo.sh` `access`-level check, shell-env token scoping, `pre_commit` `AGE-SECRET-KEY-`/high-entropy gaps — lower severity, separate change.
- The `Claude Security Review` check cannot pass on OAuth — that action supports only `ANTHROPIC_API_KEY`. Tracked in #25; unrelated to this diff.