### PR TITLE
ci: raise claude-code-review --max-turns 8 -> 20

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -57,6 +57,11 @@ jobs:
             top-level summary. If you find nothing, say so briefly instead of inventing
             findings.
 
+          # 8 turns was not enough once a PR touched a few hundred lines: the
+          # run ended "Reached maximum number of turns" and posted nothing --
+          # a red X meaning "the reviewer ran out of budget", indistinguishable
+          # from a real finding. Comments cannot go inside claude_args; the
+          # action passes that block through to the CLI verbatim.
           claude_args: |
-            --max-turns 8
+            --max-turns 20
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
The `review` job went red on #43 with `Reached maximum number of turns (8)` and posted no findings. It passed on that same branch two runs earlier and started failing once the friction diff grew to a few hundred lines — the budget, not the code. A run that dies that way is a red X meaning "the reviewer ran out of turns", which is indistinguishable from a real finding.

Split out of #43 rather than carried on it: `claude-code-action` skips entirely when the workflow file differs from the default branch, so bumping this on a feature branch turns the check **green without reviewing anything** — a worse failure than the red one, because it looks clean.

```
##[warning]Skipping action due to workflow validation: ... must ... have identical
content to the version on the repository's default branch.
```

This has to land on `main` first; #43 then rebases onto it and gets a real 20-turn review.

The comment sits above `claude_args`, not inside it — the action passes that block to the CLI verbatim, so a `#` line there would become an argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the automated code review workflow’s available processing turns.
  * Added documentation clarifying turn-budget behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->