### PR TITLE
Keep the cloud seed live instead of frozen at provisioning

### DIFF
--- a/.claude/hooks/session-start-seed-refresh.sh
+++ b/.claude/hooks/session-start-seed-refresh.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# SessionStart hook: re-run the cloud seed so a reused container tracks this
+# repo instead of the commit it was provisioned from.
+#
+# The environment's setup script runs once, when the container is created,
+# and the container is then checkpointed and reused. So without this a rule
+# edited here reaches only the sessions that get a cold VM -- and the ones
+# that don't look identical to the ones that do, which is the failure this
+# repo has already been bitten by twice (the deleted hook that kept running,
+# and the settings.json fallback that ran a stranger's copy).
+#
+# What it can and cannot do, and the difference matters:
+#   - hooks, rules/ and settings.json are read from disk when they fire, so a
+#     refresh here reaches THIS session for everything after session start.
+#   - CLAUDE.md was already loaded before this hook ran. A change to it would
+#     otherwise sit on disk unread until the next session, so when the
+#     refresh actually rewrites it the new copy is emitted as
+#     additionalContext. That costs a second copy in context, which is why it
+#     is emitted only on the sessions where it changed -- rare by
+#     construction, since most refreshes change nothing at all.
+#
+# Remote-only. On a real machine yadm owns $HOME and the installer refuses
+# there anyway, but returning before the network call keeps a local session
+# start free of it.
+set -uo pipefail
+
+[ "${CLAUDE_CODE_REMOTE:-}" = true ] || exit 0
+
+SEED="${DOTFILES_SEED:-$HOME/.local/share/dotfiles-seed}"
+SETUP="$SEED/.local/bin/cloud-session-setup.sh"
+ORDERS="$HOME/.claude/CLAUDE.md"
+
+[ -x "$SETUP" ] || [ -f "$SETUP" ] || exit 0
+
+before=$(cksum <"$ORDERS" 2>/dev/null || echo absent)
+
+# The installer's own progress lines are for a setup-script log, not for a
+# session's context window: stdout here is charged to every session. Keep
+# them out and let the exit status carry the outcome.
+CLOUD_SESSION=1 sh "$SETUP" >/dev/null 2>&1
+
+after=$(cksum <"$ORDERS" 2>/dev/null || echo absent)
+
+[ "$before" = "$after" ] && exit 0
+[ "$after" = absent ] && exit 0
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+{
+  echo "## Standing orders were refreshed after this session started"
+  echo
+  echo "\`~/.claude/CLAUDE.md\` changed on the seed refresh, so the copy loaded"
+  echo "at session start is stale. This is the current one; it supersedes it."
+  echo
+  cat "$ORDERS"
+} | jq -Rn --rawfile ctx /dev/stdin \
+  '{hookSpecificOutput:{hookEventName:"SessionStart", additionalContext:$ctx}}'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -60,7 +60,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "h=\"$HOME/.claude/hooks/no-late-pr-subscribe.sh\"; [ -f \"$h\" ] || h=\"$CLAUDE_PROJECT_DIR/.claude/hooks/no-late-pr-subscribe.sh\"; [ -f \"$h\" ] && bash \"$h\" || true"
+            "command": "h=\"$HOME/.claude/hooks/no-late-pr-subscribe.sh\"; [ -f \"$h\" ] && bash \"$h\" || true"
           }
         ]
       }
