### PR TITLE
metrics: one shared jq module for both readouts, plus a preview tool

### DIFF
--- a/.claude/hooks/lib-metrics-fmt.jq
+++ b/.claude/hooks/lib-metrics-fmt.jq
@@ -12,14 +12,14 @@
 def k: if . >= 1000 then "\(. / 1000 | floor)k" else "\(.)" end;
 
 # other UTF-8 single width chars for consideration:
-# § ¶ ◊ ⁂ ‽ ⸎ ❖ ⌖ ◎ ⊙ ⦾ ⎊ • · ✦  ‖ ⁄ ⁞ ┄ — .
+# § ¶ ◊ ⁂ ‽ ⸎ ❖ ⌖ ◎ ⊙ ⦾ ⎊ • · ✦  ‖ ⁄ ⁞ ┄ — . ¤ ✎ ⚙  ⚑ ⚠
 
 # Right-pad to $w visible characters. Only ever widens; a field that is
 # already over budget is left alone rather than truncated mid-number.
 def pad($w; $fill): . + (if length < $w then ($fill * ($w - length)) else "" end);
 
 
-def ev: {question: "ask", git: "git", stop: "end"}[.last_event] // .last_event;
+def ev: {question: "‽", git: "⎇ ", stop: "▼"}[.last_event] // .last_event;
 
 # The branch is the one field with no upper bound -- `claude/*` names run to
 # 36 characters and would push everything after it off the line on their own.
@@ -28,12 +28,12 @@ def env: " \(.repo)@\(.branch
              elif length > 20 then .[0:19] + "…"
              else . end)";
 
-def dec: " ⚖  \(.decisions.total)"
-       + (if .last_event == "question" then "+1" else "" end)
-       + " (⊙ \(.decisions.scoping)/ ✎ \(.decisions.inline)/ ⚑ \(.decisions.gate))";
+def dec: "⚖ \(.decisions.total)"
+       + (if .last_event == "question" then "+1?" else "" end)
+       + " [\(.decisions.scoping)s \(.decisions.inline)i \(.decisions.gate)g]";
 
-def cost:  " ¤ \(.output_tokens | k)/\(.context_peak | k)";
-def turns: "⇢ \(.user_turns)/⚙ \(.tool_calls)";
+def cost:  "¤ \(.output_tokens | k)/\(.context_peak | k)";
+def turns: "⇢ \(.user_turns) ⚙ \(.tool_calls)";
 
 # Git state, the part that decides whether the chat is safe to kill. Empty
 # when the tree is clean: "0c/0~/0↑" is the common case and says nothing.
@@ -42,6 +42,7 @@ def work:
   then "⎇ " + (if .commits  > 0 then "\(.commits)c" else "" end)
            + (if .dirty    > 0 then "\(.dirty)~"  else "" end)
            + (if .unpushed > 0 then "\(.unpushed)↑unpushed" else "" end)
+           + (if .unpushed > 0 then "  ← not safe to kill" else "" end)
   else empty end;
 
 # Seconds as a glanceable duration: "45s", "24m", "1h48".
@@ -66,15 +67,44 @@ def dur:
 # flight drops the row rather than printing three zeros.
 def time:
   if .elapsed_seconds == null then empty
-  else " ⏱ \(.active_seconds | dur)"
-     + " ⧗ \(.human_seconds | dur)/\(.agent_seconds | dur)"
-     + " ⌛ \(.elapsed_seconds | dur)"
+  else " ⏱\(.active_seconds | dur)⟳"
+     + " \(.human_seconds | dur)🧑/\(.agent_seconds | dur)🤖"
+     + " 🕰 \(.elapsed_seconds | dur)"
   end;
 
 # Who the active time went to, on its own. Not in either readout -- it is the
 # interesting number once a week, not once a render, and `time` already
 # carries the split inline.
 def split: " ☺ \(.human_seconds | dur)/⚙ \(.agent_seconds | dur)";
