### PR TITLE
rules/code.md: strip inline provenance, keep one-line reasons

### DIFF
--- a/.claude/rules/code.md
+++ b/.claude/rules/code.md
@@ -33,10 +33,9 @@ project-specific facts belong in that project's own CLAUDE.md.
     **session >100k tokens**, or **session >30 min wall clock**.
 
   Everything else — small fixes, doc edits, config tweaks — goes straight
-  to main, no branch, no asking. Reversed 2026-08-19 from the prior
-  deny-by-default polarity ("commit to main requires no branch reason");
-  the old rule produced five stranded `claude/*` branches from excess
-  caution, which was the actual failure mode, not landing on main.
+  to main, no branch, no asking. Deny-by-default polarity (branch unless
+  justified) produced five stranded `claude/*` branches from excess
+  caution — that was the actual failure mode, not landing on main.
 
   When a branch *is* warranted under this rule: always open the PR
   yourself immediately, **ready for review — never as a draft — with no
@@ -52,35 +51,26 @@ project-specific facts belong in that project's own CLAUDE.md.
   itself, a decision to branch.** Apply the rule above as normal — if
   nothing crosses a trigger, still land the work with
   `git push origin HEAD:main`, pushed early and often, rather than
-  treating the assigned name as the destination. Decided 2026-08-19, see
-  `claude_prompts_scratch/state/global/log/2026-08-19-git-vocabulary-worktrees.md`.
-  This does **not** apply when a session's own task instructions separately
-  name one specific branch and say to stay on it — that instruction is for
-  that session only and takes precedence; finish that branch with a PR as
-  usual. The original justification here was "cloud sessions can't
-  reliably delete their own remote branches, so the cheapest fix is not
-  creating one" — true, but as of 2026-08-20 no longer the operative
-  reason (see next bullet: a merged branch now cleans itself up with no
-  git command from any session). The rule still holds because below-branch
-  threshold work doesn't need a PR at all, not because a branch would be
-  stuck.
+  treating the assigned name as the destination. This does **not** apply
+  when a session's own task instructions separately name one specific
+  branch and say to stay on it — that instruction is for that session only
+  and takes precedence; finish that branch with a PR as usual. A merged
+  branch now cleans itself up with no git command from any session, so the
+  rule holds because below-branch-threshold work doesn't need a PR at all
+  — not because an unmerged branch would get stuck.
 
 - **Branch cleanup: merged means deleted.** Keep "Automatically delete head
-  branches" ticked on every repo (dotfiles: on, confirmed 2026-08-19 when
-  PR #5's head vanished on merge; symphony: on, confirmed 2026-08-20 when
-  PR #15's and PR #22's heads both vanished within moments of merge with no
-  session action) so the common case needs no sweep — this is the actual
-  fix for the stale-branch pileups that used to force manual sweeps.
-  Beyond that, a branch whose commits are all ancestors of `main` is
-  garbage — delete it on sight, no ceremony, no asking. A branch with
+  branches" ticked on every repo so the common case needs no sweep — this
+  is the actual fix for the stale-branch pileups that used to force manual
+  sweeps. Beyond that, a branch whose commits are all ancestors of `main`
+  is garbage — delete it on sight, no ceremony, no asking. A branch with
   commits *not* in main is real unlanded work: don't delete it, surface it
   to Mark instead. Cloud sessions often can't delete remote branches
   themselves (`git push --delete` is blocked by the auto-mode classifier
   and there is no MCP equivalent) — but that only still matters for this
   narrower leftover case, since a normal PR merge no longer needs it at
   all. From a cloud session facing that narrower case, just list what
-  should go; the sweep is a nucbox job. (Decided 2026-08-19; reasoning
-  updated 2026-08-20.)
+  should go; the sweep is a nucbox job.
 
 ## PR ownership: never a draft, never red
 
