### PR TITLE
metrics: cache-churn ratio and PR draft flag

### DIFF
--- a/.claude/hooks/measure-git-events.sh
+++ b/.claude/hooks/measure-git-events.sh
@@ -44,7 +44,8 @@ case "$tool" in
     repo=$(printf '%s' "$input" | jq -r '.tool_input.repo // ""')
     branch=$(printf '%s' "$input" | jq -r '.tool_input.head // ""')
     emit pr "$(printf '%s' "$input" | jq -c '{title: (.tool_input.title // ""),
-                                              base: (.tool_input.base // "")}')"
+                                              base: (.tool_input.base // ""),
+                                              draft: (.tool_input.draft // false)}')"
     exit 0
     ;;
   Bash) ;;
@@ -63,7 +64,9 @@ branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
 
 # PR opened from the CLI
 if printf '%s' "$cmd" | grep -qE '\bgh\b.*\bpr\b.*\bcreate\b'; then
-  emit pr '{"title":"","base":""}'
+  is_draft=false
+  printf '%s' "$cmd" | grep -qE '(^|[[:space:]])--draft([[:space:]]|$)' && is_draft=true
+  emit pr "$(jq -nc --argjson d "$is_draft" '{title:"", base:"", draft:$d}')"
 fi
 
 # Branch created. `git checkout -b` / `git switch -c` is the moment a PR

--- a/.claude/hooks/metrics-rollup.sh
+++ b/.claude/hooks/metrics-rollup.sh
@@ -52,7 +52,9 @@ jq -s '
        output_tokens: (map(.output_tokens // 0) | add),
        tool_calls:   (map(.tool_calls // 0) | add),
        decisions:    (map(.decisions.total // 0) | add),
-       gates:        (map(.decisions.gate // 0) | add)
+       gates:        (map(.decisions.gate // 0) | add),
+       cache_churn_pct_avg: ([.[] | .cache_churn_pct | select(. != null)]
+                              | if length > 0 then (add / length | round) else null end)
      }}' "${files[@]}" > "$M/metrics.json.$$" 2>/dev/null \
   && mv -f "$M/metrics.json.$$" "$M/metrics.json" 2>/dev/null \
   || rm -f "$M/metrics.json.$$" 2>/dev/null

--- a/.claude/hooks/session-metrics.jq
+++ b/.claude/hooks/session-metrics.jq
@@ -166,6 +166,15 @@ to_entries as $E
       input_tokens: sumu(.input_tokens),
       cache_creation_tokens: sumu(.cache_creation_input_tokens),
       cache_read_tokens: sumu(.cache_read_input_tokens),
+      # Cache churn: creation/read as a percent. A cold start makes one
+      # creation burst against zero reads, so a single-digit ratio is
+      # normal; anything sustained above ~30% means the prompt cache kept
+      # missing mid-session -- a stale-cache/reload proxy, not a token-cost
+      # one. Null (not 0) when there were no reads at all, so a one-turn
+      # session doesn't read as either healthy or churning.
+      cache_churn_pct: (sumu(.cache_read_input_tokens) as $r
+        | if $r > 0 then ((sumu(.cache_creation_input_tokens) / $r * 100) | round)
+          else null end),
       context_peak: (([ $amsgs[] | .message.usage
                         | ((.input_tokens // 0) + (.cache_read_input_tokens // 0)
                            + (.cache_creation_input_tokens // 0)) ] | max) // 0),


### PR DESCRIPTION
Two additions to the session/git-event metrics, as a friction/reload proxy:

- **cache_churn_pct** per session (`session-metrics.jq`) and **cache_churn_pct_avg** in the rollup (`metrics-rollup.sh`): `cache_creation/cache_read * 100`. A cold start makes one creation burst against zero reads, so single digits are normal; sustained values above ~30% mean the prompt cache kept missing mid-session — a proxy for context reload / stale cache.
- **draft** bool on the `pr` git-event (`measure-git-events.sh`): whether a logged PR was opened non-ready, from both the MCP `create_pull_request` tool and the CLI's draft flag.

Reviewed with `/code-review` (low effort): one finding, in unrelated parallel-in-flight edits to `metrics-live.sh`/`lib-metrics-fmt.jq` that this PR does not touch — not fixed here since it isn't mine to fix.

Neither field is retroactive; existing session/event files won't carry them until the next Stop or PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)