### PR TITLE
ci: secret scanning, shellcheck, dependabot; enable GH secret scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  # Pins on third-party GitHub Actions (checkout@v5, setup-python@v6, etc.)
+  # are a supply-chain surface: an unpinned or stale action version is one
+  # of the more common real-world CI compromise vectors. This repo is
+  # public and its Actions runs have write access to PRs -- keep them
+  # current rather than frozen at whatever version was current when a
+  # workflow was written.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/scripts/scan_verified_secrets.sh
+++ b/.github/scripts/scan_verified_secrets.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Scans the full git history for credentials that are actually LIVE.
+#
+# trufflehog differs from gitleaks in one important way: it doesn't just
+# pattern-match, it calls the provider's API to check whether a candidate
+# credential still works. So a finding here is never a false alarm and is
+# always urgent -- the secret is real, valid, and in a public repo.
+#
+# Why this wrapper exists: trufflehog has no --redact flag and prints raw
+# secret values on stdout. This repo's GitHub Actions logs are public, so
+# piping its output straight into CI would turn a near-miss into a second
+# exposure. We take JSON and print only detector/file/commit -- never the
+# value.
+#
+# Run locally any time:  .github/scripts/scan_verified_secrets.sh
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+TRUFFLEHOG_VERSION="3.97.0"
+REPORT="$(mktemp)"
+trap 'rm -f "$REPORT"' EXIT
+
+echo "Scanning full history for verified-live secrets (trufflehog ${TRUFFLEHOG_VERSION})..."
+
+# --fail is deliberately NOT passed: we want the JSON regardless, and this
+# script decides the exit status after redacting.
+docker run --rm -v "$PWD:/repo" "trufflesecurity/trufflehog:${TRUFFLEHOG_VERSION}" \
+  git file:///repo --results=verified --json --no-update >"$REPORT" 2>/dev/null || true
+
+python3 - "$REPORT" <<'PY'
+import json
+import sys
+
+findings = []
+with open(sys.argv[1]) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if record.get("DetectorName"):
+            findings.append(record)
+
+if not findings:
+    print("OK: no live credentials found in git history.")
+    sys.exit(0)
+
+print(f"\n{'=' * 70}")
+print(f"{len(findings)} VERIFIED LIVE CREDENTIAL(S) IN GIT HISTORY")
+print(f"{'=' * 70}\n")
+
+for record in findings:
+    meta = record.get("SourceMetadata", {}).get("Data", {}).get("Git", {})
+    # Deliberately never printing record["Raw"] / ["Redacted"] -- the point
+    # of this wrapper is that the value stays out of public CI logs.
+    print(f"  detector : {record.get('DetectorName')}")
+    print(f"  file     : {meta.get('file', '?')}")
+    print(f"  commit   : {str(meta.get('commit', '?'))[:12]}")
+    print(f"  date     : {meta.get('timestamp', '?')}")
+    print()
+
+print("These credentials are LIVE and PUBLIC. In priority order:")
+print("  1. Rotate them at the provider NOW. Revocation is the only fix that")
+print("     matters -- rewriting git history does not un-publish a secret.")
+print("  2. Then remove/re-encrypt the value and force-push the cleanup, but")
+print("     only after rotation -- history rewrite alone does not help.")
+sys.exit(1)
+PY

