### PR TITLE
security: narrow hook resolution, branch-delete scope, and token exposure

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -160,9 +160,27 @@ alias dotsync='yadm pull --rebase --autostash && yadm alt && yadm status --short
 # Secrets decrypted by `yadm bootstrap` (sops+age) land here, never in git.
 # See secrets/*.sops.env and .config/yadm/bootstrap. Mirrors the loop in .zshrc;
 # without it, bash-only hosts never load them. The glob is unquoted on purpose,
-# and the -r test covers the no-match case.
+# and the -r test covers the no-match case. claude-token.env is excluded on
+# purpose — see the `claude` wrapper below, which scopes
+# CLAUDE_CODE_OAUTH_TOKEN to just that command instead of exporting it into
+# every shell and everything the shell spawns.
 for _secret_file in "$HOME"/.config/secrets/*.env; do
+    case "$_secret_file" in
+        */claude-token.env) continue ;;
+    esac
     [ -r "$_secret_file" ] && . "$_secret_file"
 done
 unset _secret_file
 export CLAUDE_CODE_TMPDIR="$HOME/.local/state/claude-tmpdir"
+
+# CLAUDE_CODE_OAUTH_TOKEN stays out of the general environment (see the
+# excluded loop above) and is exported only for the duration of this one
+# command, in a subshell, so it never leaks into the interactive shell.
+claude() {
+    _tok="$HOME/.config/secrets/claude-token.env"
+    if [ -r "$_tok" ]; then
+        ( . "$_tok" && command claude "$@" )
+    else
+        command claude "$@"
+    fi
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,8 +21,8 @@
   "crossSessionInbound": "hold",
   "permissions": {
     "allow": [
-      "Bash(git branch -d *)",
-      "Bash(git branch -D *)",
+      "Bash(git branch -d claude/*)",
+      "Bash(git branch -D claude/*)",
       "mcp__Claude_Code_Remote__add_repo"
     ]
   },
@@ -60,7 +60,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "h=\"$HOME/.claude/hooks/no-late-pr-subscribe.sh\"; [ -f \"$h\" ] || h=\"$CLAUDE_PROJECT_DIR/.claude/hooks/no-late-pr-subscribe.sh\"; [ -f \"$h\" ] && bash \"$h\" || true"
+            "command": "h=\"$HOME/.claude/hooks/no-late-pr-subscribe.sh\"; [ -f \"$h\" ] && bash \"$h\" || true"
           }
         ]
       }

--- a/.config/yadm/bootstrap
+++ b/.config/yadm/bootstrap
@@ -7,7 +7,9 @@
 # $HOME/.config/secrets/<name>.env — a path that is NOT tracked and IS gitignored
 # (see .gitignore), so plaintext never sits inside the git working tree and can't
 # get swept up by a later `yadm add`. .zshrc/.bashrc source everything under
-# ~/.config/secrets/*.env at shell startup.
+# ~/.config/secrets/*.env at shell startup, EXCEPT claude-token.env, which is
+# scoped to a `claude` wrapper function instead so the token isn't exported
+# into every shell and everything it spawns.
 set -eu
 
 need() { command -v "$1" >/dev/null 2>&1; }

--- a/.local/bin/cloud-session-setup.sh
+++ b/.local/bin/cloud-session-setup.sh
@@ -53,6 +53,7 @@ INSTALL="
 .claude/hooks/measure-git-events.sh
 .claude/hooks/no-persistent-polling.sh
 .claude/hooks/guard-add-repo.sh
+.claude/hooks/no-late-pr-subscribe.sh
 .claude/hooks/metrics-live.sh
 .claude/hooks/metrics-rollup.sh
 .claude/hooks/log-commit.sh

--- a/.zshrc
+++ b/.zshrc
@@ -169,9 +169,27 @@ export NVM_DIR="$HOME/.nvm"
 [ -f ~/.zsh_aliases ] && source ~/.zsh_aliases
 
 # Secrets decrypted by `yadm bootstrap` (sops+age) land here, never in git.
-# See secrets/*.sops.env and .config/yadm/bootstrap.
+# See secrets/*.sops.env and .config/yadm/bootstrap. claude-token.env is
+# excluded from this loop on purpose — see the `claude` wrapper below, which
+# scopes CLAUDE_CODE_OAUTH_TOKEN to just that command instead of exporting it
+# into every shell and everything the shell spawns.
 for _secret_file in "$HOME"/.config/secrets/*.env(N); do
+  case "$_secret_file" in
+    */claude-token.env) continue ;;
+  esac
   [ -r "$_secret_file" ] && source "$_secret_file"
 done
 unset _secret_file
+
+# CLAUDE_CODE_OAUTH_TOKEN stays out of the general environment (see the
+# excluded loop above) and is exported only for the duration of this one
+# command, in a subshell, so it never leaks into the interactive shell.
+claude() {
+  local _tok="$HOME/.config/secrets/claude-token.env"
+  if [ -r "$_tok" ]; then
+    ( source "$_tok" && command claude "$@" )
+  else
+    command claude "$@"
+  fi
+}
 


### PR DESCRIPTION
Addresses four findings from the security review. A fifth finding — purging `archive/signalk-pi` and `.claude/journal` from git history with `git filter-repo` — is **not** included here; it rewrites shared history on `main` and needs your explicit go-ahead (see chat).

## Changes

- **`.claude/settings.json`**: dropped the `$CLAUDE_PROJECT_DIR` fallback on the `subscribe_pr_activity` hook. In a cloud session on a third-party repo it executed *that* repo's `.claude/hooks/*.sh` under user-scope trust; every other hook here already resolves from `$HOME` only.
- **`.claude/settings.json`**: narrowed the standing `git branch -d/-D` allows from any branch (`*`) to `claude/*`, matching the actual cleanup case documented in `.claude/rules/code.md`.
- **`.local/bin/cloud-session-setup.sh`**: added the missing `no-late-pr-subscribe.sh` to `INSTALL`. It's referenced by `settings.json` but was absent from the cloud seed, so the PR-watch context-budget guard silently no-op'd in every cloud session.
- **`.zshrc` / `.bashrc`**: stopped sourcing `claude-token.env` into every interactive shell (and everything it spawns). Added a `claude` wrapper function that sources it only for that one command, in a subshell, so `CLAUDE_CODE_OAUTH_TOKEN` never enters the general environment.

## Verification

- `bash -n .bashrc`, `sh -n .local/bin/cloud-session-setup.sh`, `sh -n .config/yadm/bootstrap` all pass.
- `.claude/settings.json` parses as valid JSON.
- Confirmed `no-late-pr-subscribe.sh` exists in `.claude/hooks/` and was genuinely missing from `INSTALL` before this change.
- Confirmed `claude-token.sops.env` is the only tracked secret, so the shell-startup exclusion is scoped correctly.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aid5emDTYMtnsCtjHq2X92)_