### PR TITLE
docs: RUNBOOK.md, repo-root CLAUDE.md, README refocused on the critical path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,111 @@
+# Working conventions — dotfiles
+
+This repo is **public**, and its worktree is `$HOME` on every machine Mark
+uses. Both facts constrain almost everything below.
+
+Global standing orders live in `.claude/CLAUDE.md` and load in every session
+everywhere; personal code and writing rules in `.claude/rules/`. Those files
+happen to be tracked here, but they are not *about* this repo. This file is.
+
+## Files
+
+- `README.md` — the critical path for a human setting up a machine, plus the
+  conventions and the design rationale.
+- `RUNBOOK.md` — procedures. Machines, cloud environments, secrets,
+  troubleshooting. Deliberately partial; it says so at the top.
+- `.config/yadm/bootstrap` — decrypts sops-managed secrets. Idempotent.
+- `.config/yadm/hooks/pre_commit` — the commit-time gate against credentials.
+- `.local/bin/dotfiles-triage.sh` — read-only inventory of `$HOME` vs policy.
+- `.local/bin/cloud-session-setup.sh` — seeds a subset of this repo into `$HOME`
+  on an ephemeral cloud VM.
+- `.claude/cloud-setup.sh` — writes `deniedMcpServers` at user scope.
+- `.claude/hooks/` — session-continuity and metrics hooks.
+
+## README.md
+
+- **The first screen is for a human who wants a working `$HOME` and nothing
+  else.** Clone, bootstrap, sync — three commands, at the top, before any
+  explanation. Everything that is not on the critical path goes below it or
+  out of the file. Nobody arrives here wanting the history.
+- **This is where the *why* lives.** Design rationale, the scars, why the
+  cloud seed is deliberately not yadm, what a guard is protecting against.
+  A passage that explains rather than instructs belongs here, not in the
+  runbook.
+- If the README starts to bloat, the fix is to move background *out* — to a
+  `reference/` file if one becomes warranted — never to compress the
+  getting-started path to make room.
+- Don't restructure it as a side effect of unrelated work. `.claude/rules/writing.md`
+  governs; it is a human-voiced doc.
+
+## RUNBOOK.md
+
+- **Actions only.** Every section answers "what do I do." Commands, the order
+  to run them in, and how to tell it worked. If a passage doesn't change what
+  the reader does next, it belongs in `README.md` instead.
+- **Every procedure ends in a verification step.** Not "it should work" — the
+  actual command whose output distinguishes success from silent failure. Most
+  of the failure modes in this repo are silent by construction: a hook that
+  isn't seeded, a key that doesn't match, a filter that isn't wired. A
+  procedure that can't tell you which one happened isn't finished.
+- Include a *why* only where its absence causes the wrong action — "don't skip
+  this, here's what silently breaks." One or two sentences, next to the step.
+  Not a background section.
+- **No point-in-time status.** Don't record which PR is open, what a session
+  found last week, or which hooks were seeded on some container. That rots
+  into a lie within days. Durable traps are fine; snapshots aren't.
+- A procedure isn't done until it has been run once, including the transition
+  path for machines that already exist. No machine here is a fresh clone.
+- Keep the "Where things are" index in sync with the headings. An index that
+  has drifted is worse than none — it sends the reader to a section that
+  isn't there and they conclude the procedure doesn't exist.
+
+## This repo is public
+
+- **Never commit session state here.** Boards, checkpoints, logs and handoffs
+  name boats, hosts and services. They go to the private
+  `claude_prompts_scratch` repo under `state/global/`. `.gitignore` blocks the
+  known paths; that is a backstop, not permission to try.
+- **Dotfiles has no board of its own.** Its cards sit on the global board, and
+  anything carrying a question becomes a dotfiles issue that the card links to.
+- Real hostnames, boat names, service URLs and account identifiers stay out of
+  tracked files, including in comments and example output. Use placeholders.
+
+## The worktree is `$HOME`
+
+- **Stage by path, always.** `git add -A` here means "add my entire home
+  directory." The `pre_commit` hook is the last line of defense, not the first.
+- Changes land in `$HOME` on every machine at the next `dotsync`. A broken
+  `.zshrc` doesn't fail a test suite; it breaks the next shell Mark opens on a
+  box he isn't sitting at.
+- Guard machine-specific values rather than branching the file: `$HOME`,
+  `command -v`, `[ -d ... ]`, `[[ "$OSTYPE" == darwin* ]]`. Reach for a yadm
+  alternate only when a whole file genuinely differs per OS, and then use
+  `##default`, never `##os.Linux` — yadm reports `WSL` under WSL2.
+
+## Shell scripts here
+
+- **POSIX `sh` unless there is a reason.** `bootstrap`, `pre_commit`,
+  `dotfiles-triage.sh` and `cloud-session-setup.sh` all run in places where
+  bash may not be what `sh` points at.
+- **Fail closed on a gate, exit 0 on a convenience.** `pre_commit` aborts when
+  it can't inspect the commit; `cloud-session-setup.sh` always exits 0, because
+  a missing dotfile must never stop a session from starting. Know which kind
+  you are writing before choosing.
+- **A guard that can be silently bypassed is not a guard.** `SKIP_GLOBS`,
+  `PRUNE_NEVER` and the yadm-managed-`$HOME` check all refuse loudly rather
+  than warn. Keep that.
+- Test with `--dry-run` where the script has one. `cloud-session-setup.sh
+  --dry-run` is safe on any machine, including Mark's own.
+
+## Claude Code config in this repo
+
+- `.claude/settings.json` is the source of truth for hooks. **Every hook it
+  references must also be in the `INSTALL` list of
+  `.local/bin/cloud-session-setup.sh`** — otherwise it silently no-ops in every
+  cloud session, and a no-op is indistinguishable from a hook that ran.
+- Adding a connector to the account does not deny it. `deniedMcpServers` is
+  by name, in two places: `.claude/cloud-setup.sh` and `.claude/settings.json`.
+  Update both.
+- Verify a Claude Code setting exists and does what you think before writing it
+  down. `disableClaudeAiConnectors` was set here for a long time and did not do
+  the job it was there for.

