### PR TITLE
hooks: fire metrics-live.sh on the rare events too

### DIFF
--- a/.claude/hooks/metrics-live.sh
+++ b/.claude/hooks/metrics-live.sh
@@ -89,7 +89,7 @@ OUT="$LIVE/$sid.json"
 #            real time, so they show immediately, uncoalesced. Streaks are
 #            only worth collapsing once git activity is established as
 #            routine for the session.
-PULSE_N="${METRICS_PULSE_N:-8}"
+PULSE_N="${METRICS_PULSE_N:-1}"
 GIT_EARLY_N="${METRICS_GIT_EARLY_N:-3}"
 if [ "$EVENT" = posttooluse ]; then
   PULSE="$LIVE/$sid.pulse.json"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -116,6 +116,46 @@
         ]
       }
     ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "h=\"$HOME/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] && bash \"$h\" notification 0 show 2>/dev/null || true"
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "h=\"$HOME/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] && bash \"$h\" subagentstop 0 show 2>/dev/null || true"
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "h=\"$HOME/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] && bash \"$h\" precompact 0 show 2>/dev/null || true"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "h=\"$HOME/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] && bash \"$h\" sessionend 0 show 2>/dev/null || true"
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "hooks": [


### PR DESCRIPTION
Wires Notification, SubagentStop, PreCompact, SessionEnd to call metrics-live.sh, matching existing Stop/PostToolUse/UserPromptSubmit/PreToolUse coverage. Also carries the already-staged PULSE_N=1 change (pulse every tool call instead of every 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)