### PR TITLE
docs: commit the tailscale setup-script variant to git

### DIFF
--- a/.local/bin/cloud-session-setup-tailscale.sh
+++ b/.local/bin/cloud-session-setup-tailscale.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Copy-paste source for the "Default (with tailscale)" cloud environment's
+# setup-script field, per RUNBOOK.md § Create a cloud environment.
+#
+# The platform does not execute this file — the setup-script field only takes
+# pasted text, and this variant installs tailscale before the seed exists to
+# delegate to, so it can't just clone-and-delegate like
+# cloud-session-setup.sh's caller does. This file is the version-controlled
+# record of what's pasted; keep the two in sync by hand.
+set -euo pipefail
+curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/noble.noarmor.gpg \
+  | tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null
+curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/noble.tailscale-keyring.list \
+  | tee /etc/apt/sources.list.d/tailscale.list
+
+# Full update, but don't let deadsnakes/ondrej 403s (not ours) kill the
+# script via set -e — apt still refreshes every list that does succeed,
+# which install needs for current package versions.
+apt-get update || true
+apt-get install -y tailscale openssh-client
+
+git clone -q https://github.com/mark-brannan/dotfiles \
+  "$HOME/.local/share/dotfiles-seed" 2>/dev/null
+CLOUD_SESSION=1 sh "$HOME/.local/share/dotfiles-seed/.local/bin/cloud-session-setup.sh"

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -134,9 +134,14 @@ A Claude Code cloud environment configures exactly four things: **name, network
 access, environment variables, and a setup script.** Repositories are *not*
 part of the environment — they attach per session, as sources.
 
-**1 — Setup script.** Paste this verbatim into the environment's setup-script
-field. It only clones and delegates, so the logic stays version-controlled here
-rather than going stale in a web form:
+**1 — Setup script.** The field only takes pasted text, so every environment's
+script is version-controlled here as the source of truth and pasted in by
+hand — the field itself is never the record.
+
+`Trusted` and `Full network access` take
+[`cloud-session-setup.sh`](.local/bin/cloud-session-setup.sh)'s caller
+verbatim. It only clones and delegates, so the logic stays in the repo rather
+than going stale in a web form:
 
 ```sh
 git clone -q https://github.com/mark-brannan/dotfiles \
@@ -145,13 +150,20 @@ CLOUD_SESSION=1 sh "$HOME/.local/share/dotfiles-seed/.local/bin/cloud-session-se
 exit 0
 ```
 
+`Default (with tailscale)` needs tailscale installed before the seed exists to
+delegate to, so it can't be a bare clone-and-delegate — paste
+[`cloud-session-setup-tailscale.sh`](.local/bin/cloud-session-setup-tailscale.sh)
+verbatim instead; it ends with the same clone-and-delegate. Neither variant is
+executed by the platform — both files exist only so the pasted text has an
+authoritative copy in git. Keep them in sync by hand if either changes.
+
 Measured cost on a cold VM: about 5s, against a ~5 minute window.
 
-Paste it into **every** environment, not just the one in front of you. An
-environment created before this existed has no seed at all, and a session
-started in it is indistinguishable from one that has it until something is
-missing — which was the whole failure. As of 2026-08-21 that means
-`Default (with tailscale)`, `Trusted` and `Full network access`.
+Paste the matching variant into **every** environment, not just the one in
+front of you. An environment created before this existed has no seed at all,
+and a session started in it is indistinguishable from one that has it until
+something is missing — which was the whole failure. As of 2026-08-21 that
+means `Default (with tailscale)`, `Trusted` and `Full network access`.
 
 **The setup script runs once, when the container is created**, and the
 container is then checkpointed and reused. So the blob's `git clone` is the


### PR DESCRIPTION
## Why

Mark asked for an authoritative git copy of what gets pasted into a cloud
environment's setup-script field — not just prose in RUNBOOK.md. The
Full-Access/Trusted variant already had one (`cloud-session-setup.sh`'s
caller, quoted verbatim in RUNBOOK.md); the tailscale variant didn't, since it
installs tailscale before the seed exists to delegate to and so can't be a
bare clone-and-delegate.

## What changed

- `.local/bin/cloud-session-setup-tailscale.sh` — the tailscale bootstrap
  followed by the same clone-and-delegate tail. Not executed by the platform;
  it exists only so the pasted text has a git source of truth.
- RUNBOOK.md's "Create a cloud environment" now names both variants and links
  each to its file, instead of showing only the Full-Access/Trusted one
  inline.

## Still needs a human

Pasting the tailscale variant into `Default (with tailscale)`'s setup-script
field — no tool reaches that UI.