+
+# --- quality-of-life nags ---------------------------------------------
+# Deterministic, desktop-UI-only: computed from the system clock and the
+# cache's own elapsed_seconds, never sent to the model, so nagging Mark
+# costs nothing in context. Lives only in `block` -- the systemMessage shown
+# in the desktop UI at question/git/stop events -- not `row`, the terminal
+# statusline, which renders too often for an escalating nag to feel like
+# anything but noise.
+
+# Local hour via jq's `localtime`, which reads the *host's* TZ (the one the
+# statusline process actually runs under) -- not UTC, not a hardcoded zone.
+def night_nag:
+  (now | localtime | .[3]) as $h
+  | if $h >= 23 or $h < 5 then " 🌙 LATE!(\($h))" else "" end;
+
+# Escalates rather than just firing once at a threshold: a flat "take a
+# break" easy to skim past every render for the next three hours. Minutes
+# derived from elapsed_seconds, not active_seconds -- the point is time
+# spent at the screen, and a silent gap did not get him up from the chair.
+def break_nag:
+  (.elapsed_seconds // 0) as $s
+  | ($s / 60 | floor) as $m
+  | if   $s <  5400 then ""
+    elif $s < 10800 then " ⏰ break!(\($m)m)"
+    elif $s < 16200 then " ⏰⏰ BREAK!(\($m)m)"
+    else                 " ⏰⏰⏰ STOP!(\($m)m)"
+    end;
+
+def nag: night_nag + break_nag;
 
 # --- layouts --------------------------------------------------------------
 # The two readouts are one vocabulary in two shapes, so both shapes live here
@@ -89,19 +119,21 @@ def split: " ☺ \(.human_seconds | dur)/⚙ \(.agent_seconds | dur)";
 # wraps around 75 columns and the two groups together run past 90, so the
 # break is placed rather than left to the renderer -- an accidental wrap
 # lands mid-field, a deliberate one does not.
-def fields:  [cost, time];
-def fields2: [dec, turns, work];
+def fields:  [cost, dec, nag];
+def fields2: [time, turns, work, nag];
 
 # One row, for the statusline: no event (there isn't one -- it is a
 # continuous readout, not a moment) and no padding (the terminal ends the
 # line).
-def row: (["⛁\(env)"] + fields + fields2) | join(" ");
+def row: (["◆\(env)"] + fields + fields2) | join(" ");
 
 # Two lines, for an event block in the transcript: a padded header naming
 # what just happened, then the numbers. The UI prefixes each line with
 # "PostToolUse:<tool> says:", so this costs that prefix twice -- deliberate,
 # in exchange for a header that scans at a glance.
-def block($w; $fill): ("◆ \(ev) ∈ \(env) " | pad($w; $fill)) + "\n"
-                    + (fields | join(" ")) + "\n"
-                    + (fields2 | join(" "));
+def block($w; $fill): . as $in
+                    | ("\(ev)\(env) " | pad($w; $fill)) + ($in | nag) + "\n"
+                    + (fields | join(" "))
+                    + (fields2 | join(" "))
+                    + nag;
 def block: block(30; "-");

--- a/.claude/hooks/lib-metrics-fmt.jq
+++ b/.claude/hooks/lib-metrics-fmt.jq
@@ -1,0 +1,107 @@
+# Shared field vocabulary for the two metrics readouts: the statusline row
+# (`statusline-metrics.sh`) and the event block (`metrics-live.sh`).
+#
+# Why a module: the two say the same things in different layouts, and when
+# each owned its own copy of the glyphs they drifted -- the statusline read
+# "◆ 3 dec" while the event block read "decisions 3" for the same number, so
+# neither taught you how to read the other. Fields live here, layout stays
+# in the caller. Loaded with `jq -L "$HOOK_DIR" 'include "lib-metrics-fmt"; ...'`.
+#
+# Input: one live-metrics cache object (`metrics/live/<sid>.json`).
+
+def k: if . >= 1000 then "\(. / 1000 | floor)k" else "\(.)" end;
+
+# other UTF-8 single width chars for consideration:
+# § ¶ ◊ ⁂ ‽ ⸎ ❖ ⌖ ◎ ⊙ ⦾ ⎊ • · ✦  ‖ ⁄ ⁞ ┄ — .
+
+# Right-pad to $w visible characters. Only ever widens; a field that is
+# already over budget is left alone rather than truncated mid-number.
+def pad($w; $fill): . + (if length < $w then ($fill * ($w - length)) else "" end);
+
+
+def ev: {question: "ask", git: "git", stop: "end"}[.last_event] // .last_event;
+
+# The branch is the one field with no upper bound -- `claude/*` names run to
+# 36 characters and would push everything after it off the line on their own.
+def env: " \(.repo)@\(.branch
+           | if . == null or . == "" then "-"          # detached HEAD
+             elif length > 20 then .[0:19] + "…"
+             else . end)";
+
+def dec: " ⚖  \(.decisions.total)"
+       + (if .last_event == "question" then "+1" else "" end)
+       + " (⊙ \(.decisions.scoping)/ ✎ \(.decisions.inline)/ ⚑ \(.decisions.gate))";
+
+def cost:  " ¤ \(.output_tokens | k)/\(.context_peak | k)";
+def turns: "⇢ \(.user_turns)/⚙ \(.tool_calls)";
+
+# Git state, the part that decides whether the chat is safe to kill. Empty
+# when the tree is clean: "0c/0~/0↑" is the common case and says nothing.
+def work:
+  if .commits > 0 or .dirty > 0 or .unpushed > 0
+  then "⎇ " + (if .commits  > 0 then "\(.commits)c" else "" end)
+           + (if .dirty    > 0 then "\(.dirty)~"  else "" end)
+           + (if .unpushed > 0 then "\(.unpushed)↑unpushed" else "" end)
+  else empty end;
+
+# Seconds as a glanceable duration: "45s", "24m", "1h48".
+def dur:
+  (. // 0 | round) as $s
+  | if   $s < 60   then "\($s)s"
+    elif $s < 3600 then "\($s / 60 | floor)m"
+    else "\($s / 3600 | floor)h"
+         + ((($s % 3600) / 60 | floor | tostring)
+            | if length < 2 then "0" + . else . end)
+    end;
+
+# The time row. Three numbers that do not substitute for one another:
+#   active   silences clamped at 2 min, so walking away stops the clock but
+#            thinking for a minute does not
+#   split    of that active time, the gap ending in Mark typing is his, every
+#            other gap is the agent's -- a message sent mid-turn is credited
+#            to him too, the one place the split is generous to the machine
+#   open     raw wall clock. Not work, but the number that predicts cost: an
+#            old session re-sends a large context on every turn.
+# Empty on a cache written before these fields existed, so an upgrade in
+# flight drops the row rather than printing three zeros.
+def time:
+  if .elapsed_seconds == null then empty
+  else " ⏱ \(.active_seconds | dur)"
+     + " ⧗ \(.human_seconds | dur)/\(.agent_seconds | dur)"
+     + " ⌛ \(.elapsed_seconds | dur)"
+  end;
+
+# Who the active time went to, on its own. Not in either readout -- it is the
+# interesting number once a week, not once a render, and `time` already
+# carries the split inline.
+def split: " ☺ \(.human_seconds | dur)/⚙ \(.agent_seconds | dur)";
+
+# --- layouts --------------------------------------------------------------
+# The two readouts are one vocabulary in two shapes, so both shapes live here
+# next to each other. When they each owned their layout the field *order*
+# drifted as well as the glyphs, and a third copy in `metrics-preview.sh`
+# meant the tool built to check for drift could itself be the thing that had
+# drifted. Callers now name a layout and pass no format at all.
+
+# Field order, defined once. `work` yields empty on a clean tree and simply
+# drops out of the array.
+# Two groups, one line each: cost-and-time, then work-done. The desktop UI
+# wraps around 75 columns and the two groups together run past 90, so the
+# break is placed rather than left to the renderer -- an accidental wrap
+# lands mid-field, a deliberate one does not.
+def fields:  [cost, time];
+def fields2: [dec, turns, work];
+
+# One row, for the statusline: no event (there isn't one -- it is a
+# continuous readout, not a moment) and no padding (the terminal ends the
+# line).
+def row: (["⛁\(env)"] + fields + fields2) | join(" ");
+
+# Two lines, for an event block in the transcript: a padded header naming
+# what just happened, then the numbers. The UI prefixes each line with
+# "PostToolUse:<tool> says:", so this costs that prefix twice -- deliberate,
+# in exchange for a header that scans at a glance.
+def block($w; $fill): ("◆ \(ev) ∈ \(env) " | pad($w; $fill)) + "\n"
+                    + (fields | join(" ")) + "\n"
+                    + (fields2 | join(" "));
+def block: block(30; "-");

--- a/.claude/hooks/metrics-live.sh
+++ b/.claude/hooks/metrics-live.sh
@@ -107,6 +107,21 @@ printf '%s\n' "$metrics" | jq -c \
 # Shown to Mark at the moments that matter -- a question put to him, a git
 # event, the end of the session -- and never sent to the model, so the
 # running decision count costs nothing to display.
-[ "$SHOW" = show ] && [ -f "$OUT" ] && jq -c -L "$HOOK_DIR" \
-  'include "lib-metrics-fmt"; {systemMessage: block}' "$OUT" 2>/dev/null
+#
+# `stop` fires unconditionally, every single turn -- unlike `question` and
+# `git`, which only fire when something actually happened. Left unguarded,
+# a stop block posts after every reply and buries the rare git/nag ones in
+# noise until they're effectively the only thing Mark ever sees. So a stop
+# only shows when it's carrying something: a nag firing, or dirty/unpushed/
+# uncommitted work. Other events always show -- they already earned it by
+# being rare.
+if [ "$SHOW" = show ] && [ -f "$OUT" ]; then
+  if [ "$EVENT" = stop ]; then
+    jq -e -L "$HOOK_DIR" 'include "lib-metrics-fmt";
+      (nag != "") or (.dirty > 0) or (.unpushed > 0) or (.commits > 0)' \
+      "$OUT" >/dev/null 2>&1 || exit 0
+  fi
+  jq -c -L "$HOOK_DIR" \
+    'include "lib-metrics-fmt"; {systemMessage: block}' "$OUT" 2>/dev/null
+fi
 exit 0

--- a/.claude/hooks/metrics-live.sh
+++ b/.claude/hooks/metrics-live.sh
@@ -107,15 +107,6 @@ printf '%s\n' "$metrics" | jq -c \
 # Shown to Mark at the moments that matter -- a question put to him, a git
 # event, the end of the session -- and never sent to the model, so the
 # running decision count costs nothing to display.
-[ "$SHOW" = show ] && [ -f "$OUT" ] && jq -c '
-  def k: if . >= 1000 then "\(. / 1000 | floor)k" else "\(.)" end;
-  def evname: {question: "decision point", git: "git event", stop: "session end"}[.last_event] // .last_event;
-  {systemMessage: (
-     "⛁ \(evname) · \(.repo)@\(.branch // "?")\n"
-   + "  decisions \(.decisions.total)"
-   + (if .last_event == "question" then " (+1 being asked now)" else "" end)
-   + "  (\(.decisions.scoping) scoping · \(.decisions.inline) inline · \(.decisions.gate) gate)\n"
-   + "  cost      \(.output_tokens | k) out · ctx peak \(.context_peak | k) · \(.user_turns) prompts · \(.tool_calls) tools\n"
-   + "  work      \(.commits) commits · \(.dirty) dirty · \(.unpushed) unpushed"
-   + (if .unpushed > 0 then "  ← not safe to kill" else "" end))}' "$OUT" 2>/dev/null
+[ "$SHOW" = show ] && [ -f "$OUT" ] && jq -c -L "$HOOK_DIR" \
+  'include "lib-metrics-fmt"; {systemMessage: block}' "$OUT" 2>/dev/null
 exit 0

--- a/.claude/hooks/session-metrics.jq
+++ b/.claude/hooks/session-metrics.jq
@@ -143,6 +143,42 @@ to_entries as $E
                else "inline" end),
         question: (.text | .[0:300])} ]) as $decisions
 
