### PR TITLE
hooks: enforce the PR-watch token threshold instead of asking prose to

### DIFF
--- a/.claude/hooks/no-late-pr-subscribe.sh
+++ b/.claude/hooks/no-late-pr-subscribe.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Blocks subscribe_pr_activity once this session's context has grown past the
+# point where watching is cheaper than starting fresh.
+#
+# Why: subscribing is free while idle, but every wake re-sends the session's
+# whole accumulated context as cache-read input, and the session only grows
+# from there. A watcher armed at 30k tokens is cheap; the same watcher armed
+# at 150k pays that 150k back on every comment, every check, for the life of
+# the PR. Past the threshold the fire-and-forget path is strictly cheaper:
+# push, open the PR, end the turn, archive the chat, pick the PR up fresh.
+#
+# This is the enforcement half of the "Babysitting a PR is cheap; polling for
+# it is not" rule in ~/.claude/rules/code.md, which was prose-only and so was
+# only followed when it happened to be in context.
+#
+# Token count is not passed to hooks directly. It is derived the same way
+# statusline-metrics.sh derives it: the last assistant `usage` block in the
+# transcript, whose input + cache_read + cache_creation is the context that
+# request actually carried. Only the tail is scanned -- transcripts run to
+# tens of MB and the newest usage record is always near the end.
+set -uo pipefail
+
+LIMIT=${CLAUDE_PR_WATCH_TOKEN_LIMIT:-100000}
+
+input=$(cat)
+
+# No jq means no measurement; fail open rather than blocking blind.
+command -v jq >/dev/null 2>&1 || exit 0
+
+transcript=$(printf '%s' "$input" | jq -r '.transcript_path // ""' 2>/dev/null)
+[ -n "$transcript" ] && [ -f "$transcript" ] || exit 0
+
+ctx=$(tail -n 500 "$transcript" 2>/dev/null | jq -s -r '
+  [ .[] | select(.type == "assistant") | .message.usage
+    | select(. != null)
+    | ((.input_tokens // 0) + (.cache_read_input_tokens // 0)
+       + (.cache_creation_input_tokens // 0)) ]
+  | (max // 0)' 2>/dev/null) || exit 0
+
+case "$ctx" in ''|*[!0-9]*) exit 0 ;; esac
+[ "$ctx" -ge "$LIMIT" ] || exit 0
+
+k=$((ctx / 1000))
+limk=$((LIMIT / 1000))
+
+jq -n --arg r "Blocked by ~/.claude/hooks/no-late-pr-subscribe.sh: this session is at ~${k}k tokens, at or over the ~${limk}k watch threshold. Every wake on this subscription would re-send that whole context, and it only grows from here. Take the fire-and-forget path instead: push, open the PR (draft, no reviewer), then end the turn with the follow-up prompt that would resume the work, plus \"You should archive this chat now. It's at ~${k}k tokens.\" No webhook, no wake -- pick the PR up fresh in a new session." '
+  {hookSpecificOutput: {
+     hookEventName: "PreToolUse",
+     permissionDecision: "deny",
+     permissionDecisionReason: $r}}'
+exit 0

--- a/.claude/hooks/no-late-pr-subscribe.sh
+++ b/.claude/hooks/no-late-pr-subscribe.sh
@@ -13,6 +13,22 @@
 # it is not" rule in ~/.claude/rules/code.md, which was prose-only and so was
 # only followed when it happened to be in context.
 #
+# The threshold is a fraction of the window, not a fixed 100k, because a fixed
+# number means different things on different plans: 100k is 50% of the default
+# 200k window but 10% of the 1M window Opus auto-upgrades to on Max, where it
+# would refuse watching for no reason. 60% is the number:
+#   - a realistic wake costs 5-15k (event payload, CI logs, diff, a fix turn),
+#     so 40% headroom on a 200k window is roughly 6-10 wakes
+#   - cloud/web sessions -- exactly the class that subscribes to PR activity --
+#     compact as they *approach* the limit rather than at it, and what
+#     compaction drops is the reasoning behind the diff under review
+#   - prompt cache lives 1h on a subscription; PR events routinely arrive
+#     further apart than that, so a large share of wakes are cache misses that
+#     reprocess the whole context at ~10x the cached rate
+# Plus a hard floor: never subscribe with less than 60k of headroom, whatever
+# the window, so the fraction cannot authorize a watch that has no room to run.
+# Sources: code.claude.com/docs/en/{model-config,costs,context-window}.
+#
 # Token count is not passed to hooks directly. It is derived the same way
 # statusline-metrics.sh derives it: the last assistant `usage` block in the
 # transcript, whose input + cache_read + cache_creation is the context that
@@ -20,7 +36,23 @@
 # tens of MB and the newest usage record is always near the end.
 set -uo pipefail
 
-LIMIT=${CLAUDE_PR_WATCH_TOKEN_LIMIT:-100000}
+# Override any of these per-session. WINDOW must be raised by hand for a 1M
+# session -- the hook payload does not carry the model's context window.
+WINDOW=${CLAUDE_PR_WATCH_CONTEXT_WINDOW:-200000}
+PERCENT=${CLAUDE_PR_WATCH_CONTEXT_PERCENT:-60}
+FLOOR=${CLAUDE_PR_WATCH_MIN_HEADROOM:-60000}
+
+# Whichever binds first: the fraction, or the headroom floor.
+LIMIT=$(( WINDOW * PERCENT / 100 ))
+[ $(( WINDOW - FLOOR )) -lt "$LIMIT" ] && LIMIT=$(( WINDOW - FLOOR ))
+# An explicit absolute limit still wins outright.
+if [ -n "${CLAUDE_PR_WATCH_TOKEN_LIMIT:-}" ]; then
+  LIMIT=$CLAUDE_PR_WATCH_TOKEN_LIMIT
+  basis=""
+else
+  basis=" (${PERCENT}% of a $(( WINDOW / 1000 ))k window)"
+fi
+[ "$LIMIT" -gt 0 ] || exit 0
 
 input=$(cat)
 
@@ -43,7 +75,7 @@ case "$ctx" in ''|*[!0-9]*) exit 0 ;; esac
 k=$((ctx / 1000))
 limk=$((LIMIT / 1000))
 
-jq -n --arg r "Blocked by ~/.claude/hooks/no-late-pr-subscribe.sh: this session is at ~${k}k tokens, at or over the ~${limk}k watch threshold. Every wake on this subscription would re-send that whole context, and it only grows from here. Take the fire-and-forget path instead: push, open the PR (draft, no reviewer), then end the turn with the follow-up prompt that would resume the work, plus \"You should archive this chat now. It's at ~${k}k tokens.\" No webhook, no wake -- pick the PR up fresh in a new session." '
+jq -n --arg r "Blocked by ~/.claude/hooks/no-late-pr-subscribe.sh: this session is at ~${k}k tokens, at or over the ~${limk}k watch threshold${basis}. Every wake on this subscription would re-send that whole context, and it only grows from here. Take the fire-and-forget path instead: push, open the PR (draft, no reviewer), then end the turn with the follow-up prompt that would resume the work, plus \"You should archive this chat now. It's at ~${k}k tokens.\" No webhook, no wake -- pick the PR up fresh in a new session." '
   {hookSpecificOutput: {
      hookEventName: "PreToolUse",
      permissionDecision: "deny",

--- a/.claude/rules/code.md
+++ b/.claude/rules/code.md
@@ -113,14 +113,22 @@ project-specific facts belong in that project's own CLAUDE.md.
 
 ### Babysitting a PR is cheap; polling for it is not
 
-- **Above ~100k tokens this session, don't subscribe.** Push, open the PR,
-  and end the turn with a follow-up prompt plus: "You should archive this
-  chat now. It's at ~Nk tokens." Fire-and-forget — no webhook, no wake,
-  pick it up fresh next time. (Added 2026-08-20.) Enforced by
-  `~/.claude/hooks/no-late-pr-subscribe.sh`, which reads the session's
-  current context from the transcript and denies `subscribe_pr_activity`
-  at or above the threshold; override the number with
-  `CLAUDE_PR_WATCH_TOKEN_LIMIT`.
+- **Past 60% of the context window — ~120k on the default 200k — don't
+  subscribe.** Push, open the PR, and end the turn with a follow-up prompt
+  plus: "You should archive this chat now. It's at ~Nk tokens."
+  Fire-and-forget — no webhook, no wake, pick it up fresh next time.
+  (Added 2026-08-20; was a flat ~100k until the number was checked against
+  the docs the same day.) A fraction, not a fixed number, because 100k is
+  half the default window but a tenth of the 1M one Opus upgrades to on
+  Max. 60% leaves room for ~6-10 wakes at 5-15k each and stops short of the
+  band where cloud sessions start compacting — and compaction drops exactly
+  the reasoning behind the diff under review. Enforced by
+  `~/.claude/hooks/no-late-pr-subscribe.sh`, which reads current context
+  from the transcript and denies `subscribe_pr_activity` at or above the
+  threshold. Knobs: `CLAUDE_PR_WATCH_CONTEXT_WINDOW` (raise it by hand for
+  a 1M session — the hook can't see the model's window),
+  `CLAUDE_PR_WATCH_CONTEXT_PERCENT`, `CLAUDE_PR_WATCH_MIN_HEADROOM`,
+  `CLAUDE_PR_WATCH_TOKEN_LIMIT` (absolute, overrides the rest).
 - **Wake on events, not timers.** Subscribing to PR activity costs nothing
   idle and fires the moment a check finishes or a comment lands — cheaper and faster than checking back. "I'll check again in a
   few minutes" is a polling loop in disguise; if a check is still running,

--- a/.claude/rules/code.md
+++ b/.claude/rules/code.md
@@ -116,7 +116,11 @@ project-specific facts belong in that project's own CLAUDE.md.
 - **Above ~100k tokens this session, don't subscribe.** Push, open the PR,
   and end the turn with a follow-up prompt plus: "You should archive this
   chat now. It's at ~Nk tokens." Fire-and-forget — no webhook, no wake,
-  pick it up fresh next time. (Added 2026-08-20.)
+  pick it up fresh next time. (Added 2026-08-20.) Enforced by
+  `~/.claude/hooks/no-late-pr-subscribe.sh`, which reads the session's
+  current context from the transcript and denies `subscribe_pr_activity`
+  at or above the threshold; override the number with
+  `CLAUDE_PR_WATCH_TOKEN_LIMIT`.
 - **Wake on events, not timers.** Subscribing to PR activity costs nothing
   idle and fires the moment a check finishes or a comment lands — cheaper and faster than checking back. "I'll check again in a
   few minutes" is a polling loop in disguise; if a check is still running,

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -55,6 +55,15 @@
             "command": "h=\"$HOME/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] || h=\"$CLAUDE_PROJECT_DIR/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] && bash \"$h\" question 0 show 2>/dev/null || true"
           }
         ]
+      },
+      {
+        "matcher": "mcp__.*__subscribe_pr_activity",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "h=\"$HOME/.claude/hooks/no-late-pr-subscribe.sh\"; [ -f \"$h\" ] || h=\"$CLAUDE_PROJECT_DIR/.claude/hooks/no-late-pr-subscribe.sh\"; [ -f \"$h\" ] && bash \"$h\" || true"
+          }
+        ]
       }
     ],
     "Stop": [


### PR DESCRIPTION
Turns the prose-only "above ~100k tokens, don't subscribe" rule in `rules/code.md` into a `PreToolUse` deny-hook, following the `no-persistent-polling.sh` pattern — and replaces the flat 100k with a fraction of the window.

## Is the token count actually available to a hook?

Not directly — there's no env var and no field in the hook payload. But the payload carries `transcript_path`, and `session-metrics.jq` / `statusline-metrics.sh` already derive context the same way: the last assistant `usage` block, `input_tokens + cache_read_input_tokens + cache_creation_input_tokens`. That's the context the most recent request actually carried, which is the number the rule is about. Only the last 500 lines are scanned — transcripts run to tens of MB and the newest usage record is always near the end.

## Why the threshold moved to 60% of the window (~120k)

100k is 50% of the default 200k window but 10% of the 1M window Opus auto-upgrades to on Max — the same constant means two very different rules depending on plan. 60% instead:

- A realistic wake costs 5–15k (event payload, CI logs, diff, a fix turn), so 40% headroom is roughly 6–10 wakes.
- Cloud/web sessions — exactly the class that subscribes to PR activity — compact as they *approach* the limit rather than at it, and compaction drops precisely the reasoning behind the diff under review.
- Prompt cache lives 1h on a subscription; PR events routinely arrive further apart, so many wakes are cache misses that reprocess the whole context at ~10× the cached rate.

A 60k headroom floor keeps the fraction from authorizing a watch with no room to run on a small window. Sources: [model-config](https://code.claude.com/docs/en/model-config), [costs](https://code.claude.com/docs/en/costs), [context-window](https://code.claude.com/docs/en/context-window).

## Changes

- `.claude/hooks/no-late-pr-subscribe.sh` — denies `subscribe_pr_activity` at or above the threshold. Deny message names the measured token count, the threshold and its basis, and points at the fire-and-forget path (push, open the PR as draft, end the turn with the resume prompt plus the archive line).
- `.claude/settings.json` — `PreToolUse` entry matching `mcp__.*__subscribe_pr_activity`, same resolution shim as the other hooks.
- `.claude/rules/code.md` — rule rewritten to 60%, naming the hook and its knobs.

Knobs: `CLAUDE_PR_WATCH_CONTEXT_WINDOW` (raise by hand for a 1M session — the hook can't see the model's window), `CLAUDE_PR_WATCH_CONTEXT_PERCENT`, `CLAUDE_PR_WATCH_MIN_HEADROOM`, `CLAUDE_PR_WATCH_TOKEN_LIMIT` (absolute, overrides the rest).

Fails open (exit 0, no verdict) when `jq` is missing, `transcript_path` is absent, or the file can't be parsed — a measurement hook that blocks blind is worse than no hook.

## Verification

Fixture transcripts through the hook: 110k/200k → allow; 130k/200k → deny naming `~120k (60% of a 200k window)`; 300k with `CONTEXT_WINDOW=1000000` → allow; 110k with `TOKEN_LIMIT=100000` → deny, and the basis clause correctly drops when the absolute override is used; `CONTEXT_WINDOW=100000` → floor binds at 40k as intended; missing transcript → fail-open. `bash -n` clean, `jq` parses the edited `settings.json`.