### PR TITLE
Bound the Claude review job by wall clock, not turns

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -29,6 +29,12 @@ jobs:
       !github.event.pull_request.draft &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    # The cost guard. Wall clock is the resource actually worth bounding, and
+    # unlike --max-turns it cannot fail a run that already did its job: a
+    # review that posted and finished has finished, however many turns it
+    # took. Reviews have run 3-5 min; this is a runaway backstop, not a
+    # target.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
         with:
@@ -57,11 +63,15 @@ jobs:
             top-level summary. If you find nothing, say so briefly instead of inventing
             findings.
 
-          # 8 turns was not enough once a PR touched a few hundred lines: the
-          # run ended "Reached maximum number of turns" and posted nothing --
-          # a red X meaning "the reviewer ran out of budget", indistinguishable
-          # from a real finding. Comments cannot go inside claude_args; the
+          # No --max-turns, deliberately. It produced two false reds and zero
+          # true ones: at 8 it killed a review of a few-hundred-line diff
+          # mid-flight and posted nothing, and at 20 it failed the job AFTER
+          # Claude had posted a clean review in 21 turns -- the action treats
+          # "succeeded, but over budget" as an error, so the red X means "the
+          # reviewer ran long", indistinguishable from a real finding on the
+          # PR it is guarding. Turn count is not the cost worth bounding;
+          # timeout-minutes on the job above is, and it cannot discard work
+          # that already landed. Comments cannot go inside claude_args; the
           # action passes that block through to the CLI verbatim.
           claude_args: |
-            --max-turns 20
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
`--max-turns` on `claude-code-review.yml` has produced **two false reds and zero true ones**:

- at `8`, it killed a review of a few-hundred-line diff mid-flight and posted nothing;
- at `20`, on [PR #50](https://github.com/mark-brannan/dotfiles/pull/50), it failed the job *after* Claude had posted a clean review — `Claude reported a successful result after 21 turns, exceeding the configured maximum of 20`.

The action treats "succeeded, but over budget" as an error, so the red X reads as a finding on the PR it is guarding. Raising the number again just relocates the next false red — this is the third time.

Turn count was never the resource worth capping. This drops `--max-turns` entirely and puts `timeout-minutes: 15` on the job instead: wall clock is the real cost, and a job timeout cannot discard a review that already posted. Recent reviews run 3–5 minutes, so 15 is a runaway backstop, not a target.

This PR's own review run exercises the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a 15-minute safeguard to prevent review jobs from running indefinitely.
  * Reviews can now continue until completion or the time limit is reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->