### PR TITLE
runbook: open the Windows firewall for WSL2 dev servers

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -52,6 +52,7 @@ and the scars behind them — see [README.md § Conventions](README.md).
 - [Nothing decrypts on a new machine](#nothing-decrypts-on-a-new-machine)
 - [PR checks fail immediately with an empty credential](#pr-checks-fail-immediately-with-an-empty-credential)
 - [The security-review workflow cannot use an OAuth token](#the-security-review-workflow-cannot-use-an-oauth-token)
+- [A dev server in WSL2 is unreachable from any other device](#a-dev-server-in-wsl2-is-unreachable-from-any-other-device)
 
 ---
 
@@ -644,3 +645,39 @@ gh run list --workflow claude-security-review.yml --repo mark-brannan/dotfiles -
 Verify whichever you pick by re-running the check, not by reading the workflow:
 a green `review` and a still-red `security` is the state that means only half
 the decision has been made.
+
+## A dev server in WSL2 is unreachable from any other device
+
+A server started inside WSL2 answers on every address from inside WSL —
+loopback, LAN, Tailscale — and times out from a phone, a tablet, or even the
+Windows host it is running on. Nothing is wrong with the server. Under
+mirrored networking WSL shares the Windows network namespace, so Windows
+Firewall governs its inbound traffic and blocks it by default.
+
+From the Windows host itself, `localhost` works with no change:
+
+```
+http://localhost:<port>/
+```
+
+To reach it from another device, open the ports once, in an **administrator**
+PowerShell on Windows. The `VMCreatorId` is WSL's, and is the same GUID on
+every machine:
+
+```powershell
+New-NetFirewallHyperVRule -Name WSL-DevServers -DisplayName "WSL dev servers" -Direction Inbound -VMCreatorId '{40E0AC32-46A5-438A-A0B2-2B479E8F2E90}' -Protocol TCP -LocalPorts 3010,8742 -Action Allow
+```
+
+Verify from a *different* device on the LAN or the tailnet — not from the
+Windows host, whose `localhost` worked before the rule and proves nothing:
+
+```shell
+curl -s -m 5 -o /dev/null -w '%{http_code}\n' http://<lan-or-tailscale-ip>:<port>/
+```
+
+`200` (or a redirect) means the rule took. A timeout means it did not — check
+`Get-NetFirewallHyperVRule -Name WSL-DevServers` exists and that the ports in
+it match the ones actually listening.
+
+Remove it with `Remove-NetFirewallHyperVRule -Name WSL-DevServers`, and edit
+`-LocalPorts` rather than adding a second rule when the set of ports changes.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -656,28 +656,32 @@ Firewall governs its inbound traffic and blocks it by default.
 
 From the Windows host itself, `localhost` works with no change:
 
-```
+```text
 http://localhost:<port>/
 ```
 
 To reach it from another device, open the ports once, in an **administrator**
 PowerShell on Windows. The `VMCreatorId` is WSL's, and is the same GUID on
-every machine:
+every machine. `-Profiles` is scoped to `Private,Domain` deliberately — the
+unscoped default is `Any`, which would leave these ports open on a `Public`
+profile too, e.g. the laptop on coffee-shop wifi:
 
 ```powershell
-New-NetFirewallHyperVRule -Name WSL-DevServers -DisplayName "WSL dev servers" -Direction Inbound -VMCreatorId '{40E0AC32-46A5-438A-A0B2-2B479E8F2E90}' -Protocol TCP -LocalPorts 3010,8742 -Action Allow
+New-NetFirewallHyperVRule -Name WSL-DevServers -DisplayName "WSL dev servers" -Direction Inbound -VMCreatorId '{40E0AC32-46A5-438A-A0B2-2B479E8F2E90}' -Protocol TCP -LocalPorts 3010,8742 -Profiles Private,Domain -Action Allow
 ```
 
 Verify from a *different* device on the LAN or the tailnet — not from the
 Windows host, whose `localhost` worked before the rule and proves nothing:
 
 ```shell
-curl -s -m 5 -o /dev/null -w '%{http_code}\n' http://<lan-or-tailscale-ip>:<port>/
+curl -s --connect-timeout 5 -o /dev/null -w '%{http_code}\n' http://<lan-or-tailscale-ip>:<port>/
 ```
 
-`200` (or a redirect) means the rule took. A timeout means it did not — check
-`Get-NetFirewallHyperVRule -Name WSL-DevServers` exists and that the ports in
-it match the ones actually listening.
+`--connect-timeout` bounds the TCP handshake, not the whole transfer — a slow
+response otherwise reads the same as a blocked port. Any HTTP status code
+means the rule took, including `401`/`404`/`500`; only a timeout means it did
+not — check `Get-NetFirewallHyperVRule -Name WSL-DevServers` exists and that
+the ports in it match the ones actually listening.
 
 Remove it with `Remove-NetFirewallHyperVRule -Name WSL-DevServers`, and edit
 `-LocalPorts` rather than adding a second rule when the set of ports changes.


### PR DESCRIPTION
A server in WSL2 answers on every address from inside WSL and times out from everywhere else — phone, tablet, even the Windows host. Reads as a broken server; it's Windows Firewall, which governs WSL's inbound traffic under mirrored networking.

Adds the troubleshooting entry: `localhost` on the host works with no change, the `New-NetFirewallHyperVRule` one-liner opens it to other devices, and the verification step is deliberately from a *different* device, since the host's own localhost worked before the rule too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a runbook for accessing WSL2 development servers from other devices.
  - Documented firewall configuration for TCP ports 3010 and 8742.
  - Added verification steps, troubleshooting guidance, and instructions for updating or removing the firewall rule.
  - Included the new topic in the documentation table of contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->