### PR TITLE
ci: raise claude-code-review --max-turns 20 -> 60

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -57,11 +57,12 @@ jobs:
             top-level summary. If you find nothing, say so briefly instead of inventing
             findings.
 
-          # 8 turns was not enough once a PR touched a few hundred lines: the
-          # run ended "Reached maximum number of turns" and posted nothing --
-          # a red X meaning "the reviewer ran out of budget", indistinguishable
-          # from a real finding. Comments cannot go inside claude_args; the
+          # A cap that a normal review exceeds is not a guard, it is a second
+          # failure mode: 8 died mid-review posting nothing, and 20 failed the
+          # job *after* Claude had finished and posted a clean review in 28
+          # turns. This is a runaway backstop only, so it sits well above what
+          # a real review costs. Comments cannot go inside claude_args; the
           # action passes that block through to the CLI verbatim.
           claude_args: |
-            --max-turns 20
+            --max-turns 60
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
Follow-up to #48. 20 was still too low, and it failed in a new way: on #43 Claude finished the review, posted a clean "nothing new found" summary, and the action *then* failed the job with `Claude reported a successful result after 28 turns, exceeding the configured maximum of 20`. A successful review that reports red is worse than no review.

A cap that a normal review exceeds isn't a guard, it's a second failure mode. 60 is a runaway backstop, well above what a real review on this repo costs (28 measured, on the largest diff here so far).

Split out rather than carried on #43 for the same reason as #48: `claude-code-action` skips itself when the workflow file differs from the default branch, which turns the check green without reviewing anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the automated code review workflow’s maximum turn limit.
  * Updated review guidance to clarify that the limit serves as a safeguard against runaway processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->