--- a/README.md
+++ b/README.md
@@ -1,32 +1,34 @@
-These are my dotfiles, managed with [yadm](https://yadm.io). Secrets, where any are
-tracked, are encrypted at rest with [sops](https://github.com/getsops/sops) +
-[age](https://github.com/FiloSottile/age) — see `.sops.yaml`.
+My dotfiles, managed with [yadm](https://yadm.io).
 
-Use at your own risk:
+## Set up a machine
+
 ```
 yadm clone git@github.com:mark-brannan/dotfiles.git
-
-yadm status
-yadm diff
-
-yadm bootstrap   # installs sops/age if missing, decrypts anything sops-managed
+yadm bootstrap    # installs nothing; decrypts sops-managed secrets
+dotsync           # the sync routine, from here on
 ```
 
-`.config/yadm/bootstrap` runs automatically after `yadm clone`, or manually via
-`yadm bootstrap`. It expects the machine's own age key to already exist at
-`~/.config/sops/age/keys.txt` (never tracked in this repo — restore it out-of-band, e.g.
-from a password manager) before it can decrypt anything.
+That's it. `.config/yadm/bootstrap` also runs automatically right after
+`yadm clone`.
 
-## Keeping machines in sync
+Two things it needs that git can't give you:
 
-`dotsync` (alias, defined in `.bashrc` and `.zsh_aliases`) is the whole routine:
+* **`yadm`, `sops` and `age` on `PATH`.** `apt-get install yadm age` /
+  `brew install yadm age sops`; sops on Linux is a
+  [release binary](https://github.com/getsops/sops/releases).
+* **The machine's age key at `~/.config/sops/age/keys.txt`**, restored
+  out-of-band from a password manager. It is never tracked here. Without it
+  everything still installs — only the secrets stay ciphertext.
+
+`dotsync` (alias, defined in `.bashrc` and `.zsh_aliases`) is the whole
+day-to-day routine:
 
 ```
 yadm pull --rebase --autostash && yadm alt && yadm status --short
 ```
 
-`--autostash` matters — a dirty `$HOME` is the normal state, and without it every
-pull stops with "cannot pull with rebase: You have unstaged changes."
+**Anything beyond this is in [RUNBOOK.md](RUNBOOK.md)** — Claude Code cloud
+environment setup, secrets, and troubleshooting.
 
 ## Conventions that keep it quiet
 
@@ -43,22 +45,16 @@ pull stops with "cannot pull with rebase: You have unstaged changes."
   never-sync paths and secret-shaped values in added lines. Override a false
   positive with `YADM_ALLOW_SECRET=1 yadm commit`. Run `.local/bin/dotfiles-triage.sh`
   for a full inventory of `$HOME` against the same policy.
+* **Secrets are sops+age, and plaintext never lands in the worktree.**
+  Ciphertext sits tracked at `secrets/<name>.sops.env`; bootstrap decrypts each
+  into `~/.config/secrets/<name>.env`, which is gitignored *and* outside the git
+  worktree, so a later `yadm add` cannot sweep it up. Shells source
+  `~/.config/secrets/*.env` at startup.
 * **Tool config that a tool rewrites lives outside git.** `~/.npmrc` is the case
   in point: npm overwrites it with an auth token on every login, so the settings
   live in `.profile`/`.zshenv` as `NPM_CONFIG_*` and the file itself is ignored.
-
-## Migrating a machine that predates the `.npmrc` change
-
-`.npmrc` used to be tracked. On a host that hasn't pulled since, `yadm pull` will
-refuse ("local changes would be overwritten") or delete the file along with any npm
-auth token in it. Save it first:
-
-```
-cp ~/.npmrc /tmp/npmrc.bak
-yadm checkout -- .npmrc
-dotsync
-cp /tmp/npmrc.bak ~/.npmrc   # now ignored; keeps the token, settings come from the shell
-```
+  (A host that hasn't pulled since that change needs
+  [a migration step](RUNBOOK.md#a-pull-refuses-local-changes-would-be-overwritten).)
 
 ## Session continuity hooks
 
@@ -104,32 +100,16 @@ Claude Code cloud sessions run as root on a throwaway Ubuntu VM with no
 `~/.claude/settings.json`. **Project settings still load** when the repo is a
 session source — confirmed 2026-08-19, a symphony `PreToolUse` hook fired in a
 cloud session with no user-scope settings at all — so a repo carrying its own
-`.claude/settings.json` already closes the gap for itself. The hooks below
-resolve to `$CLAUDE_PROJECT_DIR/.claude/hooks/` when `$HOME/.claude/hooks/` is
-absent, which is exactly that case.
+`.claude/settings.json` already closes the gap for itself.
 
 What the seed script buys is the *other* repos: standing orders, `rules/` and
 the hooks in a session working on something that has no `.claude/` of its own,
 plus `deniedMcpServers` at user scope. `.local/bin/cloud-session-setup.sh`
-installs a chosen subset of this repo into `$HOME`. Paste this into the
-environment's setup-script field (Claude Code → environment settings):
+installs a chosen subset of this repo into `$HOME`.
 
-```
-git clone -q https://github.com/mark-brannan/dotfiles \
-  "$HOME/.local/share/dotfiles-seed" 2>/dev/null
-CLOUD_SESSION=1 sh "$HOME/.local/share/dotfiles-seed/.local/bin/cloud-session-setup.sh"
-exit 0
-```
-
-**Also add `mark-brannan/claude_prompts_scratch` as a second source** on the
-same environment. The continuity hooks below read the board from it and write
-their state back to it, and the setup script cannot clone it — a VM has no
-credentials for a private repo at setup time. Without it the hooks still run
-but write to `~/.claude/state/global`, which dies with the container.
-
-The setup field only clones and delegates, so the logic stays version-controlled
-here rather than going stale in a web form. Measured cost on a cold VM: about
-5s total, against a ~5 minute window.
+**The procedure — the setup-script blob, the two sources, and how to verify —
+is [RUNBOOK.md § Create a cloud environment](RUNBOOK.md#create-a-cloud-environment).**
+The rest of this section is why it is built that way.
 
 **Deliberately not yadm**, even though yadm manages everything else here:
 
@@ -144,8 +124,11 @@ here rather than going stale in a web form. Measured cost on a cold VM: about
 * `yadm clone` also prompts on `/dev/tty` to run the bootstrap, which would
   hang the setup window.
 
-Edit the `INSTALL` allowlist in the script to add files. Two guards make that
-safe to expand:
+The setup field only clones and delegates, so the logic stays version-controlled
+here rather than going stale in a web form. Measured cost on a cold VM: about
+5s total, against a ~5 minute window.
+
+Two guards make the `INSTALL` allowlist safe to expand:
 
 * It **refuses to run where `$HOME` is yadm-managed** — every real machine has
   a yadm repo, an ephemeral VM never does — and skips entirely unless
@@ -156,8 +139,18 @@ safe to expand:
   `SKIP_GLOBS` hard-blocks `.gitconfig*`, `.gitignore` and anything
   sops-shaped even if added to `INSTALL` by mistake.
 
+A fourth scar: **seeding without pruning is why a deleted hook keeps running.**
+The container seeded it once, the repo dropped it, and the `$HOME` copy is still
+there and still wins. `PRUNE_DIRS` names the directories the script wholly owns,
+where anything not in `INSTALL` is a leftover and gets removed; `PRUNE_NEVER` is
+the tripwire for shared directories like `.claude` itself, which also holds
+`state/`, `projects/`, `todos/` and `settings.local.json` that the script never
+put there.
+
 `sh .local/bin/cloud-session-setup.sh --dry-run` previews the whole thing and
 is safe to run on any machine, including yadm-managed ones.
+
+## Archive
 
 `archive/` holds content carried over from the old chezmoi layout that isn't checked out
 live into `$HOME` on any current machine — SignalK Pi plugin config (superseded by the

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,0 +1,406 @@
+# Dotfiles runbook
+
+Procedures for setting up and operating these dotfiles: a machine, a Claude
+Code cloud environment, the sops-encrypted secrets, and the session-continuity
+hooks.
+
+**Getting started is in [README.md](README.md), not here.** If you just want a
+working `$HOME` on a new box, the three commands at the top of the README are
+the whole job. This file is for everything after that: the procedures that
+repeat, the ones that only happen when something has gone wrong, and the Claude
+Code setup that has no natural home in a dotfiles README.
+
+**Deliberately partial.** Only procedures that have been run or read out of the
+scripts they describe are written down. Age-key rotation and the two incident
+responses (a secret committed in plaintext, a lost key) are known gaps — they
+are the ones nobody has exercised, and a guessed procedure is worse than none.
+
+Procedures only. For *why* the repo is shaped the way it is — the yadm
+alternates trap, why the cloud seed is deliberately not yadm, the hook designs
+and the scars behind them — see [README.md § Conventions](README.md).
+
+## Where things are
+
+**Machines**
+- [Set up a new machine](#set-up-a-new-machine)
+- [Keep machines in sync](#keep-machines-in-sync)
+
+**Claude Code — cloud environments**
+- [Create a cloud environment](#create-a-cloud-environment)
+- [Attach the state repo to a running session](#attach-the-state-repo-to-a-running-session)
+- [Add a file to the cloud seed](#add-a-file-to-the-cloud-seed)
+- [Refresh the MCP connector deny list](#refresh-the-mcp-connector-deny-list)
+
+**Claude Code — a real machine**
+- [Wire the hooks on a real machine](#wire-the-hooks-on-a-real-machine)
+
+**Secrets**
+- [Add a secret](#add-a-secret)
+- [Rotate a secret](#rotate-a-secret)
+- [Clear a pre-commit false positive](#clear-a-pre-commit-false-positive)
+
+**Troubleshooting**
+- [`yadm status` shows a permanent typechange](#yadm-status-shows-a-permanent-typechange)
+- [A pull refuses: local changes would be overwritten](#a-pull-refuses-local-changes-would-be-overwritten)
+- [Session state went to `~/.claude/state/global`](#session-state-went-to-claudestateglobal)
+- [A hook didn't fire in a cloud session](#a-hook-didnt-fire-in-a-cloud-session)
+- [A deleted hook keeps running](#a-deleted-hook-keeps-running)
+- [Nothing decrypts on a new machine](#nothing-decrypts-on-a-new-machine)
+
+---
+
+## Set up a new machine
+
+The README's three commands cover the common case. This is the same path with
+the failure modes spelled out, in the order they bite.
+
+**1 — Tooling.** `yadm` must exist before anything else; `sops` and `age` can
+follow, but nothing decrypts until they do.
+
+```bash
+sudo apt-get install -y yadm age    # or: brew install yadm age sops
+# sops on Linux: grab a release binary from https://github.com/getsops/sops/releases
+command -v yadm age sops            # all three, before continuing
+```
+
+**2 — The age key, before the clone.** It is never in git — restore it from the
+password manager. Without it the clone still works and the bootstrap still
+runs; you just get plaintext-less secrets and a warning.
+
+```bash
+mkdir -p ~/.config/sops/age && chmod 700 ~/.config/sops/age
+# paste the key in:
+$EDITOR ~/.config/sops/age/keys.txt
+chmod 600 ~/.config/sops/age/keys.txt
+```
+
+Confirm it is the key you think it is before trusting it — a truncated paste is
+the realistic failure and is otherwise invisible:
+
+```bash
+age-keygen -y ~/.config/sops/age/keys.txt   # must print the recipient in .sops.yaml
+```
+
+**3 — Clone.** `yadm clone` prompts on the terminal to run the bootstrap; say
+yes, or run it yourself after.
+
+```bash
+yadm clone git@github.com:mark-brannan/dotfiles.git
+yadm bootstrap      # idempotent; safe to re-run at any time
+```
+
+**4 — Verify.** The bootstrap prints `==> bootstrap done`. Check what it
+produced and what yadm thinks of `$HOME`:
+
+```bash
+ls -l ~/.config/secrets/          # one .env per tracked secrets/*.sops.env
+yadm status --short               # expect clean, or only files you know about
+sh ~/.local/bin/dotfiles-triage.sh | head -40   # read-only inventory vs policy
+```
+
+**Special case — a host that predates the `.npmrc` change.** `.npmrc` used to be
+tracked, so on such a host the pull refuses or deletes the file along with any
+npm auth token in it. Save it first:
+
+```bash
+cp ~/.npmrc /tmp/npmrc.bak
+yadm checkout -- .npmrc
+dotsync
+cp /tmp/npmrc.bak ~/.npmrc   # now gitignored; settings come from the shell
+```
+
+## Keep machines in sync
+
+```bash
+dotsync    # alias: yadm pull --rebase --autostash && yadm alt && yadm status --short
+```
+
+`--autostash` is load-bearing, not tidiness — a dirty `$HOME` is the normal
+state, and without it every pull stops on "cannot pull with rebase: You have
+unstaged changes."
+
+Run `yadm alt` by hand after editing any `##`-suffixed file: yadm only relinks
+alternates when it feels like it, and a stale symlink looks exactly like a
+working one.
+
+## Create a cloud environment
+
+A Claude Code cloud environment configures exactly four things: **name, network
+access, environment variables, and a setup script.** Repositories are *not*
+part of the environment — they attach per session, as sources.
+
+**1 — Setup script.** Paste this verbatim into the environment's setup-script
+field. It only clones and delegates, so the logic stays version-controlled here
+rather than going stale in a web form:
+
+```sh
+git clone -q https://github.com/mark-brannan/dotfiles \
+  "$HOME/.local/share/dotfiles-seed" 2>/dev/null
+CLOUD_SESSION=1 sh "$HOME/.local/share/dotfiles-seed/.local/bin/cloud-session-setup.sh"
+exit 0
+```
+
+Measured cost on a cold VM: about 5s, against a ~5 minute window.
+
+**2 — Sources.** Add **both**:
+
+- `mark-brannan/dotfiles` — carries `.claude/settings.json`, so any session
+  started on this repo gets the hooks even with no user-scope settings at all.
+- `mark-brannan/claude_prompts_scratch` — the private state repo. The
+  continuity hooks read the board from it and write their state back to it.
+  **The setup script cannot clone this**: a VM has no credentials for a private
+  repo at setup time, and the GitHub proxy 403s any repo not attached. Without
+  it the hooks still run but write to `~/.claude/state/global`, which dies with
+  the container.
+
+**3 — Network access.** Outbound HTTPS goes through the environment's proxy.
+Leave it at whatever policy the other environments use unless a session
+actually needs a host that is being blocked; widening it is a deliberate
+decision, not a default.
+
+**4 — Environment variables.** Nothing in this repo requires one. The two the
+seed script reads are set inline by the paste blob (`CLOUD_SESSION=1`) or by the
+harness (`CLAUDE_CODE_REMOTE=true`), so the field stays empty.
+
+**Verify** on the next session: `session-start-continuity.sh` prints the board
+at the top. If it instead prints a "state repo NOT available" notice, step 2
+did not take — see [attaching it to a running
+session](#attach-the-state-repo-to-a-running-session).
+
+## Attach the state repo to a running session
+
+Needed every cold session where `claude_prompts_scratch` was not attached as a
+source. There is no environment setting that does this for you.
+
+1. `mcp__Claude_Code_Remote__add_repo` with owner `mark-brannan`, repo
+   `claude_prompts_scratch`, access `push`.
+2. Clone it to `/workspace/claude_prompts_scratch` — a path `state_repo()`
+   in `.claude/hooks/lib-state.sh` already searches.
+
+The other paths it searches, in order: `$CLAUDE_STATE_REPO`,
+`/home/user/claude_prompts_scratch`, `/workspace/claude_prompts_scratch`,
+`~/claude_prompts_scratch`, `~/src/…`, `~/Projects/…`, `~/code/…`. Setting
+`CLAUDE_STATE_REPO` wins over all of them if the clone landed somewhere else.
+
+## Add a file to the cloud seed
+
+Edit the `INSTALL` allowlist in `.local/bin/cloud-session-setup.sh` — repo-
+relative paths, one per line, copied to the same path under `$HOME`. Expand
+deliberately: every line lands in every cloud session.
+
+```bash
+$EDITOR .local/bin/cloud-session-setup.sh
+sh .local/bin/cloud-session-setup.sh --dry-run   # safe on any machine, including yadm-managed
+```
+
+Two guards make expansion safe, and both will simply refuse rather than warn:
+
+- `SKIP_GLOBS` hard-blocks `.gitconfig*`, `.gitignore` and anything sops-shaped
+  even if added to `INSTALL` by mistake.
+- The script refuses to run where `$HOME` is yadm-managed, and skips entirely
+  unless `CLOUD_SESSION=1` or `CLAUDE_CODE_REMOTE=true`.
+
+If the new file lives in a directory not already in `PRUNE_DIRS`, decide
+whether that directory is *wholly owned* by this script. Only wholly-owned leaf
+directories go in `PRUNE_DIRS`; `PRUNE_NEVER` lists the shared ones that must
+never be pruned.
+
+**Every hook `.claude/settings.json` references must be in `INSTALL`.** A hook
+wired in settings but missing from the seed is a silent no-op in every cloud
+session — the settings entries are `[ -f ]`-guarded and end in `|| true`, so it
+looks identical to a hook that ran and found nothing to do. After editing
+either file, diff the two lists:
+
+```bash
+grep -o '\.claude/hooks/[a-z-]*\.sh' .claude/settings.json | sort -u
+sed -n '/^INSTALL=/,/^"$/p' .local/bin/cloud-session-setup.sh | grep hooks/
+```
+
+## Refresh the MCP connector deny list
+
+Cloud sessions get claude.ai connectors delivered server-side, and their tool
+schemas are the largest fixed cost in the context floor. Deny is **by name**, so
+a connector added to the account later is not covered until this list is
+refreshed.
+
+1. Run the `ListConnectors` tool in a session to get the live list.
+2. Server names are the connector's display name with spaces replaced by
+   underscores.
+3. Update the `DENY` array in `.claude/cloud-setup.sh`, and mirror any addition
+   into `deniedMcpServers` in `.claude/settings.json`.
+
+`cloud-setup.sh` merges rather than clobbers — an existing `settings.json`
+keeps its other keys and its existing `deniedMcpServers` entries are unioned
+with the new ones — and it degrades to a non-`jq` path when `jq` is absent.
+
+```bash
+sh .claude/cloud-setup.sh
+jq '.deniedMcpServers | length' ~/.claude/settings.json
+```
+
+Note `disableClaudeAiConnectors` in `.claude/settings.json` does **not** do this
+job: it governs the CLI's own auto-fetch path, not the server-side delivery
+cloud sessions use. `deniedMcpServers` merges across all settings sources and
+beats every allowlist.
+
+## Wire the hooks on a real machine
+
+Nothing to do — `yadm clone` puts `.claude/settings.json` and
+`.claude/hooks/` in `$HOME`, which is user scope, and every session on the
+machine reads them. Hook commands resolve against `$HOME/.claude/hooks/`; the
+cloud seed's whole job is to put the same files at the same path on a VM.
+
+To confirm on a machine you have just set up:
+
+```bash
+ls ~/.claude/hooks/
+bash ~/.claude/hooks/statusline-metrics.sh   # prints the status line, or nothing
+```
+
+Then start a session: `session-start-continuity.sh` injecting the board is the
+end-to-end proof.
+
+## Add a secret
+
+Ciphertext lives tracked at `~/secrets/<name>.sops.env`; the bootstrap decrypts
+each into `~/.config/secrets/<name>.env`, which is gitignored and outside the
+git working tree, so plaintext can never be swept up by a later `yadm add`.
+`.zshrc`/`.bashrc` source everything under `~/.config/secrets/*.env` at startup.
+
+```bash
+$EDITOR /tmp/new.env                    # KEY=value lines
+sops -e /tmp/new.env > ~/secrets/new.sops.env
+shred -u /tmp/new.env
+yadm add ~/secrets/new.sops.env
+yadm commit -m "secrets: add new"
+yadm bootstrap                          # decrypts it into ~/.config/secrets/
+```
+
+`.sops.yaml` matches on `secrets/` and on `.sops.<ext>` suffixes, so both
+conventions encrypt automatically. Verify before committing — a file that
+matched no creation rule is committed in the clear:
+
+```bash
+head -5 ~/secrets/new.sops.env    # must be sops ciphertext, not your KEY=value
+```
+
+## Rotate a secret
+
+```bash
+sops ~/secrets/<name>.sops.env    # decrypts to $EDITOR, re-encrypts on save
+yadm diff ~/secrets/<name>.sops.env   # ciphertext changed; plaintext never shown
+yadm commit -m "secrets: rotate <name>"
+```
+
+Then on every other machine: `dotsync && yadm bootstrap`, and restart shells so
+the new value is sourced. Revoke the old credential at the provider *after* the
+new one is confirmed working, not before.
+
+## Clear a pre-commit false positive
+
+`~/.config/yadm/hooks/pre_commit` blocks credential material and secret-shaped
+values in added lines, and **fails closed**: if it cannot read the commit
+(`YADM_HOOK_REPO`/`WORK` unset, i.e. yadm older than 3.2) it aborts rather than
+waving it through.
+
+```bash
+yadm commit -m "..."                       # read exactly which path/line it named
+# confirm it really is a false positive, then:
+YADM_ALLOW_SECRET=1 yadm commit -m "..."
+```
+
+If the same path trips it repeatedly, fix the policy rather than the commit:
+`.gitignore`, the `NEVER` class in `.local/bin/dotfiles-triage.sh`, and the
+`pre_commit` hook mirror each other and should be edited together.
+
+---
+
+## `yadm status` shows a permanent typechange
+
+The generated alternate target is tracked as a real file as well. yadm relinks
+it after every command, so status reports a typechange forever.
+
+```bash
+yadm rm --cached .gitconfig        # stop tracking the generated target
+grep -n '^\.gitconfig$' ~/.gitignore || echo '.gitconfig' >> ~/.gitignore
+yadm alt && yadm status --short    # clean
+```
+
+Only `.gitconfig##os.Darwin` and `.gitconfig##default` are ever tracked.
+
+## A pull refuses: local changes would be overwritten
+
+Almost always a file that used to be tracked and now isn't — `.npmrc` is the
+known case. Save it, drop the local copy, pull, restore.
+
+```bash
+cp ~/<file> /tmp/<file>.bak
+yadm checkout -- <file>
+dotsync
+cp /tmp/<file>.bak ~/<file>
+```
+
+If it is not a de-tracked file, `yadm status --short` and `yadm diff <file>`
+first — do not blanket-checkout a file you have not read.
+
+## Session state went to `~/.claude/state/global`
+
+`claude_prompts_scratch` is not checked out where `state_repo()` looks, so the
+hooks degraded to a local, unpushed directory. On a cloud session it dies with
+the container.
+
+```bash
+ls -d /workspace/claude_prompts_scratch/.git ~/claude_prompts_scratch/.git 2>/dev/null
+```
+
+Cloud session: [attach it](#attach-the-state-repo-to-a-running-session). Real
+machine: clone it to one of the searched paths, or export
+`CLAUDE_STATE_REPO=/path/to/it`. Anything already written to
+`~/.claude/state/global` can be copied across by hand; nothing does that for you.
+
+## A hook didn't fire in a cloud session
+
+Check in this order:
+
+```bash
+ls ~/.claude/hooks/                              # did the seed run at all?
+grep -n 'the-hook-name' ~/.claude/settings.json  # is it wired?
+```
+
+- Nothing in `~/.claude/hooks/` → the setup script did not run. The seed skips
+  entirely unless `CLOUD_SESSION=1` or `CLAUDE_CODE_REMOTE=true`, so a paste
+  blob missing the `CLOUD_SESSION=1` prefix is a silent no-op.
+- Wired in settings but absent from `~/.claude/hooks/` → it is not in
+  `INSTALL`. See [adding a file to the seed](#add-a-file-to-the-cloud-seed).
+  This is the common one, and it is silent by design.
+- Present and wired → run it by hand (`bash ~/.claude/hooks/<name>.sh`). Every
+  settings entry ends in `|| true` and most redirect stderr, so a hook that
+  errors every time looks identical to one that is not wired.
+
+The seed is not the only path that works: a repo carrying its own
+`.claude/settings.json` gets its project settings loaded in a cloud session even
+with no user-scope settings at all. What the seed buys is the *other* repos.
+
+## A deleted hook keeps running
+
+The container seeded it once, the repo dropped it, and the `$HOME` copy is
+still there. Hook commands resolve against `$HOME/.claude/hooks/` and the file
+is present, so it runs — removing it from the repo changed nothing about this
+container.
+
+This is what `PRUNE_DIRS` in `.local/bin/cloud-session-setup.sh` exists for: any
+file in a pruned directory that is not in `INSTALL` is removed on the next seed.
+If a stale hook survived, its directory is not in `PRUNE_DIRS`. Add it if the
+script wholly owns that directory; delete the file by hand either way.
+
+## Nothing decrypts on a new machine
+
+```bash
+command -v sops age                              # both must exist
+age-keygen -y ~/.config/sops/age/keys.txt        # must match .sops.yaml's recipient
+sops -d ~/secrets/<name>.sops.env | head -1      # the actual failure message
+```
+
+A key that does not match the recipient in `.sops.yaml` cannot decrypt anything
+and never will — it is not a permissions problem. Restore the correct key from
+the password manager, or re-encrypt from a machine that still holds the old one.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -34,6 +34,9 @@ and the scars behind them — see [README.md § Conventions](README.md).
 **Claude Code — a real machine**
 - [Wire the hooks on a real machine](#wire-the-hooks-on-a-real-machine)
 
+**GitHub repository**
+- [Set the Anthropic API key for the PR review workflows](#set-the-anthropic-api-key-for-the-pr-review-workflows)
+
 **Secrets**
 - [Add a secret](#add-a-secret)
 - [Rotate a secret](#rotate-a-secret)
@@ -46,6 +49,7 @@ and the scars behind them — see [README.md § Conventions](README.md).
 - [A hook didn't fire in a cloud session](#a-hook-didnt-fire-in-a-cloud-session)
 - [A deleted hook keeps running](#a-deleted-hook-keeps-running)
 - [Nothing decrypts on a new machine](#nothing-decrypts-on-a-new-machine)
+- [PR checks fail immediately with an empty API key](#pr-checks-fail-immediately-with-an-empty-api-key)
 
 ---
 
@@ -260,6 +264,66 @@ bash ~/.claude/hooks/statusline-metrics.sh   # prints the status line, or nothin
 Then start a session: `session-start-continuity.sh` injecting the board is the
 end-to-end proof.
 
+## Set the Anthropic API key for the PR review workflows
+
+`.github/workflows/claude-code-review.yml` and `claude-security-review.yml` run
+on every PR and both read the **repository** secret `ANTHROPIC_API_KEY`. They
+pass it under different input names (`anthropic_api_key` and `claude-api-key`)
+but it is one secret. Until it is set, both checks fail about 30 seconds in —
+see [the troubleshooting entry](#pr-checks-fail-immediately-with-an-empty-api-key).
+
+This is a **GitHub repo secret, not a sops secret.** Nothing about it lives in
+this repo: `secrets/`, `.sops.yaml` and the bootstrap are not involved. It is
+set once per repository and it is not something a machine setup can do for you.
+
+**1 — Mint a dedicated key** at <https://console.anthropic.com/settings/keys>.
+Use a separate key named for this repo rather than reusing a local one, so
+revoking it later doesn't break Claude Code on your machines.
+
+**2 — Set it.** Never paste a key onto the command line — it lands in shell
+history. Pipe it in, or let `gh` prompt:
+
+```bash
+gh secret set ANTHROPIC_API_KEY --repo mark-brannan/dotfiles
+# reads the value from the prompt; nothing is echoed and nothing is stored locally
+```
+
+From a file, if the key is already on disk somewhere disposable:
+
+```bash
+gh secret set ANTHROPIC_API_KEY --repo mark-brannan/dotfiles < /tmp/key.txt
+shred -u /tmp/key.txt
+```
+
+Without `gh`: GitHub web UI → the repo → Settings → Secrets and variables →
+Actions → New repository secret. Name it exactly `ANTHROPIC_API_KEY`.
+
+**3 — Verify.** `gh` never prints a secret's value, so the only proof is that
+the name exists and that a run goes green:
+
+```bash
+gh secret list --repo mark-brannan/dotfiles     # ANTHROPIC_API_KEY, with a set date
+```
+
+Then re-run the failed checks on any open PR — **setting the secret does not
+retroactively rerun anything**, and a PR that failed before the secret existed
+stays red until something kicks it:
+
+```bash
+gh run list --repo mark-brannan/dotfiles --limit 5
+gh run rerun <run-id> --failed --repo mark-brannan/dotfiles
+```
+
+Both `review` and `security` should complete and post a comment on the PR.
+
+This repo is public. Actions secrets are not exposed to workflows triggered by
+forked PRs, and the security workflow's own comment says it should only run
+against trusted PRs — true here because only the owner pushes. If that ever
+stops being true, the security workflow needs revisiting before the key does.
+
+CodeRabbit is configured by `.coderabbit.yaml` and authenticates as a GitHub
+App. It needs no secret, so it is unaffected by any of this.
+
 ## Add a secret
 
 Ciphertext lives tracked at `~/secrets/<name>.sops.env`; the bootstrap decrypts
@@ -404,3 +468,21 @@ sops -d ~/secrets/<name>.sops.env | head -1      # the actual failure message
 A key that does not match the recipient in `.sops.yaml` cannot decrypt anything
 and never will — it is not a permissions problem. Restore the correct key from
 the password manager, or re-encrypt from a machine that still holds the old one.
+
+## PR checks fail immediately with an empty API key
+
+Both `review` and `security` go red about 30 seconds in, on every PR, including
+ones that change nothing relevant. The tell is in the job log's env group:
+
+```bash
+gh run view <run-id> --repo mark-brannan/dotfiles --log | grep -i 'ANTHROPIC_API_KEY'
+```
+
+`ANTHROPIC_API_KEY:` with nothing after it means the repository secret is unset
+or empty — the workflow is fine, the credential is missing. Set it via
+[the procedure above](#set-the-anthropic-api-key-for-the-pr-review-workflows),
+then rerun the failed jobs; the secret does not apply retroactively.
+
+Not this if only *one* of the two checks fails, or if the failure comes minutes
+in rather than seconds — that is a real finding or a rate limit, not a missing
+key.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -35,7 +35,7 @@ and the scars behind them — see [README.md § Conventions](README.md).
 - [Wire the hooks on a real machine](#wire-the-hooks-on-a-real-machine)
 
 **GitHub repository**
-- [Set the Anthropic API key for the PR review workflows](#set-the-anthropic-api-key-for-the-pr-review-workflows)
+- [Set the auth token for the PR review workflows](#set-the-auth-token-for-the-pr-review-workflows)
 
 **Secrets**
 - [Add a secret](#add-a-secret)
@@ -49,7 +49,8 @@ and the scars behind them — see [README.md § Conventions](README.md).
 - [A hook didn't fire in a cloud session](#a-hook-didnt-fire-in-a-cloud-session)
 - [A deleted hook keeps running](#a-deleted-hook-keeps-running)
 - [Nothing decrypts on a new machine](#nothing-decrypts-on-a-new-machine)
-- [PR checks fail immediately with an empty API key](#pr-checks-fail-immediately-with-an-empty-api-key)
+- [PR checks fail immediately with an empty credential](#pr-checks-fail-immediately-with-an-empty-credential)
+- [The security-review workflow cannot use an OAuth token](#the-security-review-workflow-cannot-use-an-oauth-token)
 
 ---
 
@@ -264,65 +265,76 @@ bash ~/.claude/hooks/statusline-metrics.sh   # prints the status line, or nothin
 Then start a session: `session-start-continuity.sh` injecting the board is the
 end-to-end proof.
 
-## Set the Anthropic API key for the PR review workflows
+## Set the auth token for the PR review workflows
 
-`.github/workflows/claude-code-review.yml` and `claude-security-review.yml` run
-on every PR and both read the **repository** secret `ANTHROPIC_API_KEY`. They
-pass it under different input names (`anthropic_api_key` and `claude-api-key`)
-but it is one secret. Until it is set, both checks fail about 30 seconds in —
-see [the troubleshooting entry](#pr-checks-fail-immediately-with-an-empty-api-key).
+Two workflows run on every PR, and **they do not authenticate the same way.**
+Check which you are fixing before touching a secret:
 
-This is a **GitHub repo secret, not a sops secret.** Nothing about it lives in
-this repo: `secrets/`, `.sops.yaml` and the bootstrap are not involved. It is
-set once per repository and it is not something a machine setup can do for you.
+| workflow | action | input | secret | billing |
+| --- | --- | --- | --- | --- |
+| `claude-code-review.yml` | `anthropics/claude-code-action@v1` | `claude_code_oauth_token` | `CLAUDE_CODE_OAUTH_TOKEN` | subscription |
+| `claude-security-review.yml` | `anthropics/claude-code-security-review@main` | `claude-api-key` | `ANTHROPIC_API_KEY` | API, metered |
 
-**1 — Mint a dedicated key** at <https://console.anthropic.com/settings/keys>.
-Use a separate key named for this repo rather than reusing a local one, so
-revoking it later doesn't break Claude Code on your machines.
+The OAuth token bills against a Claude subscription rather than API credit,
+which is why the review workflow uses it. **The security-review action has no
+OAuth input** — its `claude-api-key` is `required: true` — so it cannot be
+converted; it either gets a metered API key or it gets disabled. See
+[the entry below](#the-security-review-workflow-cannot-use-an-oauth-token).
 
-**2 — Set it.** Never paste a key onto the command line — it lands in shell
-history. Pipe it in, or let `gh` prompt:
+These are **GitHub repo secrets, not sops secrets.** Nothing about them lives
+in this repo: `secrets/`, `.sops.yaml` and the bootstrap are not involved. They
+are set once per repository, and no machine setup does it for you.
 
-```bash
-gh secret set ANTHROPIC_API_KEY --repo mark-brannan/dotfiles
-# reads the value from the prompt; nothing is echoed and nothing is stored locally
-```
-
-From a file, if the key is already on disk somewhere disposable:
+**1 — Mint the token.** From Claude Code on a machine already logged in:
 
 ```bash
-gh secret set ANTHROPIC_API_KEY --repo mark-brannan/dotfiles < /tmp/key.txt
-shred -u /tmp/key.txt
+claude setup-token
 ```
 
-Without `gh`: GitHub web UI → the repo → Settings → Secrets and variables →
-Actions → New repository secret. Name it exactly `ANTHROPIC_API_KEY`.
+It prints a long-lived token tied to your subscription. It is not an API key
+and will not work in `ANTHROPIC_API_KEY`.
+
+**2 — Set it.** Never paste a token onto the command line — it lands in shell
+history. Let `gh` prompt, or pipe it in:
+
+```bash
+gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo mark-brannan/dotfiles
+# reads from the prompt; nothing is echoed, nothing is stored locally
+```
+
+Without `gh`: the repo's Settings → Secrets and variables → Actions → New
+repository secret. Name it exactly `CLAUDE_CODE_OAUTH_TOKEN`.
 
 **3 — Verify.** `gh` never prints a secret's value, so the only proof is that
 the name exists and that a run goes green:
 
 ```bash
-gh secret list --repo mark-brannan/dotfiles     # ANTHROPIC_API_KEY, with a set date
+gh secret list --repo mark-brannan/dotfiles     # the name, with a set date
 ```
 
-Then re-run the failed checks on any open PR — **setting the secret does not
-retroactively rerun anything**, and a PR that failed before the secret existed
-stays red until something kicks it:
+Then re-run the failed checks on any open PR. **Setting a secret does not
+retroactively rerun anything** — a PR that failed before it existed stays red
+until something kicks it:
 
 ```bash
 gh run list --repo mark-brannan/dotfiles --limit 5
 gh run rerun <run-id> --failed --repo mark-brannan/dotfiles
 ```
 
-Both `review` and `security` should complete and post a comment on the PR.
+`review` should now complete and comment on the PR. `security` stays red until
+its own separate decision is made.
+
+The token expires. When `review` starts failing on PRs that used to pass and
+nothing about the workflow changed, re-run `claude setup-token` and set the
+secret again — same procedure, no other cleanup.
 
 This repo is public. Actions secrets are not exposed to workflows triggered by
 forked PRs, and the security workflow's own comment says it should only run
-against trusted PRs — true here because only the owner pushes. If that ever
-stops being true, the security workflow needs revisiting before the key does.
+against trusted PRs — true here because only the owner pushes. If that stops
+being true, that workflow needs revisiting before the credential does.
 
 CodeRabbit is configured by `.coderabbit.yaml` and authenticates as a GitHub
-App. It needs no secret, so it is unaffected by any of this.
+App. It needs no secret, so none of this affects it.
 
 ## Add a secret
 
@@ -469,20 +481,43 @@ A key that does not match the recipient in `.sops.yaml` cannot decrypt anything
 and never will — it is not a permissions problem. Restore the correct key from
 the password manager, or re-encrypt from a machine that still holds the old one.
 
-## PR checks fail immediately with an empty API key
+## PR checks fail immediately with an empty credential
 
-Both `review` and `security` go red about 30 seconds in, on every PR, including
-ones that change nothing relevant. The tell is in the job log's env group:
+A check goes red about 30 seconds in, on every PR, including ones that change
+nothing relevant. The tell is in the job log's env group:
 
 ```bash
-gh run view <run-id> --repo mark-brannan/dotfiles --log | grep -i 'ANTHROPIC_API_KEY'
+gh run view <run-id> --repo mark-brannan/dotfiles --log \
+  | grep -iE 'ANTHROPIC_API_KEY|CLAUDE_CODE_OAUTH_TOKEN'
 ```
 
-`ANTHROPIC_API_KEY:` with nothing after it means the repository secret is unset
-or empty — the workflow is fine, the credential is missing. Set it via
-[the procedure above](#set-the-anthropic-api-key-for-the-pr-review-workflows),
-then rerun the failed jobs; the secret does not apply retroactively.
+A name with nothing after it means that repository secret is unset or empty —
+the workflow is fine, the credential is missing. Check which secret the failing
+workflow actually reads before setting anything; the two workflows use different
+ones, and setting the wrong one changes nothing. Then
+[set it](#set-the-auth-token-for-the-pr-review-workflows) and rerun the failed
+jobs; a secret does not apply retroactively.
 
-Not this if only *one* of the two checks fails, or if the failure comes minutes
-in rather than seconds — that is a real finding or a rate limit, not a missing
-key.
+Not this if the failure comes minutes in rather than seconds — that is a real
+finding, a rate limit, or an expired token, not a missing one.
+
+## The security-review workflow cannot use an OAuth token
+
+`anthropics/claude-code-security-review@main` exposes no OAuth input:
+`claude-api-key` is `required: true` in its `action.yml`. There is no way to
+point it at a subscription token, so while `ANTHROPIC_API_KEY` is unset this
+check stays red no matter what is done to `CLAUDE_CODE_OAUTH_TOKEN`.
+
+Three ways out, all deliberate choices rather than fixes:
+
+- **Set `ANTHROPIC_API_KEY`** and accept metered API billing for this one
+  workflow.
+- **Delete `.github/workflows/claude-security-review.yml`.** The general review
+  pass already prompts for secrets handling, sops rules and auto-executing
+  hooks, so the coverage loss is smaller than it looks.
+- **Narrow when it runs** — `on: workflow_dispatch` instead of `on:
+  pull_request` — so it is available on demand without gating every PR.
+
+Verify whichever you pick by re-running the check, not by reading the workflow:
+a green `review` and a still-red `security` is the state that means only half
+the decision has been made.


### PR DESCRIPTION
Closes the gap where Claude Code setup was only half written down: the cloud setup-script blob was in the README, but the two sources, the per-session `add_repo` for the state repo, the network/env fields, the deny-list refresh, and how CI authenticates were nowhere.

Modeled on symphony's `RUNBOOK.md` + `CLAUDE.md § RUNBOOK.md` split, adapted down — this repo is a tenth the size, so no `reference/` tier and no `docs/` directory.

## What changed

**`README.md`** — leads with the three commands a human needs on a new machine, before any explanation. Keeps the conventions and the design rationale (why the cloud seed is deliberately not yadm, the hook scars, the prune rationale). Procedures move to the runbook; the *why* stays.

**`RUNBOOK.md`** (new) — actions only, with a "Where things are" index. Machines · cloud environments · the PR-workflow auth token · secrets · six troubleshooting entries. Every procedure ends in a command whose output distinguishes success from silent failure.

**`CLAUDE.md`** (new, repo root) — discipline for both docs plus the two constraints that shape everything here: the repo is public, and its worktree is `$HOME`. Scoped to dotfiles sessions, so it costs nothing in sessions on other projects.

## Deliberately partial

Only procedures run or read out of the scripts they describe are written down. Age-key rotation and the two incident responses (a secret committed in plaintext, a lost key) are named as gaps at the top of the runbook rather than guessed at — those are exactly the ones nobody has exercised, and a wrong procedure there is worse than none.

## A finding this surfaced

The OAuth switch converted `claude-code-review.yml` but not `claude-security-review.yml`, which still reads `ANTHROPIC_API_KEY`. `anthropics/claude-code-security-review`'s `action.yml` exposes **no OAuth input** — `claude-api-key` is `required: true`, verified upstream — so that check cannot go green without metered API billing. The runbook states the three real options (pay, delete the workflow, or move it to `workflow_dispatch`) instead of implying a secret will fix it. Not changed here; it's a decision, not a doc bug.

## History note

The first version of this branch shared no common ancestor with `main` after the history rewrite landed, so it could not be merged and its diff read as 999 insertions. Rebuilt directly on current `main` — three files, merges clean.

## Verification

Anchor links and index coverage checked programmatically after every edit: no broken `#anchor`, no heading missing from the index, no broken `README.md → RUNBOOK.md#…` link. Content is drawn from the scripts and workflows themselves (`cloud-session-setup.sh`, `cloud-setup.sh`, `bootstrap`, `pre_commit`, `lib-state.sh`, `settings.json`, `.sops.yaml`, both workflow files, and the upstream `action.yml`), not from memory. The procedures have not been executed end-to-end on a fresh machine — that's the test this iteration is short enough to allow.