@@ -106,6 +106,11 @@
     "SessionStart": [
       {
         "hooks": [
+          {
+            "type": "command",
+            "command": "h=\"$HOME/.claude/hooks/session-start-seed-refresh.sh\"; [ -f \"$h\" ] && bash \"$h\" || true",
+            "timeout": 60
+          },
           {
             "type": "command",
             "command": "h=\"$HOME/.claude/hooks/session-start-continuity.sh\"; [ -f \"$h\" ] && bash \"$h\" || true"

--- a/.local/bin/cloud-session-setup.sh
+++ b/.local/bin/cloud-session-setup.sh
@@ -52,6 +52,8 @@ INSTALL="
 .claude/hooks/stop-continuity.sh
 .claude/hooks/measure-git-events.sh
 .claude/hooks/no-persistent-polling.sh
+.claude/hooks/no-late-pr-subscribe.sh
+.claude/hooks/session-start-seed-refresh.sh
 .claude/hooks/guard-add-repo.sh
 .claude/hooks/metrics-live.sh
 .claude/hooks/metrics-rollup.sh
@@ -147,6 +149,32 @@ fi
 
 [ -d "$SEED/.git" ] || { warn "no checkout at $SEED — nothing installed"; exit 0; }
 [ "$DRY_RUN" = yes ] && say "DRY RUN — nothing will be written"
+
+# =========================================================================
+# Refresh — bring the seed checkout up to date before installing from it.
+# =========================================================================
+# The setup-script blob's `git clone` is a no-op once $SEED exists, and a
+# cloud container is checkpointed and reused across sessions. Without this
+# the seed is frozen at whatever it cloned the first time the environment
+# was provisioned, so a rule edited here never reaches a session again --
+# and it fails silently, exactly like the deleted-hook scar above.
+#
+# `pull --ff-only`, not `fetch` plus a merge of FETCH_HEAD: the latter takes
+# origin's default branch whatever the seed has checked out, so testing a
+# change by checking the branch out in $SEED would silently reset it to main.
+# --ff-only because the VM never commits here -- anything that will not fast
+# forward means the checkout is damaged, and a merge would only bury it.
+# Never fatal: a proxy that blocks the fetch must still leave the session
+# with the last-known-good seed rather than none at all.
+if [ "$DRY_RUN" = yes ]; then
+  say "would refresh $SEED (skipped: --dry-run does no network)"
+elif ! out=$(git -C "$SEED" pull -q --ff-only 2>&1); then
+  warn "refresh failed, installing from the existing checkout:"
+  warn "  ${out:-unknown error}"
+else
+  say "refreshed to $(git -C "$SEED" rev-parse --short HEAD 2>/dev/null)"
+fi
+
 
 # =========================================================================
 # Overwrite policy

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ degrades to `~/.claude/state/global` if it isn't checked out.
 
 | hook | event | what it does |
 | --- | --- | --- |
+| `session-start-seed-refresh.sh` | SessionStart | re-runs the cloud seed so a reused container tracks this repo, not the commit it was provisioned from |
 | `session-start-continuity.sh` | SessionStart | injects the open board, where the last three sessions left off, and the week's decision load |
 | `stop-continuity.sh` | Stop | writes the session record, the decision log and an auto-checkpoint, then commits and pushes the state repo |
 | `measure-git-events.sh` | PostToolUse | logs branches created, PRs opened, cherry-picks |
@@ -139,7 +140,15 @@ Two guards make the `INSTALL` allowlist safe to expand:
   `SKIP_GLOBS` hard-blocks `.gitconfig*`, `.gitignore` and anything
   sops-shaped even if added to `INSTALL` by mistake.
 
-A fourth scar: **seeding without pruning is why a deleted hook keeps running.**
+A fourth scar: **the setup script runs once, at container creation, not once
+per session.** Containers are checkpointed and reused, so the seed froze at
+whatever it cloned when the environment was provisioned and a rule edited here
+reached only the sessions that happened to get a cold VM. The installer now
+pulls the seed before installing from it, and `session-start-seed-refresh.sh`
+re-runs it on every SessionStart — live rather than pinned, because a stale
+standing order in an interactive session is worse than a changed one.
+
+A fifth scar: **seeding without pruning is why a deleted hook keeps running.**
 The container seeded it once, the repo dropped it, and the `$HOME` copy is still
 there and still wins. `PRUNE_DIRS` names the directories the script wholly owns,
 where anything not in `INSTALL` is a leftover and gets removed; `PRUNE_NEVER` is

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -147,6 +147,26 @@ exit 0
 
 Measured cost on a cold VM: about 5s, against a ~5 minute window.
 
+Paste it into **every** environment, not just the one in front of you. An
+environment created before this existed has no seed at all, and a session
+started in it is indistinguishable from one that has it until something is
+missing — which was the whole failure. As of 2026-08-21 that means
+`Default (with tailscale)`, `Trusted` and `Full network access`.
+
+**The setup script runs once, when the container is created**, and the
+container is then checkpointed and reused. So the blob's `git clone` is the
+seed's only chance to be fresh, and it is a no-op forever after. Two things
+close that gap and both are in this repo, not in the web form:
+`cloud-session-setup.sh` pulls the seed before installing from it, and
+`session-start-seed-refresh.sh` re-runs the whole installer on every
+SessionStart. A rule edited here therefore reaches the next session with no
+re-provision — deliberately live rather than pinned, because these are
+interactive sessions and a stale standing order is worse than a changed one.
+
+Only `CLAUDE.md` cannot be refreshed in place: it is loaded before any hook
+runs. When the refresh rewrites it, the hook emits the new copy as
+`additionalContext` so the current session gets it too.
+
 **2 — Sources.** Add **both**:
 
 - `mark-brannan/dotfiles` — carries `.claude/settings.json`, so any session
@@ -456,6 +476,21 @@ grep -n 'the-hook-name' ~/.claude/settings.json  # is it wired?
 The seed is not the only path that works: a repo carrying its own
 `.claude/settings.json` gets its project settings loaded in a cloud session even
 with no user-scope settings at all. What the seed buys is the *other* repos.
+
+## A cloud session is running an old rule
+
+The seed checkout at `~/.local/share/dotfiles-seed` is a real clone, so ask it:
+
+```bash
+git -C ~/.local/share/dotfiles-seed log --oneline -1
+```
+
+Behind `origin/main` means the refresh is not running. Either the container
+predates it — `ls ~/.claude/hooks/session-start-seed-refresh.sh` — or the pull
+failed, which the installer reports rather than swallowing:
+`CLOUD_SESSION=1 sh ~/.local/share/dotfiles-seed/.local/bin/cloud-session-setup.sh`
+prints the reason. A blocked proxy leaves the last-known-good seed in place on
+purpose; that is a stale session, not a broken one.
 
 ## A deleted hook keeps running
 


### PR DESCRIPTION
## Why

Found from the other end: a `signalk-noaa-space-weather` session carried a
`kanban.md` card saying a rule had to be pasted into `~/.claude/CLAUDE.md` "on
a real machine, because agents here run in ephemeral containers." The rule was
already here, in `.claude/CLAUDE.md` § Open loops, and `.claude/CLAUDE.md` is
already the second line of `INSTALL`. The card was not the problem.

The problem was that the session had no `~/.claude/CLAUDE.md` at all — no
`~/.local/share/dotfiles-seed`, no `~/.claude/hooks/`, no `~/.claude/settings.json`,
and the connector deny list unapplied (Evernote, QuickBooks and TurboTax
schemas were loaded in a session that denies all three). Its environment,
`Default (with tailscale)`, was created 2026-07-26, three weeks before the seed
existed.

That is a paste job, not a code change. But chasing it surfaced one that is:
**the setup script runs once, when the container is created.** Containers are
checkpointed and reused, and the blob's `git clone` is a no-op once `$SEED`
exists, while `cloud-session-setup.sh` never fetched. So the seed froze at the
commit the environment was provisioned from, a rule edited here reached only
the sessions that happened to get a cold VM, and a stale session looked exactly
like a fresh one — the same silent shape as the deleted-hook and
unconfigured-filter scars already in the README.

## What changed

- **`cloud-session-setup.sh` pulls the seed** (`--ff-only`, never fatal) before
  installing from it, so a cold VM and a reused one land on the same commit. A
  blocked proxy leaves the last-known-good seed rather than none.
  `--dry-run` still does no network, so it stays safe on any machine.
- **`session-start-seed-refresh.sh`** re-runs the installer on every
  SessionStart, remote-only. Hooks, `rules/` and `settings.json` are read from
  disk when they fire, so this reaches the *current* session. `CLAUDE.md` is
  loaded before any hook runs, so on the rare refresh that rewrites it the new
  copy is emitted as `additionalContext` — only when it actually changed, since
  otherwise every session pays for a second copy of a 14k file.
- **`no-late-pr-subscribe.sh` added to `INSTALL`.** It was referenced by
  `settings.json` and missing from the seed, which is exactly what the runbook's
  own drift check is for: a silent no-op in every cloud session. Its
  `$CLAUDE_PROJECT_DIR` fallback goes with it — on a third-party repo that ran
  *that* repo's hook under user-scope trust, the reason the fallback was removed
  everywhere else.

Live, not pinned, and that is a decision rather than a default: these are
interactive sessions, and a standing order that is a week stale is worse than
one that changed under you. CI is the opposite case and keeps its pin.

## Validated

Against a throwaway `$HOME` with the seed cloned from this branch:

- cold install → `refreshed to 709fb34`, 18 installed, 0 refused, 0 missing, 0 failed
- second run → 0 installed, 18 unchanged (idempotent)
- hook with nothing upstream → exit 0, no output
- hook after a probe commit touching `.claude/CLAUDE.md` → valid
  `{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":…}}`,
  14062 chars, carrying the new text
- `--dry-run` → reports `would refresh`, makes no network call
- drift check from the runbook → every hook `settings.json` references is now in `INSTALL`

`pull --ff-only` rather than `fetch` + `merge FETCH_HEAD` because the latter
takes origin's default branch whatever the seed has checked out — it silently
reset the test seed from this branch back to `main`, which is also how anyone
testing a seed change would lose their own.

## Still needs a human

Pasting the blob into all three environments. Only the web UI can set a setup
script; nothing here can do it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ca8LKFyAdwgeeWCBJi9W2U)_