### PR TITLE
hooks: fire metrics-live.sh on SessionStart too

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -161,6 +161,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "h=\"$HOME/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] && bash \"$h\" sessionstart 0 2>/dev/null || true"
+          },
+          {
+            "type": "command",
             "command": "h=\"$HOME/.claude/hooks/session-start-seed-refresh.sh\"; [ -f \"$h\" ] && bash \"$h\" || true",
             "timeout": 60
           },


### PR DESCRIPTION
Completes the sweep from #40 — every hook event now calls metrics-live.sh unconditionally except PreToolUse (still scoped to the AskUserQuestion matcher). No 'show' flag on SessionStart: that output is model-visible, same as UserPromptSubmit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)