@@ -94,9 +84,7 @@ project-specific facts belong in that project's own CLAUDE.md.
   that.** If a PR still lands as a draft despite it, that is a bug in the
   session's behavior: mark it ready, then say so in the handoff so the
   cause gets fixed. Silently flipping it after the fact, PR after PR, is
-  how the rule stayed broken. (Replaces "open as draft if you like, then
-  mark it ready", 2026-08-20. Ported from
-  [space-weather#93](https://github.com/mark-brannan/signalk-noaa-space-weather/pull/93).)
+  how the rule stayed broken.
 - **Green before it is handed over.** The bar, in order:
   - every fast check the repo defines passes locally — formatter, lint,
     typecheck, build, tests; whatever that repo actually has;
@@ -126,10 +114,9 @@ project-specific facts belong in that project's own CLAUDE.md.
   circling back to re-confirm.
 - This stops at merge, not before it. Getting a PR to ready-and-green is
   mine by default; merging it is a separate, explicit action unless told
-  otherwise for a given PR or repo. (Added 2026-08-20.)
+  otherwise for a given PR or repo.
 - Don't ask "want me to watch this PR?" — subscribe yourself, or don't,
-  per the token-budget rule below. Either way, no question. (Added
-  2026-08-20.)
+  per the token-budget rule below. Either way, no question.
 
 ### Babysitting a PR is cheap; polling for it is not
 
@@ -137,8 +124,7 @@ project-specific facts belong in that project's own CLAUDE.md.
   subscribe.** Push, open the PR, and end the turn with a follow-up prompt
   plus: "You should archive this chat now. It's at ~Nk tokens."
   Fire-and-forget — no webhook, no wake, pick it up fresh next time.
-  (Added 2026-08-20; was a flat ~100k until the number was checked against
-  the docs the same day.) A fraction, not a fixed number, because 100k is
+  A fraction, not a fixed number, because 100k is
   half the default window but a tenth of the 1M one Opus upgrades to on
   Max. 60% leaves room for ~6-10 wakes at 5-15k each and stops short of the
   band where cloud sessions start compacting — and compaction drops exactly
@@ -172,9 +158,7 @@ project-specific facts belong in that project's own CLAUDE.md.
   when the PR is green and the automated reviews have been dealt with. The
   two exceptions both end in a decision only he can make: a blocker I
   can't resolve, or a design question where guessing wrong means redoing
-  the work — lay out the options and ask, don't narrate. (Ported
-  2026-08-20 from
-  [space-weather#93](https://github.com/mark-brannan/signalk-noaa-space-weather/pull/93).)
+  the work — lay out the options and ask, don't narrate.
 - **Long agentic loops, not long conversations, are the real expense.**
   Every tool call re-sends the full context, so a tool-dense task (PR
   review, CI chasing, branch cleanup) costs far more than its wall-clock
@@ -185,16 +169,12 @@ project-specific facts belong in that project's own CLAUDE.md.
   never only in session scrollback. A question that lives solely in a
   session's last response is invisible the moment that session scrolls out
   of view.
-  (Added 2026-08-20; generalized from `symphony/CLAUDE.md`'s "PR
-  automation and session cost" section, which stays the canonical version
-  for that repo's specifics.)
 
 ## Publishing
 
 - **npm publish: no OTP.** My npm account uses browser 2FA with a passkey.
   Run plain `npm publish` and let it open (or print) the auth URL; I approve
   in my browser. Don't ask me for authenticator codes or pass `--otp`.
-  (Added 2026-08-08.)
 
 ## Design
 


### PR DESCRIPTION
Strips dated provenance (`Decided YYYY-MM-DD`, `Added YYYY-MM-DD`, `Ported from #NN`, log-file cross-links) out of `.claude/rules/code.md`, keeping the one-line reason each rule needs to stand on its own. Full dated history preserved in `claude_prompts_scratch/state/global/log/2026-08-21-code-md-provenance-history.md`.

No behavioral change — text only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwVKoe8uoJYksXm7m15vtu)_