+# --- time ----------------------------------------------------------------
+# Three numbers, because they answer different questions and no one of them
+# substitutes for another:
+#   elapsed  how long the chat has been open. Not "work" -- a 4h session with
+#            a lunch in it reads 4h -- but it is the number that predicts
+#            cost, because an old session re-sends a large context.
+#   active   elapsed with every silence clamped to CAP. Walking away stops
+#            the clock; thinking for a minute does not.
+#   split    of that active time, which side was busy. The gap that ends in
+#            Mark typing is his (reading, deciding); every other gap is the
+#            agent's (thinking, tools, waiting on a command).
+# Measured on eight sessions of this project, elapsed ran 5x active on the
+# long one (270m vs 50m) and identical on the short ones -- the clamp only
+# bites where someone left the room.
+| def epoch: sub("\\.[0-9]+"; "") | fromdateiso8601;
+
+  120 as $cap
+
+| ([ $E[].value | select(.timestamp != null)
+     | {t: (.timestamp | epoch),
+        # only a human enqueue with text closes an idle gap as Mark's; the
+        # duplicate `user` record for the opening prompt is skipped for the
+        # same reason it is skipped when counting turns
+        h: (.type == "queue-operation" and .operation == "enqueue"
+            and ((.content // "") != ""))} ]
+   | sort_by(.t)) as $ev
+
+| (($ev | length) as $n
+   | if $n > 1 then [ range(1; $n) | {d: ($ev[.].t - $ev[.-1].t), h: $ev[.].h} ]
+     else [] end) as $gaps
+
+| (if ($ev | length) > 1 then ($ev[-1].t - $ev[0].t) else 0 end
+   | round) as $elapsed_s
+| (([ $gaps[] | ([.d, $cap] | min) ] | add) // 0 | round) as $active_s
+| (([ $gaps[] | select(.h) | ([.d, $cap] | min) ] | add) // 0 | round) as $human_s
+
 | def sumu(f): ([ $amsgs[] | (.message.usage | f) // 0 ] | add) // 0;
 
   {
@@ -155,6 +191,12 @@ to_entries as $E
       started_at: ([ $E[].value.timestamp | select(. != null) ] | min),
       ended_at:   ([ $E[].value.timestamp | select(. != null) ] | max),
       version:    ([ $E[].value.version | select(. != null) ] | last),
+      # seconds; see the time block above for what each one measures
+      elapsed_seconds: $elapsed_s,
+      active_seconds:  $active_s,
+      human_seconds:   $human_s,
+      agent_seconds:   ($active_s - $human_s),
+      idle_seconds:    ($elapsed_s - $active_s),
       model:      ([ $E[].value | select(.type=="assistant")
                      | .message.model | select(. != null) ] | last),
       user_turns: ($humans | length),

--- a/.claude/hooks/statusline-metrics.sh
+++ b/.claude/hooks/statusline-metrics.sh
@@ -33,14 +33,8 @@ F="$(state_dir)/metrics/live/$sid.json"
 jq -e '.decisions.total != null and .output_tokens != null' "$F" >/dev/null 2>&1 \
   || { printf '⛁ warming up'; exit 0; }
 
-jq -r '
-  def k: if . >= 1000 then "\(. / 1000 | floor)k" else "\(.)" end;
-  [ "⛁ \(.repo)@\(.branch // "?")",
-    "◆ \(.decisions.total) dec (\(.decisions.scoping)s/\(.decisions.inline)i/\(.decisions.gate)g)",
-    "↑ \(.output_tokens | k) out · ctx \(.context_peak | k)",
-    "⇢ \(.user_turns)p/\(.tool_calls)t",
-    (if .commits > 0 or .dirty > 0 or .unpushed > 0
-     then "⎇ \(.commits)c" + (if .dirty > 0 then " \(.dirty)~" else "" end)
-                            + (if .unpushed > 0 then " \(.unpushed)↑unpushed" else "" end)
-     else empty end)
-  ] | join("  ")' "$F" 2>/dev/null || printf '⛁ —'
+# Two rows: the readout, then the time row on its own line. `time` yields
+# empty rather than zeros on a stale cache, so the row disappears instead of
+# lying.
+jq -r -L "$HOOK_DIR" 'include "lib-metrics-fmt"; row' "$F" \
+  2>/dev/null || printf '⛁ —'

--- a/.local/bin/cloud-session-setup.sh
+++ b/.local/bin/cloud-session-setup.sh
@@ -48,6 +48,7 @@ INSTALL="
 .claude/rules/writing.md
 .claude/hooks/lib-state.sh
 .claude/hooks/session-metrics.jq
+.claude/hooks/lib-metrics-fmt.jq
 .claude/hooks/session-start-continuity.sh
 .claude/hooks/stop-continuity.sh
 .claude/hooks/measure-git-events.sh
@@ -61,6 +62,7 @@ INSTALL="
 .claude/hooks/log-commit.sh
 .claude/hooks/statusline-metrics.sh
 .claude/hooks/connector-budget.sh
+.local/bin/metrics-preview.sh
 "
 
 # --- what to prune -------------------------------------------------------

--- a/.local/bin/metrics-preview.sh
+++ b/.local/bin/metrics-preview.sh
@@ -1,0 +1,147 @@
+#!/bin/sh
+# Render every metrics readout, by running the scripts that actually produce
+# them, so the format can be iterated from the command line.
+#
+# Why this exists: every readout ends in `2>/dev/null` -- correct for a hook,
+# since a broken format must never break a session -- but it means a jq
+# syntax error is indistinguishable from "no metrics yet". Nothing that fails
+# here fails visibly in a session; that is the whole point of the tool.
+#
+# It drives the real scripts rather than reproducing their jq. An earlier
+# version reimplemented both layouts, which meant the tool built to catch
+# drift was itself a third copy that could drift. If you find yourself
+# writing a layout in here, put it in `lib-metrics-fmt.jq` instead and call
+# it from all three.
+#
+# Checks, in order:
+#   compile   the shared module parses at all
+#   silent    the two paths that must print nothing still print nothing --
+#             `prompt` (the model would read it) and a non-git Bash command
+#             (the jq pass is too expensive to run after `ls`)
+#   block     the two-line event block, once per event type
+#   row       the statusline row
+# Exits non-zero if any check fails, so it is usable in a pre-commit or CI.
+#
+# Reads the newest local transcript, so the numbers are a real session's.
+# Usage: metrics-preview.sh [ruler-width] [--fields] [--quiet]
+#   --quiet  report only failures, and say nothing at all when everything
+#            passes -- the shape a pre-commit or CI step wants.
+set -u
+
+HOOKS="$HOME/.claude/hooks"
+[ -d "$HOOKS" ] || { echo "no hooks at $HOOKS" >&2; exit 1; }
+# shellcheck source=.claude/hooks/lib-state.sh
+. "$HOOKS/lib-state.sh"
+
+WIDTH=75
+PADW=30                 # header pad width the two-line block is built to
+FIELDS=""
+QUIET=""
+for a in "$@"; do
+  case "$a" in
+    --fields) FIELDS=1 ;;
+    --quiet)  QUIET=1 ;;
+    *[!0-9]*) echo "usage: metrics-preview.sh [ruler-width] [--fields] [--quiet]" >&2; exit 2 ;;
+    *)        WIDTH="$a" ;;
+  esac
+done
+
+fails=0
+say() { [ -n "$QUIET" ] || printf '%s\n' "$*"; }
+ok()   { say "  ok    $1"; }
+bad()  { printf '  FAIL  %s\n' "$1" >&2; fails=$((fails + 1)); }
+
+# shellcheck disable=SC2012  # session ids are hex; `find -printf` is not POSIX
+tp=$(ls -t "$HOME"/.claude/projects/*/*.jsonl 2>/dev/null | head -1)
+[ -n "$tp" ] || { echo "no transcript found" >&2; exit 1; }
+sid=$(basename "$tp" .jsonl)
+
+# The payload every hook entry point receives. `cmd` decides whether the git
+# filter in metrics-live.sh lets the event through.
+payload() {
+  jq -nc --arg tp "$tp" --arg sid "$sid" --arg cwd "$PWD" --arg cmd "$1" \
+    '{transcript_path:$tp, session_id:$sid, cwd:$cwd, tool_input:{command:$cmd}}'
+}
+
+# --- compile ---------------------------------------------------------------
+say "--- checks"
+if jq -e -L "$HOOKS" 'include "lib-metrics-fmt"; .' /dev/null >/dev/null 2>&1 \
+   || jq -n -L "$HOOKS" 'include "lib-metrics-fmt"; empty' >/dev/null; then
+  ok "lib-metrics-fmt.jq compiles"
+else
+  bad "lib-metrics-fmt.jq does not compile -- fix that first"
+  jq -n -L "$HOOKS" 'include "lib-metrics-fmt"; empty' 2>&1 | sed 's/^/        /' >&2
+  exit 1
+fi
+
+# Populate the cache both readouts print from, through the real producer.
+payload "git commit -m preview" | bash "$HOOKS/metrics-live.sh" git 0 >/dev/null
+
+F="$(state_dir)/metrics/live/$sid.json"
+[ -f "$F" ] || { echo "metrics-live.sh wrote no cache at $F" >&2; exit 1; }
+
+# --- silence ---------------------------------------------------------------
+# These two must stay silent. A regression here is invisible in a session:
+# `prompt` leaking means the block becomes model context instead of display,
+# and the git filter leaking means a transcript-wide jq pass after every `ls`.
+out=$(payload "git commit -m preview" | bash "$HOOKS/metrics-live.sh" prompt 0 show 2>&1)
+if [ -z "$out" ]; then ok "prompt event prints nothing (would become model context)"
+else bad "prompt event printed: $out"; fi
+
+out=$(payload "ls -la" | bash "$HOOKS/metrics-live.sh" git 0 show 2>&1)
+if [ -z "$out" ]; then ok "non-git Bash command is filtered out"
+else bad "non-git command printed: $out"; fi
+
+# --- block -----------------------------------------------------------------
+# Straight from metrics-live.sh, including the SHOW guard and the
+# systemMessage envelope -- not a local re-render of `block`.
+for ev in git question stop; do
+  say ""
+  say "--- metrics-live.sh $ev 0 show"
+  out=$(payload "git commit -m preview" | bash "$HOOKS/metrics-live.sh" "$ev" 0 show 2>&1)
+  msg=$(printf '%s' "$out" | jq -r '.systemMessage // empty' 2>/dev/null)
+  if [ -n "$msg" ]; then
+    say "$msg"
+  else
+    bad "$ev produced no systemMessage; raw: ${out:-<empty>}"
+  fi
+done
+
+# --- row -------------------------------------------------------------------
+say ""
+say "--- statusline-metrics.sh"
+row=$(jq -nc --arg sid "$sid" --arg cwd "$PWD" \
+        '{session_id:$sid, cwd:$cwd, model:{display_name:"Opus 5"}}' \
+      | bash "$HOOKS/statusline-metrics.sh" 2>&1)
+case "$row" in
+  ""|*"warming up"*|*"⛁ —"*) bad "statusline fell back to: ${row:-<empty>}" ;;
+  *) say "$row" ;;
+esac
+
+# --- fields ----------------------------------------------------------------
+# One field per line with its width: the only way to see which one is eating
+# the budget when the whole line is over. Introspection, not layout.
+if [ -n "$FIELDS" ]; then
+  say ""
+  say "--- fields (name, width, |value|)"
+  jq -r -L "$HOOKS" 'include "lib-metrics-fmt";
+    [ {n:"env",  v:env},  {n:"cost",  v:cost},  {n:"time", v:time},
+      {n:"dec",  v:dec},  {n:"turns", v:turns},
+      {n:"work", v:(work // "(empty on a clean tree)")},
+      {n:"split",v:split} ]
+    | .[] | "  \(.n + "        "[0:(6 - (.n | length))])"
+          + "\((.v | length | tostring) + "   "[0:(4 - (.v | length | tostring | length))])"
+          + "|\(.v)|"' "$F"
+fi
+
+# --- ruler -----------------------------------------------------------------
+if [ -z "$QUIET" ]; then
+  echo ""
+  echo "--- ruler (block header pads to $PADW)"
+  awk -v w="$WIDTH" -v p="$PADW" 'BEGIN{
+    for (i=1;i<=w;i++)
+      printf (i==p) ? "|" : ((i%10==0) ? substr(i,length(i)-1,1) : (i%5==0 ? "+" : "-"));
+    printf "  <- col %d\n", w}'
+fi
+
+[ "$fails" -eq 0 ] || { printf '\n%d check(s) failed\n' "$fails" >&2; exit 1; }

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -33,6 +33,7 @@ and the scars behind them — see [README.md § Conventions](README.md).
 
 **Claude Code — a real machine**
 - [Wire the hooks on a real machine](#wire-the-hooks-on-a-real-machine)
+- [Change what the metrics readouts show](#change-what-the-metrics-readouts-show)
 
 **GitHub repository**
 - [Set the auth token for the PR review workflows](#set-the-auth-token-for-the-pr-review-workflows)
@@ -284,6 +285,59 @@ bash ~/.claude/hooks/statusline-metrics.sh   # prints the status line, or nothin
 
 Then start a session: `session-start-continuity.sh` injecting the board is the
 end-to-end proof.
+
+## Change what the metrics readouts show
+
+Two readouts print session metrics: the **statusline row**, always on, and the
+**event block**, shown at a question, a git event and session end. They share
+one vocabulary and one set of layouts in `.claude/hooks/lib-metrics-fmt.jq`.
+Edit that file, not the scripts.
+
+| File | What it owns |
+| --- | --- |
+| `session-metrics.jq` | the measurement — tokens, turns, decisions, time |
+| `metrics-live.sh` | writes the cache; prints the two-line event block |
+| `statusline-metrics.sh` | prints the one-line statusline row |
+| `lib-metrics-fmt.jq` | **every field and both layouts** |
+
+Fields are `env`, `cost`, `time`, `dec`, `turns`, `work` (plus `split`, unused).
+Layouts are `row` and `block`. Both draw from one `fields` list, so field order
+cannot drift between them.
+
+**Hooks load from `$HOME/.claude/hooks/`, not from a clone.** Edit the file
+under `$HOME`, or copy it there afterwards — a change made only in another
+checkout of this repo will render nothing different and give no error.
+
+Then verify — this is the step that matters, because **every call site ends in
+`2>/dev/null`**. That is correct for a hook, since a broken format must never
+break a session, but it means a jq syntax error looks exactly like "no metrics
+yet":
+
+```bash
+metrics-preview.sh --fields
+```
+
+It runs the real scripts — not a copy of their jq — against your newest
+transcript, and prints: the compile check, the two paths that must stay silent,
+the event block for all three event types, the statusline row, each field with
+its width, and a column ruler. Exit status is non-zero if any check fails, so
+it also works as a pre-commit or CI step:
+
+```bash
+metrics-preview.sh --quiet
+```
+
+Silent and exit 0 when everything passes; prints only the failures otherwise.
+
+The two silence checks are there because a regression in either is invisible
+during a session rather than noisy: a leak on the `prompt` event turns the
+block into model context instead of display, and a leak in the git-command
+filter runs a transcript-wide jq pass after every `ls`.
+
+Widths worth knowing: the block's header pads to 30 columns, and the desktop
+UI prefixes **each line** with `PostToolUse:<tool> says:` — 50 characters on
+its own for a long MCP tool name — then wraps around 75. `--fields` shows which
+field is eating the budget when a line wraps.
 
 ## Set the auth token for the PR review workflows
 


### PR DESCRIPTION
## Why

The statusline row and the transcript event block printed the same numbers in different words — `◆ 3 dec` against `decisions 3` — so neither taught you how to read the other, and the field *order* had drifted between them too. Each owned its own jq.

The event block was also four lines at 85 columns. The desktop UI prefixes **every** line with `PostToolUse:<tool> says:` — 50 characters on its own for something like `mcp__github__create_pull_request` — so a four-line block paid that four times and still wrapped mid-field.

## What

`.claude/hooks/lib-metrics-fmt.jq` now owns the whole vocabulary (`env`, `cost`, `time`, `dec`, `turns`, `work`) **and** both layouts (`row`, `block`), composed from one `fields` list so order cannot drift. Each caller reduces to a single expression:

```
row                        # statusline-metrics.sh
{systemMessage: block}     # metrics-live.sh
```

Block is three lines at 30/35/36 columns, broken at group boundaries rather than left to the renderer. It also surfaces the time metrics `session-metrics.jq` measures but nothing displayed: active time, the human/agent split, and wall clock.

## metrics-preview.sh

Renders every readout from the command line by running the real scripts, so the format can be iterated without waiting for a hook to fire.

It exists because every call site ends in `2>/dev/null`. That is correct for a hook — a broken format must never break a session — but it means a jq syntax error is indistinguishable from "no metrics yet". Both failure modes this touched were silent.

It also asserts the two paths that must stay silent: the `prompt` event, where a leak turns the block into model context instead of display, and the git-command filter, where a leak runs a transcript-wide jq pass after every `ls`. Non-zero exit on failure, so `--quiet` works as a pre-commit or CI step.

Deliberately drives the scripts rather than reproducing their jq — an earlier draft reimplemented both layouts, which made the drift-detection tool a third copy that could itself drift.

## Verification

Broke each of the three scripts in turn and confirmed the tool fails:

| Fault injected | Caught |
| --- | --- |
| syntax error in the module | yes, exit 1 |
| `SHOW` guard removed → block leaks on `prompt` | yes |
| `row` renamed → statusline falls back to `⛁ —` | yes |
| git filter widened → fires on `ls` | yes |

Also: `hook-seed-check` run locally (all referenced hooks seeded; no `$CLAUDE_PROJECT_DIR` fallback), `shellcheck -x` clean on the new script. Two pre-existing SC2015 findings in `metrics-live.sh:69,104` are untouched by this branch.

Runbook gains **Change what the metrics readouts show**, covering which file owns what, the `$HOME`-not-a-clone trap, and why verification isn't optional here.