### PR TITLE
Installer atomicity, .sync-status.json, SessionStart brief line (#17 P1)

### DIFF
--- a/.claude/hooks/session-start-continuity.sh
+++ b/.claude/hooks/session-start-continuity.sh
@@ -27,8 +27,34 @@ emit() {
 
 command -v jq >/dev/null 2>&1 || exit 0
 
+# Config sync status (strategy doc §6.7/§13 P1) -- one line, folded into this
+# hook rather than a hook of its own, since a new hook doubles the fixed
+# context tax every session pays. Cloud-only: a real machine is yadm-managed,
+# never runs the installer, and would never have this file -- printing
+# DEGRADED there would be a false alarm, not a signal.
+sync_status_line() {
+  [ "${CLAUDE_CODE_REMOTE:-}" = true ] || return 0
+  SF="$HOME/.claude/.sync-status.json"
+  if [ ! -f "$SF" ]; then
+    echo "config: DEGRADED — no .sync-status.json (installer never ran, or predates P1)"
+    return 0
+  fi
+  complete=$(jq -r '.complete' "$SF" 2>/dev/null)
+  sha=$(jq -r '.sha' "$SF" 2>/dev/null | cut -c1-7)
+  channel=$(jq -r '.channel' "$SF" 2>/dev/null)
+  at=$(jq -r '.installed_at' "$SF" 2>/dev/null)
+  if [ "$complete" != true ]; then
+    echo "config: DEGRADED — incomplete install ($channel@$sha, $at)"
+  else
+    echo "config: $channel@$sha (installed $at)"
+  fi
+}
+CONFIG_LINE=$(sync_status_line)
+
 if ! SR=$(state_repo); then
-  cat <<'MSG' | emit
+  {
+    [ -n "$CONFIG_LINE" ] && printf '%s\n\n' "$CONFIG_LINE"
+    cat <<'MSG'
 ## Continuity: state repo NOT available
 
 `claude_prompts_scratch` is not checked out here, so the board, the prior
@@ -44,6 +70,7 @@ you. Cloud environments configure only name, network access, environment
 variables and a setup script -- repositories attach per session, and the
 GitHub proxy 403s any repo not attached, so a setup script cannot clone this.
 MSG
+  } | emit
   exit 0
 fi
 
@@ -53,6 +80,7 @@ SD="$SR/state/global"
 timeout 25 git -C "$SR" pull --rebase --autostash -q >/dev/null 2>&1 || true
 
 {
+  [ -n "$CONFIG_LINE" ] && { printf '%s\n' "$CONFIG_LINE"; echo; }
   echo "## Continuity brief"
   echo
   echo "State repo: \`$SR\` (board, checkpoints and metrics live here; the Stop"

--- a/.local/bin/cloud-session-setup.sh
+++ b/.local/bin/cloud-session-setup.sh
@@ -257,12 +257,22 @@ done
 # without serialization is a delete of the release the other run just
 # pointed `current` at. Best-effort: a VM without flock, or a lock that
 # never frees, must still leave a session installable.
+#
+# Fail-open, but not into the race: a VM with no flock at all has nothing to
+# contend with and proceeds as before, while a lock that is held and times
+# out means another installer is mid-flip right now -- exactly when running
+# the GC unserialized is most likely to delete the release that run just
+# activated. There, ADVANCE=no: skip the flip, and link against whatever
+# `current` already resolves to. 20s, not longer: this runs inside a
+# SessionStart hook and an install takes well under a second, so a wait
+# that long already means the holder is wedged. Nothing needs to block;
+# this run simply doesn't move the release, and the next SessionStart will.
 LOCK="$CONFIG_DIR/.install.lock"
+ADVANCE=yes
 if [ "$DRY_RUN" = no ] && command -v flock >/dev/null 2>&1 &&
    mkdir -p "$CONFIG_DIR" 2>/dev/null && : >>"$LOCK" 2>/dev/null; then
   exec 9>>"$LOCK"
-  flock -w 60 9 2>/dev/null ||
-    warn "  no lock on $LOCK after 60s — continuing unserialized"
+  flock -w 20 9 2>/dev/null || ADVANCE=no
 fi
 
 flip() {
@@ -282,6 +292,12 @@ flip() {
 
 if [ "$DRY_RUN" = yes ]; then
   say "would flip $CONFIG_DIR/current -> releases/$REV"
+elif [ "$ADVANCE" = no ]; then
+  warn "another installer holds $LOCK — not advancing the release"
+  warn "  linking against whatever $CONFIG_DIR/current already holds"
+  # Only a failure if there is nothing to fall back to: an earlier release
+  # still serving the session is a stale install, not an incomplete one.
+  [ -e "$CONFIG_DIR/current" ] || failed=$((failed + 1))
 elif [ "$missing" -gt 0 ] || [ "$failed" -gt 0 ] || [ "$refused" -gt 0 ]; then
   # A partial stage must never be activated. $HOME reaches its whole
   # instruction set through `current`, so flipping to a tree that is missing

--- a/.local/bin/cloud-session-setup.sh
+++ b/.local/bin/cloud-session-setup.sh
@@ -30,8 +30,9 @@ set -uf
 SEED="${DOTFILES_SEED:-$HOME/.local/share/dotfiles-seed}"
 BACKUP="$HOME/.dotfiles-replaced"
 # Versioned releases + the "current" symlink that makes an install atomic --
-# see "Stage" and "Flip" below. Overridable so a test run doesn't touch a
-# real $HOME/.claude-config.
+# see "Stage" and "Flip" below. Overridable, but on its own it is NOT a test
+# harness: the Link step still writes symlinks under the real $HOME, and
+# STATUS_FILE is still under it. Isolating a run means overriding $HOME.
 CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude-config}"
 STATUS_FILE="$HOME/.claude/.sync-status.json"
 DRY_RUN=no
@@ -194,7 +195,11 @@ fi
 # and $HOME never sees the difference until the flip below. A file dropped
 # from INSTALL simply isn't copied -- no separate prune step needed, unlike
 # the old per-file-copy design this replaced.
-REV=$(git -C "$SEED" rev-parse HEAD 2>/dev/null) || REV=unknown
+# The release name must identify its content: the flip below reuses an
+# existing release rather than rebuilding it, which is only sound because a
+# git SHA pins exactly what was staged. With no SHA to be had, fall back to a
+# name unique to this run so that shortcut can never match a stale tree.
+REV=$(git -C "$SEED" rev-parse HEAD 2>/dev/null) || REV="unknown.$$"
 STAGE="$CONFIG_DIR/releases/$REV"
 STAGE_TMP="$CONFIG_DIR/releases/.tmp.$$"
 CURRENT_TMP="$CONFIG_DIR/.current.$$"
@@ -244,19 +249,53 @@ done
 # this script targets) is load-bearing here -- plain `mv src dst` treats an
 # existing symlink-to-directory `dst` as that directory and moves `src`
 # *into* it instead of replacing it.
+flip() {
+  ln -s "$STAGE" "$CURRENT_TMP" &&
+    mv -T "$CURRENT_TMP" "$CONFIG_DIR/current" ||
+    { warn "  FAILED to flip current to releases/$REV"; failed=$((failed + 1)); return 1; }
+  say "  flipped current -> releases/$REV"
+  # Superseded releases go only after the flip, never before it: every $HOME
+  # symlink now resolves through the new one. Without this a checkpointed
+  # container accumulates a full tree per seed commit, forever.
+  set +f
+  for old in "$CONFIG_DIR"/releases/*; do
+    [ -d "$old" ] && [ "$old" != "$STAGE" ] && rm -rf "$old"
+  done
+  set -f
+}
+
 if [ "$DRY_RUN" = yes ]; then
   say "would flip $CONFIG_DIR/current -> releases/$REV"
+elif [ "$missing" -gt 0 ] || [ "$failed" -gt 0 ] || [ "$refused" -gt 0 ]; then
+  # A partial stage must never be activated. $HOME reaches its whole
+  # instruction set through `current`, so flipping to a tree that is missing
+  # a hook or a rule file does not degrade the session gracefully -- it
+  # deletes that instruction. The previous release is complete; keep it.
+  warn "staging incomplete ($missing missing, $failed failed, $refused refused)"
+  warn "  leaving the previous release in place"
+  failed=$((failed + 1))
 elif [ ! -d "$STAGE_TMP" ]; then
   warn "staging produced nothing usable — leaving the previous release in place"
   failed=$((failed + 1))
+elif [ -d "$STAGE" ]; then
+  # The common path, not an edge case: session-start-seed-refresh.sh runs
+  # this installer on EVERY SessionStart, and the seed's SHA only moves when
+  # a commit lands upstream. $REV pins the content, so an existing release
+  # under that name already holds exactly what was just staged -- and
+  # `rm -rf "$STAGE"` to rebuild it would be a delete of the directory
+  # `current` is resolving through right then, leaving every $HOME symlink
+  # dangling until the mv landed and nothing at all if the run died between
+  # the two. Throw the redundant copy away and re-point instead; the flip is
+  # a no-op when current already points here.
+  say "  release $REV already staged — reusing it"
+  rm -rf "$STAGE_TMP"
+  flip
 else
-  mkdir -p "$CONFIG_DIR/releases" &&
-    rm -rf "$STAGE" &&
-    mv "$STAGE_TMP" "$STAGE" &&
-    ln -s "$STAGE" "$CURRENT_TMP" &&
-    mv -T "$CURRENT_TMP" "$CONFIG_DIR/current" &&
-    say "  flipped current -> releases/$REV" ||
-    { warn "  FAILED to flip current to releases/$REV"; failed=$((failed + 1)); }
+  if mkdir -p "$CONFIG_DIR/releases" && mv "$STAGE_TMP" "$STAGE"; then
+    flip
+  else
+    warn "  FAILED to stage releases/$REV"; failed=$((failed + 1))
+  fi
 fi
 
 # =========================================================================
@@ -267,8 +306,15 @@ fi
 # only place content ever changes. A directory in OWNED_DIRS is linked once
 # as a whole (so a file INSTALL later drops from it just disappears, with no
 # prune step); anything else is linked individually.
+# No release to point at means no linking: a symlink into a missing
+# `current` is worse than the real file it would replace.
+if [ "$DRY_RUN" = no ] && [ ! -e "$CONFIG_DIR/current" ]; then
+  warn "no usable release at $CONFIG_DIR/current — skipping Link"
+fi
+
 link_path() {
   rel=$1
+  [ "$DRY_RUN" = yes ] || [ -e "$CONFIG_DIR/current" ] || return
   dst="$HOME/$rel"
   target="$CONFIG_DIR/current/$rel"
 
@@ -330,12 +376,23 @@ done
 # install actually finished (R6/T7: a missing or stale file is the signal a
 # degraded session uses to say so, in the SessionStart brief).
 # =========================================================================
+# Report the release that is actually live, not the one this run tried to
+# build: when the flip is refused above, `sha` naming the rejected revision
+# would make the degraded session look current at exactly the moment the
+# status file matters most.
+ACTIVE=$REV
+if [ "$DRY_RUN" = no ]; then
+  target=$(readlink "$CONFIG_DIR/current" 2>/dev/null) || target=
+  [ -n "$target" ] && ACTIVE=${target##*/}
+fi
+
 BRANCH=$(git -C "$SEED" rev-parse --abbrev-ref HEAD 2>/dev/null) || BRANCH=main
 [ "$BRANCH" = HEAD ] && BRANCH=main   # detached checkout -- not expected yet, but not fatal
 NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 COMPLETE=true
 [ "$missing" -gt 0 ] && COMPLETE=false
 [ "$failed" -gt 0 ] && COMPLETE=false
+[ "$refused" -gt 0 ] && COMPLETE=false   # an allowlisted entry that did not install
 
 if [ "$DRY_RUN" = yes ]; then
   say "would write $STATUS_FILE (complete: $COMPLETE)"
@@ -344,7 +401,7 @@ else
 {
   "channel": "$BRANCH",
   "tag": null,
-  "sha": "$REV",
+  "sha": "$ACTIVE",
   "installed_at": "$NOW",
   "complete": $COMPLETE,
   "source": "cloud-session-setup.sh"
@@ -354,5 +411,5 @@ fi
 
 say "$installed staged, $linked linked, $refused refused, $missing missing, $failed failed"
 say "seed checkout: $SEED"
-say "config: $CONFIG_DIR/current -> releases/$REV (complete: $COMPLETE)"
+say "config: $CONFIG_DIR/current -> releases/$ACTIVE (complete: $COMPLETE)"
 exit 0

--- a/.local/bin/cloud-session-setup.sh
+++ b/.local/bin/cloud-session-setup.sh
@@ -416,7 +416,10 @@ else
   # Staged and renamed, not truncated in place: session-start-continuity.sh
   # reads this file, and a parallel session catching it mid-write would parse
   # an empty document and announce a DEGRADED session that isn't one.
-  mkdir -p "$(dirname "$STATUS_FILE")" && cat >"$STATUS_TMP" <<EOF
+  # The rename is gated on the write: `mv` only cares that its source
+  # exists, so an unconditional one would publish a half-written temp over
+  # the previous good file -- the very corruption the temp exists to avoid.
+  if mkdir -p "$(dirname "$STATUS_FILE")" && cat >"$STATUS_TMP" <<EOF &&
 {
   "channel": "$BRANCH",
   "tag": null,
@@ -426,11 +429,13 @@ else
   "source": "cloud-session-setup.sh"
 }
 EOF
-  mv -f "$STATUS_TMP" "$STATUS_FILE" 2>/dev/null || {
+     mv -f "$STATUS_TMP" "$STATUS_FILE" 2>/dev/null; then
+    :
+  else
     warn "  FAILED to write $STATUS_FILE — the status below is what this run"
     warn "  intended, not what a later session will read"
     rm -f "$STATUS_TMP"
-  }
+  fi
 fi
 
 say "$installed staged, $linked linked, $refused refused, $missing missing, $failed failed"

--- a/.local/bin/cloud-session-setup.sh
+++ b/.local/bin/cloud-session-setup.sh
@@ -35,6 +35,7 @@ BACKUP="$HOME/.dotfiles-replaced"
 # STATUS_FILE is still under it. Isolating a run means overriding $HOME.
 CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude-config}"
 STATUS_FILE="$HOME/.claude/.sync-status.json"
+STATUS_TMP="$STATUS_FILE.$$"
 DRY_RUN=no
 [ "${1:-}" = "--dry-run" ] && DRY_RUN=yes
 
@@ -205,7 +206,7 @@ STAGE_TMP="$CONFIG_DIR/releases/.tmp.$$"
 CURRENT_TMP="$CONFIG_DIR/.current.$$"
 # A crash or interrupt mid-stage/mid-flip must never leave a half-built temp
 # behind for the next run to trip over -- both names are unique to this PID.
-trap 'rm -rf "$STAGE_TMP" "$CURRENT_TMP"' EXIT INT TERM
+trap 'rm -rf "$STAGE_TMP" "$CURRENT_TMP" "$STATUS_TMP"' EXIT INT TERM
 
 installed=0; refused=0; missing=0; failed=0; linked=0
 
@@ -249,6 +250,21 @@ done
 # this script targets) is load-bearing here -- plain `mv src dst` treats an
 # existing symlink-to-directory `dst` as that directory and moves `src`
 # *into* it instead of replacing it.
+# One installer at a time from here on. session-start-seed-refresh.sh runs
+# this on every SessionStart and a checkpointed container can host several
+# sessions at once, so two runs on different SHAs can reach the flip
+# together -- and the GC below deletes every release but its own, which
+# without serialization is a delete of the release the other run just
+# pointed `current` at. Best-effort: a VM without flock, or a lock that
+# never frees, must still leave a session installable.
+LOCK="$CONFIG_DIR/.install.lock"
+if [ "$DRY_RUN" = no ] && command -v flock >/dev/null 2>&1 &&
+   mkdir -p "$CONFIG_DIR" 2>/dev/null && : >>"$LOCK" 2>/dev/null; then
+  exec 9>>"$LOCK"
+  flock -w 60 9 2>/dev/null ||
+    warn "  no lock on $LOCK after 60s — continuing unserialized"
+fi
+
 flip() {
   ln -s "$STAGE" "$CURRENT_TMP" &&
     mv -T "$CURRENT_TMP" "$CONFIG_DIR/current" ||
@@ -397,7 +413,10 @@ COMPLETE=true
 if [ "$DRY_RUN" = yes ]; then
   say "would write $STATUS_FILE (complete: $COMPLETE)"
 else
-  mkdir -p "$(dirname "$STATUS_FILE")" && cat >"$STATUS_FILE" <<EOF
+  # Staged and renamed, not truncated in place: session-start-continuity.sh
+  # reads this file, and a parallel session catching it mid-write would parse
+  # an empty document and announce a DEGRADED session that isn't one.
+  mkdir -p "$(dirname "$STATUS_FILE")" && cat >"$STATUS_TMP" <<EOF
 {
   "channel": "$BRANCH",
   "tag": null,
@@ -407,6 +426,11 @@ else
   "source": "cloud-session-setup.sh"
 }
 EOF
+  mv -f "$STATUS_TMP" "$STATUS_FILE" 2>/dev/null || {
+    warn "  FAILED to write $STATUS_FILE — the status below is what this run"
+    warn "  intended, not what a later session will read"
+    rm -f "$STATUS_TMP"
+  }
 fi
 
 say "$installed staged, $linked linked, $refused refused, $missing missing, $failed failed"

--- a/.local/bin/cloud-session-setup.sh
+++ b/.local/bin/cloud-session-setup.sh
@@ -29,6 +29,11 @@ set -uf
 
 SEED="${DOTFILES_SEED:-$HOME/.local/share/dotfiles-seed}"
 BACKUP="$HOME/.dotfiles-replaced"
+# Versioned releases + the "current" symlink that makes an install atomic --
+# see "Stage" and "Flip" below. Overridable so a test run doesn't touch a
+# real $HOME/.claude-config.
+CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude-config}"
+STATUS_FILE="$HOME/.claude/.sync-status.json"
 DRY_RUN=no
 [ "${1:-}" = "--dry-run" ] && DRY_RUN=yes
 
@@ -66,25 +71,26 @@ INSTALL="
 .local/bin/metrics-preview.sh
 "
 
-# --- what to prune -------------------------------------------------------
-# Directories this script OWNS ENTIRELY: anything in them that is not in
-# INSTALL is a leftover from an older seed and is removed. Seeding without
-# pruning is why a deleted hook keeps running -- the container seeded it
-# once, the repo dropped it, and the $HOME copy is still there and still
-# wins. The $CLAUDE_PROJECT_DIR fallback does not save you: it fires only
-# when the $HOME path is ABSENT, which is exactly not this case.
+# --- what is wholly owned by this installer -------------------------------
+# Directories entirely populated by INSTALL entries below them: linked into
+# $HOME as a single symlink to the staged tree rather than mirrored file by
+# file. Nothing else ever writes here, so nothing is lost by treating the
+# whole directory as one unit -- and a directory INSTALL later drops from
+# these needs no separate prune step, because the next stage simply doesn't
+# contain it (see "Stage" below).
 #
 # Only wholly-owned leaf directories go here. `.claude` itself must NEVER
 # appear: it also holds state/, projects/, todos/ and settings.local.json,
 # none of which this script put there.
-PRUNE_DIRS='.claude/hooks .claude/rules'
+OWNED_DIRS='.claude/hooks .claude/rules'
 
-# A tripwire for PRUNE_DIRS, in the same spirit as SKIP_GLOBS: these are
-# shared directories that hold files this script never put there, so a prune
-# of one would delete a stranger's work. `.claude` is the live example --
-# INSTALL names files directly under it, which would otherwise make it look
-# prunable, and settings.local.json, state/ and projects/ all live there.
-PRUNE_NEVER='. .claude .config .local .local/bin .ssh'
+# A tripwire for OWNED_DIRS, in the same spirit as SKIP_GLOBS: these are
+# shared directories that hold files this script never put there, so linking
+# one as a whole would hide a stranger's files behind the symlink swap.
+# `.claude` is the live example -- INSTALL names files directly under it,
+# which would otherwise make it look owned, and settings.local.json, state/
+# and projects/ all live there.
+OWNED_NEVER='. .claude .config .local .local/bin .ssh'
 
 # The continuity hooks read and write the private state repo
 # (claude_prompts_scratch). This script cannot clone it -- a VM has no
@@ -181,60 +187,22 @@ fi
 
 
 # =========================================================================
-# Overwrite policy
+# Stage — build the next release in full, touching nothing under $HOME.
 # =========================================================================
-# Overwriting is the point on an ephemeral VM, but it is never silent and
-# never irreversible within the session:
-#   missing      -> install
-#   identical    -> no-op
-#   symlink      -> refuse (that is yadm-alt or another manager's file)
-#   differs      -> copy the old one to ~/.dotfiles-replaced/, then overwrite
-install_file() {
-  src=$1; rel=$2; dst="$HOME/$rel"
+# T3 (partial failure -> mixed instruction set) is fixed here, not by care
+# at install time: this stage either produces a complete tree or it doesn't,
+# and $HOME never sees the difference until the flip below. A file dropped
+# from INSTALL simply isn't copied -- no separate prune step needed, unlike
+# the old per-file-copy design this replaced.
+REV=$(git -C "$SEED" rev-parse HEAD 2>/dev/null) || REV=unknown
+STAGE="$CONFIG_DIR/releases/$REV"
+STAGE_TMP="$CONFIG_DIR/releases/.tmp.$$"
+CURRENT_TMP="$CONFIG_DIR/.current.$$"
+# A crash or interrupt mid-stage/mid-flip must never leave a half-built temp
+# behind for the next run to trip over -- both names are unique to this PID.
+trap 'rm -rf "$STAGE_TMP" "$CURRENT_TMP"' EXIT INT TERM
 
-  if [ -L "$dst" ]; then
-    warn "  REFUSED $rel — destination is a symlink, left alone"
-    refused=$((refused + 1)); return
-  fi
-
-  if [ -e "$dst" ] && cmp -s "$src" "$dst"; then
-    same=$((same + 1)); return
-  fi
-
-  if [ -e "$dst" ]; then
-    if [ "$DRY_RUN" = yes ]; then
-      say "  would REPLACE $rel (backup to ~/.dotfiles-replaced/$rel)"
-    else
-      mkdir -p "$BACKUP/$(dirname "$rel")" && cp -a "$dst" "$BACKUP/$rel" || {
-        warn "  FAILED to back up $rel — not overwriting"
-        failed=$((failed + 1)); return
-      }
-      cp -a "$src" "$dst" &&
-        say "  replaced $rel (old copy: ~/.dotfiles-replaced/$rel)" ||
-        { warn "  FAILED $rel"; failed=$((failed + 1)); return; }
-    fi
-    replaced=$((replaced + 1))
-  else
-    if [ "$DRY_RUN" = yes ]; then
-      say "  would install $rel"
-    else
-      mkdir -p "$(dirname "$dst")" && cp -a "$src" "$dst" ||
-        { warn "  FAILED $rel"; failed=$((failed + 1)); return; }
-      say "  installed $rel"
-    fi
-    installed=$((installed + 1))
-  fi
-}
-
-installed=0; replaced=0; same=0; refused=0; missing=0; failed=0; pruned=0
-
-# Flatten INSTALL (which may name directories) to one src<TAB>relpath per line
-# in a temp file. A file, not a pipe: `find | while` would run the loop in a
-# subshell and every counter above would be discarded at the end of it.
-TAB=$(printf '\t')
-LIST=$(mktemp) || exit 0
-PRUNE=$(mktemp) || exit 0
-trap 'rm -f "$LIST" "$PRUNE"' EXIT INT TERM
+installed=0; refused=0; missing=0; failed=0; linked=0
 
 for path in $INSTALL; do
   [ -n "$path" ] || continue
@@ -255,86 +223,136 @@ for path in $INSTALL; do
     missing=$((missing + 1)); continue
   fi
 
-  if [ -d "$src" ]; then
-    # walk the tree so the policy applies per file, not as a blanket copy
-    find "$src" -type f -exec printf '%s\t%s\n' '{}' "$path" \; >>"$LIST"
-  else
-    printf '%s\t%s\n' "$src" "$path" >>"$LIST"
+  if [ "$DRY_RUN" = yes ]; then
+    say "  would stage $path"
+    installed=$((installed + 1)); continue
   fi
+
+  dst="$STAGE_TMP/$path"
+  mkdir -p "$(dirname "$dst")" && cp -a "$src" "$dst" ||
+    { warn "  FAILED to stage $path"; failed=$((failed + 1)); continue; }
+  installed=$((installed + 1))
 done
 
-KEEP=$(mktemp) || exit 0
-trap 'rm -f "$LIST" "$KEEP" "$PRUNE"' EXIT INT TERM
-
-while IFS="$TAB" read -r src path; do
-  [ -n "${src:-}" ] || continue
-  case "$src" in
-    "$SEED/$path") rel=$path ;;                    # single file
-    *)             rel="$path/${src#"$SEED/$path/"}" ;;  # file within a dir
-  esac
-  # recorded before install_file, so a refused or failed copy is still never
-  # pruned -- prune removes only what this script has no business keeping
-  printf '%s\n' "$rel" >>"$KEEP"
-  install_file "$src" "$rel"
-done <"$LIST"
+# =========================================================================
+# Flip — atomically swap what "current" points to.
+# =========================================================================
+# The rename is the whole install: every path under $HOME that reaches its
+# content through $CONFIG_DIR/current (see "Link" below) changes target in
+# one filesystem operation, so a reader never sees half of $STAGE_TMP and
+# half of the previous release. `mv -T` (GNU, guaranteed on the Ubuntu VMs
+# this script targets) is load-bearing here -- plain `mv src dst` treats an
+# existing symlink-to-directory `dst` as that directory and moves `src`
+# *into* it instead of replacing it.
+if [ "$DRY_RUN" = yes ]; then
+  say "would flip $CONFIG_DIR/current -> releases/$REV"
+elif [ ! -d "$STAGE_TMP" ]; then
+  warn "staging produced nothing usable — leaving the previous release in place"
+  failed=$((failed + 1))
+else
+  mkdir -p "$CONFIG_DIR/releases" &&
+    rm -rf "$STAGE" &&
+    mv "$STAGE_TMP" "$STAGE" &&
+    ln -s "$STAGE" "$CURRENT_TMP" &&
+    mv -T "$CURRENT_TMP" "$CONFIG_DIR/current" &&
+    say "  flipped current -> releases/$REV" ||
+    { warn "  FAILED to flip current to releases/$REV"; failed=$((failed + 1)); }
+fi
 
 # =========================================================================
-# Prune — remove files under PRUNE_DIRS that INSTALL no longer names.
+# Link — point $HOME at "current", once. Never needs to move again.
 # =========================================================================
-# Same policy as an overwrite: never silent, never irreversible within the
-# session. The old file is copied to ~/.dotfiles-replaced/ before removal.
-prune_dir() {
-  rel_dir=$1
+# Every entry INSTALL names ends up reachable at $HOME/<path>, but not as a
+# copy: a symlink through $CONFIG_DIR/current, so the Flip step above is the
+# only place content ever changes. A directory in OWNED_DIRS is linked once
+# as a whole (so a file INSTALL later drops from it just disappears, with no
+# prune step); anything else is linked individually.
+link_path() {
+  rel=$1
+  dst="$HOME/$rel"
+  target="$CONFIG_DIR/current/$rel"
 
-  # A prune must never be able to walk outside a managed directory. Three
-  # independent checks, because one bad PRUNE_DIRS entry would be `rm`ing
-  # under $HOME: the relative path is literal and local, it is actually
-  # named by INSTALL, and every file found is re-checked against its dir.
-  case "$rel_dir" in
-    ''|/*|*..*|*'*'*|*'?'*|.|./*)
-      warn "  PRUNE SKIPPED '$rel_dir' — not a safe managed path"; return ;;
-  esac
-  for never in $PRUNE_NEVER; do
-    [ "$rel_dir" = "$never" ] && {
-      warn "  PRUNE SKIPPED $rel_dir — on the never-prune list"; return; }
-  done
-  grep -q "^$rel_dir/[^/]" "$KEEP" 2>/dev/null || {
-    warn "  PRUNE SKIPPED $rel_dir — INSTALL names nothing under it"; return; }
+  if [ -L "$dst" ] && [ "$(readlink "$dst")" = "$target" ]; then
+    return   # already correct -- most sessions, most runs
+  fi
 
-  dir="$HOME/$rel_dir"
-  [ -d "$dir" ] || return
-  [ -L "$dir" ] && { warn "  PRUNE SKIPPED $rel_dir — directory is a symlink"; return; }
-
-  # -maxdepth 1 -type f: regular files directly in the directory. Symlinks
-  # and subdirectories are left alone, as everywhere else in this script.
-  : >"$PRUNE"
-  find "$dir" -maxdepth 1 -type f -print >>"$PRUNE" 2>/dev/null
-
-  while IFS= read -r found; do
-    [ -n "${found:-}" ] || continue
-    base=${found##*/}
-    # belt and braces: the file must really be a direct child of $dir
-    [ "$found" = "$dir/$base" ] || { warn "  PRUNE SKIPPED $found — outside $rel_dir"; continue; }
-    rel="$rel_dir/$base"
-    grep -qx "$rel" "$KEEP" 2>/dev/null && continue   # in INSTALL, keep
-
+  if [ -e "$dst" ] || [ -L "$dst" ]; then
+    # A real file/dir here (or a symlink to somewhere else) is either a
+    # leftover from the old copy-based installer or something else's --
+    # never silently discarded, same policy as everywhere else in this
+    # script: back it up, then replace it.
     if [ "$DRY_RUN" = yes ]; then
-      say "  would PRUNE $rel (backup to ~/.dotfiles-replaced/$rel)"
-      pruned=$((pruned + 1)); continue
+      say "  would replace $rel with a symlink (backup to ~/.dotfiles-replaced/$rel)"
+      linked=$((linked + 1)); return
     fi
-    mkdir -p "$BACKUP/$rel_dir" && cp -a "$found" "$BACKUP/$rel" || {
-      warn "  FAILED to back up $rel — not pruning"; failed=$((failed + 1)); continue; }
-    rm -f "$found" &&
-      say "  pruned $rel — no longer in INSTALL (old copy: ~/.dotfiles-replaced/$rel)" ||
-      { warn "  FAILED to prune $rel"; failed=$((failed + 1)); continue; }
-    pruned=$((pruned + 1))
-  done <"$PRUNE"
+    mkdir -p "$BACKUP/$(dirname "$rel")" && rm -rf "${BACKUP:?}/${rel:?}" 2>/dev/null
+    cp -a "$dst" "$BACKUP/$rel" || {
+      warn "  FAILED to back up $rel — not linking"; failed=$((failed + 1)); return; }
+    rm -rf "$dst"
+  fi
+
+  if [ "$DRY_RUN" = yes ]; then
+    say "  would link $rel -> current/$rel"
+    linked=$((linked + 1)); return
+  fi
+  mkdir -p "$(dirname "$dst")" &&
+    ln -s "$target" "$dst" &&
+    { say "  linked $rel -> current/$rel"; linked=$((linked + 1)); } ||
+    { warn "  FAILED to link $rel"; failed=$((failed + 1)); }
 }
 
-for d in $PRUNE_DIRS; do
-  prune_dir "$d"
+for path in $INSTALL; do
+  [ -n "$path" ] || continue
+  owned=no
+  for dir in $OWNED_DIRS; do
+    case "$path" in
+      "$dir"/*) owned=yes; break ;;
+    esac
+  done
+  [ "$owned" = yes ] && continue   # reachable via its OWNED_DIRS symlink
+  link_path "$path"
 done
 
-say "$installed installed, $replaced replaced, $same unchanged, $pruned pruned, $refused refused, $missing missing, $failed failed"
+for dir in $OWNED_DIRS; do
+  blocked=no
+  for never in $OWNED_NEVER; do
+    [ "$dir" = "$never" ] && { blocked=yes; break; }
+  done
+  if [ "$blocked" = yes ]; then
+    warn "  REFUSED to link $dir — on the never-own list"
+    continue
+  fi
+  link_path "$dir"
+done
+
+# =========================================================================
+# Status — written last, so its mere presence with complete:true means the
+# install actually finished (R6/T7: a missing or stale file is the signal a
+# degraded session uses to say so, in the SessionStart brief).
+# =========================================================================
+BRANCH=$(git -C "$SEED" rev-parse --abbrev-ref HEAD 2>/dev/null) || BRANCH=main
+[ "$BRANCH" = HEAD ] && BRANCH=main   # detached checkout -- not expected yet, but not fatal
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+COMPLETE=true
+[ "$missing" -gt 0 ] && COMPLETE=false
+[ "$failed" -gt 0 ] && COMPLETE=false
+
+if [ "$DRY_RUN" = yes ]; then
+  say "would write $STATUS_FILE (complete: $COMPLETE)"
+else
+  mkdir -p "$(dirname "$STATUS_FILE")" && cat >"$STATUS_FILE" <<EOF
+{
+  "channel": "$BRANCH",
+  "tag": null,
+  "sha": "$REV",
+  "installed_at": "$NOW",
+  "complete": $COMPLETE,
+  "source": "cloud-session-setup.sh"
+}
+EOF
+fi
+
+say "$installed staged, $linked linked, $refused refused, $missing missing, $failed failed"
 say "seed checkout: $SEED"
+say "config: $CONFIG_DIR/current -> releases/$REV (complete: $COMPLETE)"
 exit 0

--- a/README.md
+++ b/README.md
@@ -134,11 +134,20 @@ Two guards make the `INSTALL` allowlist safe to expand:
 * It **refuses to run where `$HOME` is yadm-managed** — every real machine has
   a yadm repo, an ephemeral VM never does — and skips entirely unless
   `CLOUD_SESSION=1` or `CLAUDE_CODE_REMOTE=true`.
-* Overwriting is necessary on a VM but never silent: identical files are a
-  no-op, a symlink destination is refused as some other manager's, and a
-  differing file is copied to `~/.dotfiles-replaced/` before being replaced.
-  `SKIP_GLOBS` hard-blocks `.gitconfig*`, `.gitignore` and anything
-  sops-shaped even if added to `INSTALL` by mistake.
+* The install itself is atomic: every INSTALL entry is staged into a
+  versioned `~/.claude-config/releases/<sha>/` directory, then a single
+  symlink flip (`~/.claude-config/current`) is the only step that changes
+  what a session actually reads — a session never sees half the old set and
+  half the new one. `$HOME` paths reach that content through their own
+  symlinks into `current`, created once and never touched again. A real
+  file found where a symlink belongs (a leftover from before this design, or
+  something else's) is copied to `~/.dotfiles-replaced/` before being
+  replaced — never silently discarded. `SKIP_GLOBS` hard-blocks
+  `.gitconfig*`, `.gitignore` and anything sops-shaped even if added to
+  `INSTALL` by mistake. `~/.claude/.sync-status.json`, written last, records
+  what actually landed — channel, sha, timestamp and whether the install
+  came out complete — and a missing or `complete: false` file is what the
+  SessionStart brief reports as a degraded session.
 
 A fourth scar: **the setup script runs once, at container creation, not once
 per session.** Containers are checkpointed and reused, so the seed froze at
@@ -148,13 +157,16 @@ pulls the seed before installing from it, and `session-start-seed-refresh.sh`
 re-runs it on every SessionStart — live rather than pinned, because a stale
 standing order in an interactive session is worse than a changed one.
 
-A fifth scar: **seeding without pruning is why a deleted hook keeps running.**
-The container seeded it once, the repo dropped it, and the `$HOME` copy is still
-there and still wins. `PRUNE_DIRS` names the directories the script wholly owns,
-where anything not in `INSTALL` is a leftover and gets removed; `PRUNE_NEVER` is
-the tripwire for shared directories like `.claude` itself, which also holds
-`state/`, `projects/`, `todos/` and `settings.local.json` that the script never
-put there.
+A fifth scar: **seeding without pruning is why a deleted hook kept running.**
+The container seeded it once, the repo dropped it, and the `$HOME` copy was
+still there and still won. The atomic redesign above fixes this structurally
+rather than by sweeping stale files: `OWNED_DIRS` names the directories the
+script wholly owns and links into `$HOME` as a whole (`.claude/hooks`,
+`.claude/rules`), so a file dropped from `INSTALL` just isn't in the next
+staged release — no separate prune step to keep in sync. `OWNED_NEVER` is the
+tripwire for shared directories like `.claude` itself, which also holds
+`state/`, `projects/`, `todos/` and `settings.local.json` that the script
+never put there.
 
 `sh .local/bin/cloud-session-setup.sh --dry-run` previews the whole thing and
 is safe to run on any machine, including yadm-managed ones.

--- a/README.md
+++ b/README.md
@@ -147,7 +147,10 @@ Two guards make the `INSTALL` allowlist safe to expand:
   `INSTALL` by mistake. `~/.claude/.sync-status.json`, written last, records
   what actually landed — channel, sha, timestamp and whether the install
   came out complete — and a missing or `complete: false` file is what the
-  SessionStart brief reports as a degraded session.
+  SessionStart brief reports as a degraded session. A stage that came up
+  short — a source missing, a copy failed — is discarded rather than
+  activated, so the previous complete release keeps serving the session;
+  superseded releases are removed only after a flip, never before one.
 
 A fourth scar: **the setup script runs once, at container creation, not once
 per session.** Containers are checkpointed and reused, so the seed froze at

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -200,9 +200,12 @@ decision, not a default.
 seed script reads are set inline by the paste blob (`CLOUD_SESSION=1`) or by the
 harness (`CLAUDE_CODE_REMOTE=true`), so the field stays empty.
 
-**Verify** on the next session: `session-start-continuity.sh` prints the board
-at the top. If it instead prints a "state repo NOT available" notice, step 2
-did not take — see [attaching it to a running
+**Verify** on the next session: `session-start-continuity.sh` prints a
+`config: <channel>@<sha> (installed <timestamp>)` line, then the board. A
+`config: DEGRADED` line means the installer never ran or didn't finish —
+see [a deleted hook keeps running](#a-deleted-hook-keeps-running) for the
+same `~/.claude/.sync-status.json` check. If it instead prints a "state repo
+NOT available" notice, step 2 did not take — see [attaching it to a running
 session](#attach-the-state-repo-to-a-running-session).
 
 ## Attach the state repo to a running session
@@ -238,10 +241,11 @@ Two guards make expansion safe, and both will simply refuse rather than warn:
 - The script refuses to run where `$HOME` is yadm-managed, and skips entirely
   unless `CLOUD_SESSION=1` or `CLAUDE_CODE_REMOTE=true`.
 
-If the new file lives in a directory not already in `PRUNE_DIRS`, decide
+If the new file lives in a directory not already in `OWNED_DIRS`, decide
 whether that directory is *wholly owned* by this script. Only wholly-owned leaf
-directories go in `PRUNE_DIRS`; `PRUNE_NEVER` lists the shared ones that must
-never be pruned.
+directories go in `OWNED_DIRS` — the script links them into `$HOME` as a
+single symlink to the staged release rather than mirroring them file by file;
+`OWNED_NEVER` lists the shared ones that must never be linked that way.
 
 **Every hook `.claude/settings.json` references must be in `INSTALL`.** A hook
 wired in settings but missing from the seed is a silent no-op in every cloud
@@ -560,15 +564,24 @@ purpose; that is a stale session, not a broken one.
 
 ## A deleted hook keeps running
 
-The container seeded it once, the repo dropped it, and the `$HOME` copy is
-still there. Hook commands resolve against `$HOME/.claude/hooks/` and the file
-is present, so it runs — removing it from the repo changed nothing about this
-container.
+`$HOME/.claude/hooks` is a symlink to `~/.claude-config/current/.claude/hooks`
+(and `.claude/rules` the same), so a file dropped from `INSTALL` simply isn't
+in the next staged release — there is no separate prune step to fall out of
+sync, unlike the per-file-copy design this replaced. If a stale hook is still
+running, check first that its directory is actually in `OWNED_DIRS` in
+`.local/bin/cloud-session-setup.sh` — a file outside those two directories is
+linked individually and a rename can leave the old name behind:
 
-This is what `PRUNE_DIRS` in `.local/bin/cloud-session-setup.sh` exists for: any
-file in a pruned directory that is not in `INSTALL` is removed on the next seed.
-If a stale hook survived, its directory is not in `PRUNE_DIRS`. Add it if the
-script wholly owns that directory; delete the file by hand either way.
+```bash
+ls -la ~/.claude/hooks   # should be a symlink -> ~/.claude-config/current/.claude/hooks
+cat ~/.claude/.sync-status.json   # sha/installed_at of what's actually live
+```
+
+If the symlink target is stale (points at a release dir other than
+`~/.claude-config/current`'s own target, or is missing), re-run the installer:
+`CLOUD_SESSION=1 sh ~/.local/share/dotfiles-seed/.local/bin/cloud-session-setup.sh`.
+If the hook's directory isn't in `OWNED_DIRS` at all, add it there — that's the
+structural fix, not a one-off `rm`.
 
 ## Nothing decrypts on a new machine
 


### PR DESCRIPTION
Implements [strategy doc §13 P1](.claude/docs/config-sync-strategy.md#13-rollout): installer atomicity + status file + SessionStart brief line, still tracking `main` — no ceremony change yet (that's P2).

## What changed

**`cloud-session-setup.sh` — stage-then-symlink.** Every `INSTALL` entry is staged into a versioned `~/.claude-config/releases/<sha>/` directory, then a single symlink flip (`~/.claude-config/current`) is the only step that changes what a session actually reads. A crash at any point leaves the previous release fully intact — fixes **T3** (partial failure → mixed instruction set).

`$HOME` paths reach that content through symlinks into `current`, created once and never touched again. `OWNED_DIRS` (`.claude/hooks`, `.claude/rules`) are linked whole, so a file dropped from `INSTALL` simply isn't in the next staged release — no prune step to keep in sync, replacing the old `PRUNE_DIRS` sweep. A real file found where a symlink belongs (a leftover from the old copy-based installer, or something else's) is backed up to `~/.dotfiles-replaced/` before being replaced, same policy as before.

**`.sync-status.json`**, written last: `{channel, tag, sha, installed_at, complete, source}`. `tag` is `null` — no signed releases yet (P2). Its absence or `complete: false` is the degraded signal.

**SessionStart brief line**, folded into `session-start-continuity.sh` per §6.7 rather than a new hook: `config: <channel>@<sha> (installed <ts>)`, or `config: DEGRADED — <reason>`. Cloud-only (gated on `CLAUDE_CODE_REMOTE`) so a real yadm-managed machine never sees a false DEGRADED — fixes **T7** (silent staleness) for the cloud installer path.

**Docs**: README's design-rationale section and RUNBOOK's cloud-environment / troubleshooting sections updated for the new mechanism (`PRUNE_DIRS`/`PRUNE_NEVER` → `OWNED_DIRS`/`OWNED_NEVER`, the new verify step).

## Review round (4 follow-up commits)

Review found the flip unsafe on the path it runs most, plus four smaller holes. All fixed:

- **Never rebuild a release under a live `current`.** `session-start-seed-refresh.sh` re-runs this installer at every SessionStart, so most runs land on an unchanged `$REV` — where `rm -rf "$STAGE"` deleted the exact directory `current` was resolving through. A git SHA pins content, so an existing release under that name already holds what was just staged: reuse and re-point instead. With no SHA to be had, `$REV` falls back to a run-unique name so that shortcut can never match a stale tree.
- **Never activate a partial stage.** `$HOME` reaches its whole instruction set through `current`; flipping to a tree missing a hook doesn't degrade a session, it deletes an instruction. Missing/failed/refused all block the flip and all count against `complete`, and `sha` now reports the release that is actually live rather than the one the run tried to install.
- **Garbage-collect superseded releases** after the flip, never before — otherwise a checkpointed container keeps one full tree per seed commit forever.
- **Serialize with `flock`.** Several sessions can share a container, and the GC deletes every release but its own. A *contended* timeout (20s) skips the flip and links against whatever `current` holds rather than failing open into the race; a VM with no `flock` at all proceeds as before.
- **Write `.sync-status.json` atomically**, with the rename gated on the write actually succeeding — a torn read is exactly the false DEGRADED this file exists to prevent.

Not taken: CodeRabbit's suggestion of a *unique* release directory per install. Content-addressing by SHA plus the reuse branch achieves the same guarantee with less machinery, and keeps the release set to one directory per commit rather than one per session start.

## Verified

- concurrent installs (3 at once) leave `current` and every `$HOME` symlink resolving
- a held lock: the run warns, advances nothing, and reports the live sha
- a short stage (an `INSTALL` entry deleted from the seed): `current` unchanged, `complete: false`
- a forced status-write failure (read-only `~/.claude`): warns, prior good file intact, no temp left behind
- `--dry-run` against the real seed
- a from-scratch install into a scratch `$HOME`
- idempotent re-run (0 linked, 0 failed on the second pass)
- the migration path from the old copy-based installer's leftover real files/dirs (backed up, then replaced with symlinks)
- `shellcheck --severity=warning` clean on both changed scripts (repo's CI bar)
- the `hook-seed-check.yml` INSTALL/settings.json cross-check still passes unmodified (the `INSTALL` list's shape is unchanged)

## Not in scope here

P2 (signed-tag channel, release script, ruleset) and P4 (local Stop-hook push / SessionStart fetch-and-notify) are separate phases per §13; this PR is P1 only.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9zWXvHbmB6c2JBNHbiGCs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added installation status reporting with release channel, revision, installation time, and completeness details.
  - Added degraded-session diagnostics when configuration sync is unavailable or incomplete.
  - Improved configuration installation with atomic, versioned releases and safer replacement handling.
  - Protected shared and sensitive configuration content from unintended changes.
  - Removed stale content from fully owned configuration directories while preserving shared data.

- **Documentation**
  - Updated installer and continuity guidance with status verification, ownership rules, and troubleshooting steps for stale configuration links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->