### PR TITLE
Add 18 missing connectors to deniedMcpServers

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -163,6 +163,60 @@
     },
     {
       "serverName": "Evernote_MCP"
+    },
+    {
+      "serverName": "Audible"
+    },
+    {
+      "serverName": "Autodesk_Product_Help"
+    },
+    {
+      "serverName": "DocuSeal"
+    },
+    {
+      "serverName": "Docusign"
+    },
+    {
+      "serverName": "Dropbox"
+    },
+    {
+      "serverName": "Harvey"
+    },
+    {
+      "serverName": "IFTTT"
+    },
+    {
+      "serverName": "Lucid"
+    },
+    {
+      "serverName": "Postman"
+    },
+    {
+      "serverName": "PubMed"
+    },
+    {
+      "serverName": "Scholar_Gateway"
+    },
+    {
+      "serverName": "SignNow"
+    },
+    {
+      "serverName": "Spotify"
+    },
+    {
+      "serverName": "Superhuman_Docs"
+    },
+    {
+      "serverName": "Taskrabbit_Booking_Assistance"
+    },
+    {
+      "serverName": "Todoist"
+    },
+    {
+      "serverName": "Trello"
+    },
+    {
+      "serverName": "Zapier"
     }
   ],
   "statusLine": {


### PR DESCRIPTION
## What

Mirrors `.claude/cloud-setup.sh`'s `DENY` list into `deniedMcpServers` in `.claude/settings.json`, so a seeded cloud session (which reads project settings, not the standalone script) denies the same set of connectors.

`ListConnectors` was re-run to confirm the live account still has 27 connectors, and the script's `DENY` array covers all of them (28 entries — the script also carries `Evernote_MCP`, which is connected/enabled but not returned in the "27" count of authless/disconnected ones — no change needed there since it was already present).

## Details

`settings.json` had 10 of the 28 `DENY` entries already present:
`Intuit_QuickBooks`, `Intuit_TurboTax`, `CourtListener`, `Courtroom5`, `Legal_Data_Hunter`, `LegalZoom`, `Gmail`, `Google_Drive`, `Google_Calendar`, `Evernote_MCP`.

Added the 18 that were missing:
`Audible`, `Autodesk_Product_Help`, `DocuSeal`, `Docusign`, `Dropbox`, `Harvey`, `IFTTT`, `Lucid`, `Postman`, `PubMed`, `Scholar_Gateway`, `SignNow`, `Spotify`, `Superhuman_Docs`, `Taskrabbit_Booking_Assistance`, `Todoist`, `Trello`, `Zapier`.

`deniedMcpServers` now has all 28 entries from the script's `DENY` list, keeping settings.json in sync with cloud-setup.sh.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XBgdiV1pyENa1febMUCEaF)_