### PR TITLE
night_nag: check Pacific time, not the host's TZ

### DIFF
--- a/.claude/hooks/lib-metrics-fmt.jq
+++ b/.claude/hooks/lib-metrics-fmt.jq
@@ -107,10 +107,13 @@ def split: " ☺ \(.human_seconds | dur)/⚙ \(.agent_seconds | dur)";
 # statusline, which renders too often for an escalating nag to feel like
 # anything but noise.
 
-# Local hour via jq's `localtime`, which reads the *host's* TZ (the one the
-# statusline process actually runs under) -- not UTC, not a hardcoded zone.
+# Pacific hour, not the host's TZ. An ephemeral/cloud session's host clock
+# is usually UTC, which made this fire "LATE!" every Pacific evening. TZOFF
+# is the US/Pacific UTC offset in seconds, an env var the caller computes
+# (jq has no timezone database of its own); defaults to PST (-8h) if unset.
 def night_nag:
-  (now | localtime) as $lt
+  (($ENV.TZOFF // "-28800") | tonumber) as $tzoff
+  | (now + $tzoff | gmtime) as $lt
   | ($lt[3]) as $h24
   | ($lt[4]) as $m
   | if $h24 >= 22 or $h24 < 5

--- a/.claude/hooks/metrics-live.sh
+++ b/.claude/hooks/metrics-live.sh
@@ -266,6 +266,17 @@ printf '%s\n' "$metrics" | jq -c \
 # event, a pulse tick, the end of the session -- and never sent to the
 # model, so the running decision count costs nothing to display.
 if [ "$SHOW" = show ] && [ -f "$OUT" ]; then
+  # night_nag needs Pacific time, not the host's TZ -- an ephemeral/cloud
+  # session usually runs UTC, which read as "LATE!" all evening. Compute the
+  # US/Pacific UTC offset here (handles PST/PDT) and hand it to jq as seconds,
+  # since jq has no timezone database of its own.
+  TZOFF=$(TZ="America/Los_Angeles" date +%z | awk '{
+    sign = (substr($0,1,1) == "-") ? -1 : 1
+    hh = substr($0,2,2) + 0
+    mm = substr($0,4,2) + 0
+    print sign * (hh * 3600 + mm * 60)
+  }')
+  export TZOFF
   jq -c -L "$HOOK_DIR" \
     'include "lib-metrics-fmt"; {systemMessage: block}' "$OUT" 2>/dev/null
 fi


### PR DESCRIPTION
On an ephemeral/cloud session the host clock is usually UTC, so
`night_nag` in `lib-metrics-fmt.jq` fired "LATE!" all evening even
though it was daytime in the Pacific.

`metrics-live.sh` now computes the US/Pacific UTC offset (correctly
handles PST vs PDT) via `TZ=America/Los_Angeles date +%z` and passes
it through the `TZOFF` env var — jq has no timezone database of its
own to do this directly. `lib-metrics-fmt.jq` reads `TZOFF` (falling
back to fixed PST, -8h, if unset) instead of jq's `localtime`, which
reads the host's zone.

`statusline-metrics.sh` is untouched: it only renders `row`, which
never calls `nag`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nighttime metric notifications by using the correct US/Pacific local time.
  * Added automatic handling for Pacific Standard Time and Pacific Daylight Time.
  * Preserved the existing nighttime escalation behavior while making timing consistent across host environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->