### PR TITLE
Enforce never-draft PRs with a PreToolUse hook

### DIFF
--- a/.claude/hooks/no-draft-pr.sh
+++ b/.claude/hooks/no-draft-pr.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Denies creating a pull request in draft state, whichever tool creates it.
+#
+# Why: the cloud harness's own system prompt says "create the pull request
+# as a draft", so prose in CLAUDE.md/rules is a rule competing with the
+# harness's rule and loses often enough to matter. Drafts get no automated
+# review (CodeRabbit and claude-review both skip them) and stall waiting for
+# a manual ready-flip that keeps not happening. The rule lives in
+# ~/.claude/rules/code.md ("PR ownership: never a draft, never red"); this
+# hook is its enforcement.
+#
+# Deny, don't rewrite: a deny reason is fed back to the model, which retries
+# the same call with draft off. That works identically for the GitHub MCP
+# tool (draft parameter) and gh CLI (--draft flag).
+set -euo pipefail
+
+input=$(cat)
+
+# Without jq we cannot parse the request. Fail open: this guard protects a
+# convenience (review latency), not a secret -- a draft that slips through is
+# visible and repairable with `gh pr ready`, unlike the gates that fail
+# closed. Denying every PR creation because jq is missing would be worse.
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+tool=$(printf '%s' "$input" | jq -r '.tool_name // ""')
+
+jq_deny() {
+  jq -n --arg r "$1" '{hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "deny",
+    permissionDecisionReason: $r}}'
+  exit 0
+}
+
+case "$tool" in
+  *__create_pull_request)
+    draft=$(printf '%s' "$input" | jq -r '.tool_input.draft // false')
+    if [ "$draft" = "true" ]; then
+      jq_deny "Blocked by ~/.claude/hooks/no-draft-pr.sh: PRs are never opened as drafts (see ~/.claude/rules/code.md, 'PR ownership'). Drafts skip CodeRabbit/claude-review and stall waiting for a ready-flip. Retry the same create_pull_request call with draft:false (or omit draft). Do not ask the user; this is settled."
+    fi
+    ;;
+  Bash)
+    cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
+    case "$cmd" in
+      *"gh pr create"*)
+        case "$cmd" in
+          *--draft*|*"-d "*)
+            jq_deny "Blocked by ~/.claude/hooks/no-draft-pr.sh: PRs are never opened as drafts (see ~/.claude/rules/code.md, 'PR ownership'). Rerun the same gh pr create without --draft. Do not ask the user; this is settled."
+            ;;
+        esac
+        ;;
+      *"gh pr ready"*)
+        # Allowed: this is the repair path for a draft that slipped through.
+        ;;
+    esac
+    ;;
+esac
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -56,6 +56,15 @@
         ]
       },
       {
+        "matcher": "Bash|mcp__.*__create_pull_request",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "h=\"$HOME/.claude/hooks/no-draft-pr.sh\"; [ -f \"$h\" ] && bash \"$h\" || true"
+          }
+        ]
+      },
+      {
         "matcher": "mcp__.*__subscribe_pr_activity",
         "hooks": [
           {

--- a/.local/bin/cloud-session-setup.sh
+++ b/.local/bin/cloud-session-setup.sh
@@ -53,6 +53,7 @@ INSTALL="
 .claude/hooks/measure-git-events.sh
 .claude/hooks/no-persistent-polling.sh
 .claude/hooks/no-late-pr-subscribe.sh
+.claude/hooks/no-draft-pr.sh
 .claude/hooks/session-start-seed-refresh.sh
 .claude/hooks/guard-add-repo.sh
 .claude/hooks/metrics-live.sh


### PR DESCRIPTION
The never-draft rule in `rules/code.md` is prose competing with the cloud harness's own system-prompt instruction to open PRs as drafts, and prose loses often enough to matter. Per the repo's own maxim — anything that *must* happen belongs in a hook, not in CLAUDE.md — this moves enforcement into a PreToolUse hook.

- **`.claude/hooks/no-draft-pr.sh`** — denies `mcp__*__create_pull_request` with `draft: true` and `gh pr create --draft`/`-d`. The deny reason instructs the session to retry the same call ready-for-review, without asking the user. Fails open when jq is missing (this guards review latency, not a secret; a slipped draft is visible and repairable with `gh pr ready`).
- **`.claude/settings.json`** — registers it under `PreToolUse` with matcher `Bash|mcp__.*__create_pull_request`.
- **`.local/bin/cloud-session-setup.sh`** — added to the INSTALL list so it actually runs in cloud sessions.

Tested all four paths (MCP draft/non-draft, gh with/without `--draft`) and validated settings.json. Note: the hook takes effect in sessions started after the seed lands in `$HOME`; this PR itself was opened ready-for-review directly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcwB7iits8HdF1h3kVYNcZ)_