--- a/.github/scripts/verify_encrypted.sh
+++ b/.github/scripts/verify_encrypted.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Confirms every secret-bearing file is actually encrypted in what git has
+# committed. This is the backstop that cannot be bypassed: the local
+# pre_commit hook can be skipped with YADM_ALLOW_SECRET=1 or --no-verify (on
+# a plain-git clone), but this runs in CI on every push.
+#
+# The file list comes straight from .sops.yaml's path_regex entries, not a
+# hand-copied list here -- that's the drift symptom this exists to prevent.
+# Extraction is a grep, not a YAML parser: .sops.yaml in this repo is a flat
+# list of `path_regex: <value>` lines under creation_rules with no nested
+# structure. If that ever stops being true, switch this to python+pyyaml
+# (see symphony's scripts/sops_paths.py for the pattern) rather than
+# stretching the grep.
+#
+# Checks `git show HEAD:<path>`, not the working tree -- dotfiles' secrets
+# are whole-file ciphertext at rest (no clean/smudge filter, unlike
+# symphony), so the two are the same content anyway. Needs no age key: this
+# checks that ciphertext IS ciphertext, which works without decrypting it.
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+SOPS_CONFIG=".sops.yaml"
+
+# is_sops_encrypted -- reads file content on stdin, exits 0 only if it
+# carries real sops metadata, in any of the three shapes sops writes:
+# dotenv (sops_mac=ENC[...] + sops_version=), JSON (`"sops": {...}` with
+# mac + version), or YAML (`sops:` block with mac: + version:). Not "does
+# the text contain the word sops" -- a coincidental match would make every
+# guard downstream treat a live credential as encrypted.
+is_sops_encrypted() {
+  local text
+  text="$(cat)"
+  if grep -Eq '^sops_mac=ENC\[' <<<"$text" && grep -Eq '^sops_version=' <<<"$text"; then
+    return 0
+  fi
+  if grep -Eq '"sops"[[:space:]]*:[[:space:]]*\{' <<<"$text"; then
+    grep -Eq '"mac"[[:space:]]*:' <<<"$text" && grep -Eq '"version"[[:space:]]*:' <<<"$text"
+    return
+  fi
+  if grep -Eq '^sops:[[:space:]]*$' <<<"$text"; then
+    grep -Eq '^[[:space:]]+mac:' <<<"$text" && grep -Eq '^[[:space:]]+version:' <<<"$text"
+    return
+  fi
+  return 1
+}
+
+mapfile -t regexes < <(grep -oP '^\s*- path_regex:\s*\K.*' "$SOPS_CONFIG")
+if [ "${#regexes[@]}" -eq 0 ]; then
+  echo "verify_encrypted: no path_regex entries found in $SOPS_CONFIG -- nothing to check." >&2
+  exit 1
+fi
+
+fail=0
+checked=0
+while IFS= read -r path; do
+  [ -n "$path" ] || continue
+  # The sops config itself is not a secret, but the "ends in .sops.<ext>"
+  # rule structurally matches its own filename (.sops.yaml looks exactly
+  # like "<name>.sops.yaml"). Exclude it explicitly rather than tightening
+  # the shared regex, which .config/yadm/bootstrap also depends on as-is.
+  [ "$path" = "$SOPS_CONFIG" ] && continue
+  matched=0
+  for re in "${regexes[@]}"; do
+    if [[ "$path" =~ $re ]]; then
+      matched=1
+      break
+    fi
+  done
+  [ "$matched" -eq 1 ] || continue
+
+  blob="$(git show "HEAD:${path}" 2>/dev/null)" || continue
+  if is_sops_encrypted <<<"$blob"; then
+    checked=$((checked + 1))
+  else
+    echo "NOT ENCRYPTED: ${path}" >&2
+    fail=1
+  fi
+done < <(git ls-files)
+
+if [ "$fail" -ne 0 ]; then
+  echo >&2
+  echo "One or more secret-bearing files are not encrypted in git. This must never happen." >&2
+  echo "Encrypt with sops before committing; see .config/yadm/bootstrap for how this repo reads them back." >&2
+  exit 1
+fi
+
+if [ "$checked" -eq 0 ]; then
+  echo "verify_encrypted: no files matched .sops.yaml's path_regex entries -- check the patterns." >&2
+  exit 1
+fi
+
+echo "OK: ${checked} secret-bearing file(s) encrypted as committed."

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,87 @@
+name: Secret scan
+
+# This repo's worktree is $HOME on every machine Mark uses, and it's public.
+# A leaked credential here is a bigger incident than in any single project
+# repo -- these jobs answer "has a credential reached the public internet,"
+# on the push itself, not on some later PR review.
+#
+# The gap this closes: nothing in this repo scanned git history for secrets
+# before this workflow existed. The local pre_commit hook (regex-based,
+# added-lines-only) is the fast local check and can be skipped with
+# YADM_ALLOW_SECRET=1 or --no-verify; CI cannot be skipped from a laptop.
+# Both layers, deliberately -- see symphony's secret-scan.yml for the same
+# split, reused here almost verbatim.
+#
+# Why no paths: filter, though it would cut run count: gitleaks and
+# trufflehog both scan FULL history (fetch-depth: 0) on every run, so
+# filtering by one push's changed files would skip a whole-history scan
+# just because the newest commit only touched a README. A path allowlist
+# would also gate the scan on the same "files we thought about" list whose
+# gaps are the actual leak path.
+#
+# Nothing here needs the age key. All three checks work on ciphertext (or
+# its absence) by design.
+
+on:
+  push:
+    branches: ['**']
+  workflow_dispatch:
+  schedule:
+    # Weekly re-scan of unchanged history. Not redundant: trufflehog ships
+    # new detectors continuously, so a commit that was clean last month can
+    # be flagged this month by a detector that didn't exist then.
+    - cron: "23 9 * * 1"
+
+# A session that pushes four times in two minutes only needs the newest
+# commit scanned; superseded runs are cancelled. Scheduled runs are exempt
+# -- the weekly sweep of unchanged history is the one run that must not be
+# cancelled by an unrelated push landing on the same ref.
+concurrency:
+  group: secret-scan-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'push' }}
+
+permissions:
+  contents: read
+
+jobs:
+  # Asserts every file .sops.yaml says should be encrypted actually is, in
+  # what git has committed -- not what's on disk locally.
+  secrets-encrypted:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - run: bash .github/scripts/verify_encrypted.sh
+
+  # Pattern/entropy scan over the entire history, not just the diff --
+  # catches a secret introduced in any commit on the branch, including one
+  # that a bypassed local hook let through.
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: gitleaks (full history)
+        run: |
+          docker run --rm -v "$PWD:/repo" -w /repo \
+            zricethezav/gitleaks:v8.30.1 \
+            git --no-banner --redact --verbose \
+            --config /repo/.gitleaks.toml \
+            --exit-code 1
+
+  # Complements gitleaks rather than duplicating it: trufflehog calls the
+  # provider API to check whether a candidate credential is actually live.
+  # It fails only on confirmed-live secrets, so a red build here is never a
+  # false alarm and is always urgent.
+  trufflehog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: trufflehog (verified-live secrets, full history)
+        run: bash .github/scripts/scan_verified_secrets.sh

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,52 @@
+name: Shellcheck
+
+# Syntax/correctness lint for every tracked shell script. Worth having on
+# its own rather than folded into secret-scan.yml: this catches a different
+# class of mistake, and the scripts here are exactly the ones CLAUDE.md
+# flags for extra scrutiny -- .claude/hooks/*, .config/yadm/hooks/*, and
+# .config/yadm/bootstrap all execute automatically (session start/stop, git
+# commit, machine bootstrap). A shellcheck-caught bug in one of those is a
+# bug that runs unattended on every session or every commit, on every
+# machine, at the next dotsync.
+#
+# Runs on every branch push, not just PRs against main: a claude/* branch
+# pushed without a PR should still get feedback at push time, same
+# reasoning as secret-scan.yml.
+
+on:
+  push:
+    branches: ['**']
+  workflow_dispatch:
+
+concurrency:
+  group: shellcheck-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - name: shellcheck
+        run: |
+          set -euo pipefail
+          command -v shellcheck || (sudo apt-get update && sudo apt-get install -y shellcheck)
+          # --severity=warning: at the point this job was added, the
+          # existing scripts already carried ~20 info/style-level notes
+          # (SC1091 unfollowed sources, SC2015 A&&B||C, SC2012/13/16) and
+          # nothing at warning or above. Failing on those would make this
+          # job red on day one over pre-existing style, not a bug it
+          # caught -- exactly the "gate that cries wolf" failure mode.
+          # Tightening to catch style too is a deliberate later choice, not
+          # a default.
+          #
+          # POSIX sh scripts (see CLAUDE.md: bootstrap, pre_commit run where
+          # bash may not be what /bin/sh points at) get -s sh; everything
+          # else here is bash-shebanged and checked as such.
+          shellcheck --severity=warning -s sh .config/yadm/bootstrap .config/yadm/hooks/pre_commit
+          shellcheck --severity=warning .claude/hooks/*.sh .claude/cloud-setup.sh .local/bin/*.sh

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,28 @@
+# gitleaks configuration.
+#
+# Uses the full upstream ruleset unmodified and narrows it only where a
+# finding is provably not a secret. Do not redefine upstream rules here --
+# the built-in patterns are more carefully written than a hand-rolled
+# replacement.
+#
+# Before adding an allowlist entry, ask whether the value should instead be
+# encrypted (sops) or removed. Allowlisting is the last resort, not the
+# first fix. Keep every entry scoped with condition = "AND" so it silences
+# one string in one place, never a whole file -- a blanket path exclusion
+# also silences every future rule on that file, which is how scanners
+# quietly stop working.
+
+[extend]
+useDefault = true
+
+# sops ciphertext is high-entropy by construction. Flagging it would mean
+# flagging the mechanism working correctly. The age *public* key in
+# .sops.yaml is likewise not a secret -- it is published so anyone can
+# encrypt to this host; the private key never enters the repo (it lives at
+# ~/.config/sops/age/keys.txt, gitignored, and is never tracked).
+[[allowlists]]
+description = "sops ciphertext and the age public recipient are not secrets"
+regexes = [
+  '''ENC\[AES256_GCM,data:[A-Za-z0-9+/=,_-]+\]''',
+  '''age1[0-9a-z]{58}''',
+]


### PR DESCRIPTION
Brings dotfiles up to the same leak-detection rigor symphony already has. Reuses symphony's secret-scan.yml pattern almost verbatim, scoped down for this repo's simpler whole-file-only sops layout (no `.gitattributes` clean/smudge filter here, so no sops-config-consistency job and no python secret-tooling test suite).

## Added
- **`.gitleaks.toml` + `secret-scan.yml`** — gitleaks (full-history pattern/entropy) and trufflehog (full-history, verified-live-only) on every branch push plus a weekly re-scan.
- **`.github/scripts/verify_encrypted.sh`** — asserts every path `.sops.yaml` says should be encrypted actually is, in what git has committed. Survives `--no-verify` / `YADM_ALLOW_SECRET=1`, unlike the local `pre_commit` hook.
- **`.github/scripts/scan_verified_secrets.sh`** — trufflehog wrapper, never prints raw secret values (this repo's Actions logs are public).
- **`shellcheck.yml`** — lints every tracked shell script at `--severity=warning`. Existing scripts only carry info/style-level notes today, so warning is the bar that doesn't cry wolf on day one. Extra weight here since CLAUDE.md already flags `.claude/hooks/*`, `.config/yadm/hooks/*`, and `bootstrap` as auto-executing.
- **`dependabot.yml`** — weekly `github-actions` version bumps.

## Also done (not in this diff)
Enabled GitHub-native secret scanning + push protection via the repo's `security_and_analysis` API — free for public repos, no billing. This was off here and on in symphony; biggest single gap, zero cost to close.

All four local checks (verify_encrypted.sh, gitleaks, trufflehog, shellcheck) ran clean against this repo's current history before pushing.

## Left alone, deliberately
- `claude-security-review.yml` — already carded as blocked on an `ANTHROPIC_API_KEY` billing decision, not re-litigated here.
- `.secrets.baseline` — committed once, never wired to anything that runs it. Worth deleting now that gitleaks/trufflehog cover this ground, but that's a separate call.
- No required-status-checks on the branch ruleset — matches symphony's documented policy and this repo's direct-push-to-main model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated secret scanning for pushes, scheduled runs, and manual checks.
  * Added validation to ensure tracked secret files are encrypted.
  * Added ShellCheck validation for shell scripts.
  * Added weekly automated updates for GitHub Actions dependencies.

* **Security**
  * Improved credential detection across the full repository history.
  * Added tailored scanning rules to reduce false positives for encrypted content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->