### PR TITLE
code.md: port the board-only-PR auto-merge pattern

### DIFF
--- a/.claude/rules/code.md
+++ b/.claude/rules/code.md
@@ -129,7 +129,11 @@ A PR whose diff touches **only** the board/state file (`kanban.md` or
 whatever the repo names it) needs no review and no approval to ask for —
 it's a card, not code; nothing installs it, and the next session to read the
 board fixes anything wrong with it in the same breath it's reading it in
-anyway. Set this up once per repo, not per PR:
+anyway. Only wire this up on a repo where PR authorship is trusted (solo
+maintainer, own bots) — the board is exactly the file a session-start hook
+reads into every future session's context, so skipping review on it is
+skipping review on a live prompt-injection surface, not just inert data.
+Set this up once per repo, not per PR:
 
 - Repo settings: auto-merge enabled, branch deletes on merge.
 - Every review bot the repo runs (CodeRabbit, `claude-review`, etc.) is
@@ -141,11 +145,13 @@ anyway. Set this up once per repo, not per PR:
   immediately, since a board-only diff triggers nothing else.
 
 Keep the merge-rule diff test and the bot skip-filters matched to each
-other — widen one without the other and either unreviewed changes slip past
-a filter that no longer covers them, or a board PR waits on a review it was
-supposed to be exempt from. This does not apply to a repo whose board edits
-already go straight to `main` with no PR at all (e.g. `claude_prompts_scratch`)
-— there's no PR here to auto-merge.
+other — the two can drift in either direction, and each is wrong a
+different way: a bot-skip filter *wider* than the merge rule lets non-board
+changes bypass review, while a bot-skip filter *narrower* than the merge
+rule leaves a board-only PR waiting on a bot it was supposed to be exempt
+from. This does not apply to a repo whose board edits already go straight
+to `main` with no PR at all (e.g. `claude_prompts_scratch`) — there's no PR
+here to auto-merge.
 
 ### Babysitting a PR is cheap; polling for it is not
 

--- a/.claude/rules/code.md
+++ b/.claude/rules/code.md
@@ -118,6 +118,35 @@ project-specific facts belong in that project's own CLAUDE.md.
 - Don't ask "want me to watch this PR?" — subscribe yourself, or don't,
   per the token-budget rule below. Either way, no question.
 
+### A board-only PR merges itself
+
+Ported from `signalk-noaa-space-weather/AGENTS.md`, 2026-08-26 — the pattern
+was write-once there; this generalizes it for any repo whose board/state file
+lives inside the repo and is edited via PR (a cloud session pinned to a
+branch is the case that comes up, per each repo's own branch-vs-main rule).
+
+A PR whose diff touches **only** the board/state file (`kanban.md` or
+whatever the repo names it) needs no review and no approval to ask for —
+it's a card, not code; nothing installs it, and the next session to read the
+board fixes anything wrong with it in the same breath it's reading it in
+anyway. Set this up once per repo, not per PR:
+
+- Repo settings: auto-merge enabled, branch deletes on merge.
+- Every review bot the repo runs (CodeRabbit, `claude-review`, etc.) is
+  filtered to skip when the board file is the *entire* diff — same test the
+  merge rule uses. Without this, a slow bot's finding lands as a comment on
+  an already-merged PR, which nobody reads.
+- The PR itself: `gh pr merge --squash --auto --delete-branch` as soon as
+  whatever required check the repo has (if any) goes green — often
+  immediately, since a board-only diff triggers nothing else.
+
+Keep the merge-rule diff test and the bot skip-filters matched to each
+other — widen one without the other and either unreviewed changes slip past
+a filter that no longer covers them, or a board PR waits on a review it was
+supposed to be exempt from. This does not apply to a repo whose board edits
+already go straight to `main` with no PR at all (e.g. `claude_prompts_scratch`)
+— there's no PR here to auto-merge.
+
 ### Babysitting a PR is cheap; polling for it is not
 
 - **Past 60% of the context window — ~120k on the default 200k — don't


### PR DESCRIPTION
Ports the pattern from `signalk-noaa-space-weather/AGENTS.md`: a PR
whose diff touches only a board/state file needs no review, so
auto-merge it and filter the review bots on the same diff test the
merge rule uses.

Written as a per-repo setup checklist (repo auto-merge setting +
review-bot path filters + `gh pr merge --squash --auto --delete-branch`)
rather than copied verbatim, since it needs to work for any repo's
board file, not just `kanban.md` in that one plugin. Explicitly notes
it doesn't apply to `claude_prompts_scratch`, whose board edits already
go straight to `main` with no PR at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for automatically handling pull requests that modify only board or state files.
  - Documented enabling automatic merging and branch cleanup after required checks pass.
  - Clarified when review automation should exclude board-only changes.
  - Added guidance to keep merge-rule and file-diff tests consistent.
  - Noted that repositories with direct board edits on the main branch are excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->