### PR TITLE
ci: fix claude-code-review posting nothing on every PR

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,6 +3,9 @@ name: Claude Code Review
 # Automatic Claude review of every PR diff. Complements CodeRabbit and the
 # dedicated security-review workflow — this pass is general correctness and
 # dotfiles-specific footguns (secrets handling, sops, hooks that auto-run).
+#
+# Auth: needs the CLAUDE_CODE_OAUTH_TOKEN secret (mint one with
+# `claude setup-token`, then `gh secret set CLAUDE_CODE_OAUTH_TOKEN`).
 
 permissions:
   contents: read
@@ -12,7 +15,7 @@ permissions:
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: claude-review-${{ github.event.pull_request.number }}
@@ -20,15 +23,22 @@ concurrency:
 
 jobs:
   review:
+    # Skip drafts, and skip fork PRs -- forks can't read the secret, so a
+    # run there only produces a red X that means nothing.
+    if: >-
+      !github.event.pull_request.draft &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
-          fetch-depth: 1
+          fetch-depth: 0
+          persist-credentials: false
 
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
           prompt: |
             Review this pull request diff to a personal dotfiles repo.
 
@@ -46,6 +56,7 @@ jobs:
             Skip pure style nits. Post inline comments on specific lines, then a short
             top-level summary. If you find nothing, say so briefly instead of inventing
             findings.
+
           claude_args: |
             --max-turns 8
-            --model claude-sonnet-4-6
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Summary
`claude-code-review.yml` has been running since `CLAUDE_CODE_OAUTH_TOKEN` was set (2026-08-20) but posting **zero** comments — no inline comments, no top-level summary, on any PR. Confirmed against #42 and #43's run logs: `permission_denials_count: 2`, `"No buffered inline comments"`, ~$0.92 and 7 turns spent per run for no visible output. It's the exact "green check that means nothing" failure this repo's own CLAUDE.md warns about.

Root cause: no `--allowedTools` grant, so the agent can't call `gh pr comment` or the inline-comment MCP tool. Fixed by bringing the workflow in line with the identical setup already working in `symphony` and `signalk-noaa-space-weather`:
- grant `mcp__github_inline_comment__create_inline_comment` + `gh pr comment/diff/view`
- skip draft and fork PRs (forks can't read the secret — a run there is a red X that means nothing)
- `track_progress: true`, so a stuck run is visible instead of silent
- `checkout@v5`, `fetch-depth: 0`, `persist-credentials: false`
- drop the stale `claude-sonnet-4-6` pin

This PR's own review run is the test — if it posts a comment, the fix works.

## Out of scope (already decided/carded, not touched here)
- `claude-security-review.yml` stays on `workflow_dispatch` — needs a paid `ANTHROPIC_API_KEY` with no OAuth path, and neither sibling repo has an equivalent workflow at all. Board card open for that billing decision.
- CodeRabbit App install on this repo — GitHub-account-owner action, can't be done from here. `.coderabbit.yaml` (landed in #18) is already correct and waiting. Card: https://github.com/apps/coderabbitai