### PR TITLE
gitconfig: sign every commit with the ssh key by default

### DIFF
--- a/.gitconfig##default
+++ b/.gitconfig##default
@@ -7,3 +7,8 @@
 [user]
 	email = markbrannan@gmail.com
 	name = Mark Brannan
+	signingkey = ~/.ssh/id_ed25519.pub
+[gpg]
+	format = ssh
+[commit]
+	gpgsign = true


### PR DESCRIPTION
Signing was set per-repo, ad hoc, not globally, so a fresh worktree/repo had none and landed unsigned commits that sat BLOCKED against `required_signatures` (mark-brannan/signalk-noaa-space-weather#154, #172). Points every repo's commits at the ssh key + GitHub-registered public key that already exist on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)