### PR TITLE
bin: add resign-branch.sh for cloud-session commits

### DIFF
--- a/.claude/rules/code.md
+++ b/.claude/rules/code.md
@@ -120,6 +120,15 @@ project-specific facts belong in that project's own CLAUDE.md.
   do, independent of check status. Scar: 2026-08-27, ampacity#3 — confirmed a
   flagged link was live, never replied or resolved the thread, merge failed
   on branch policy.
+- **A repeated CodeRabbit comment gets re-verified live, not answered from
+  turn memory.** When the same finding text shows up again (re-pasted, or a
+  fresh review pass after a push), re-fetch the actual thread state — GraphQL
+  `reviewThreads` (path, `isResolved`, comment body) — before telling Mark
+  it's already handled, even when you're confident it's the same one. State
+  what you found: thread id, resolved status, which commit fixed it. Scar:
+  2026-08-28, signalk-noaa-space-weather#214 — said "nothing further to do"
+  from memory of an earlier fix; the conclusion happened to be right, but it
+  was asserted, not checked, on the very question "is this fully closed."
 - "Looks good" / "I'm signing off" said before CI finishes isn't a stall —
   it's pre-authorization: push the moment CI comes back green, without
   circling back to re-confirm.

--- a/.local/bin/resign-branch.sh
+++ b/.local/bin/resign-branch.sh
@@ -35,6 +35,14 @@ git config user.signingkey >/dev/null 2>&1 || {
 }
 
 git fetch -q "$remote" "$branch"
+
+if git rev-parse --verify -q "$branch" >/dev/null; then
+  ahead=$(git rev-list --count "$remote/$branch..$branch")
+  [ "$ahead" -eq 0 ] || {
+    echo "resign-branch: local $branch has $ahead commit(s) not on $remote/$branch — refusing to reset and discard them. Push or rebase them onto $remote/$branch first." >&2
+    exit 1
+  }
+fi
 git checkout -q -B "$branch" "$remote/$branch"
 
 base=$(git merge-base "$branch" "$remote/HEAD") || {
@@ -42,8 +50,13 @@ base=$(git merge-base "$branch" "$remote/HEAD") || {
   exit 1
 }
 
+git rev-list --merges "$base..$branch" | grep -q . && {
+  echo "resign-branch: $branch..$base contains merge commit(s) — a plain rebase would drop them and their conflict resolutions. Refusing; re-sign manually with --rebase-merges if that's really what you want." >&2
+  exit 1
+}
+
 echo "resign-branch: re-signing $(git rev-list --count "$base..$branch") commit(s) on $branch"
-GIT_SEQUENCE_EDITOR=true git rebase -q -S "$base" "$branch"
+GIT_SEQUENCE_EDITOR=true git rebase -q -S --force-rebase "$base" "$branch"
 
 echo "resign-branch: verifying signatures"
 # Note: with gpg.format ssh, %G? reports E unless gpg.ssh.allowedSignersFile

--- a/.local/bin/resign-branch.sh
+++ b/.local/bin/resign-branch.sh
@@ -37,18 +37,24 @@ git config user.signingkey >/dev/null 2>&1 || {
 git fetch -q "$remote" "$branch"
 git checkout -q -B "$branch" "$remote/$branch"
 
-base=$(git merge-base "$branch" "$remote/HEAD" 2>/dev/null) || base=$(git rev-list --max-parents=0 "$branch")
+base=$(git merge-base "$branch" "$remote/HEAD") || {
+  echo "resign-branch: couldn't determine merge-base against $remote/HEAD — is it set? (git remote set-head $remote -a)" >&2
+  exit 1
+}
 
 echo "resign-branch: re-signing $(git rev-list --count "$base..$branch") commit(s) on $branch"
 GIT_SEQUENCE_EDITOR=true git rebase -q -S "$base" "$branch"
 
 echo "resign-branch: verifying signatures"
+# Note: with gpg.format ssh, %G? reports E unless gpg.ssh.allowedSignersFile
+# is configured for your own key — set that up first, or this loop will
+# false-alarm on good signatures and train you to ignore it.
 git log --pretty='%H %G?' "$base..$branch" | while read -r sha status; do
   case "$status" in
     G) : ;;
-    *) echo "resign-branch: $sha did not verify locally (status $status)" >&2 ;;
+    *) echo "resign-branch: $sha did not verify locally (status $status)" >&2; exit 1 ;;
   esac
-done
+done || { echo "resign-branch: aborting push, not all commits verified" >&2; exit 1; }
 
 git push --force-with-lease "$remote" "$branch"
 echo "resign-branch: pushed $branch to $remote"

--- a/.local/bin/resign-branch.sh
+++ b/.local/bin/resign-branch.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# resign-branch.sh — re-sign a branch's commits with this machine's real
+# signing key, then force-push it.
+#
+# Why this exists: Claude Code cloud/remote sessions push unsigned commits —
+# there is no local signing key on an ephemeral VM, and Anthropic has no
+# server-side signing (unlike Cursor or GitHub Actions' bot commits, which
+# are signed by the platform itself). Filed upstream as
+# https://github.com/anthropics/claude-code/issues/7711 (closed "not
+# planned"). A repo whose branch protection requires signed commits will
+# BLOCK any PR built from such a branch until every commit on it is signed.
+#
+# This script re-signs from a machine that already has real signing config
+# (dotfiles' .gitconfig##default: user.signingkey, gpg.format ssh,
+# commit.gpgsign) — the opposite of seeding a private key into an ephemeral,
+# third-party-adjacent cloud VM, which is a worse trade than this manual step.
+#
+# Usage:
+#   resign-branch.sh <branch> [<remote>]     remote defaults to origin
+#
+# Rewrites history on <branch> (rebase -S) and force-pushes. Never run this
+# against main or any shared branch someone else has already pulled — this
+# is for single-author PR branches only, per "never force-push" in standing
+# orders: fine on your own branch, never on main.
+set -eu
+
+branch="${1:?usage: resign-branch.sh <branch> [<remote>]}"
+remote="${2:-origin}"
+
+git rev-parse --git-dir >/dev/null 2>&1 || { echo "resign-branch: not in a git repo" >&2; exit 1; }
+
+git config user.signingkey >/dev/null 2>&1 || {
+  echo "resign-branch: no user.signingkey configured on this machine — nothing to sign with" >&2
+  exit 1
+}
+
+git fetch -q "$remote" "$branch"
+git checkout -q -B "$branch" "$remote/$branch"
+
+base=$(git merge-base "$branch" "$remote/HEAD" 2>/dev/null) || base=$(git rev-list --max-parents=0 "$branch")
+
+echo "resign-branch: re-signing $(git rev-list --count "$base..$branch") commit(s) on $branch"
+GIT_SEQUENCE_EDITOR=true git rebase -q -S "$base" "$branch"
+
+echo "resign-branch: verifying signatures"
+git log --pretty='%H %G?' "$base..$branch" | while read -r sha status; do
+  case "$status" in
+    G) : ;;
+    *) echo "resign-branch: $sha did not verify locally (status $status)" >&2 ;;
+  esac
+done
+
+git push --force-with-lease "$remote" "$branch"
+echo "resign-branch: pushed $branch to $remote"


### PR DESCRIPTION
Claude Code cloud/remote sessions push unsigned commits — no local signing
key on an ephemeral VM, and Anthropic has no server-side signing (unlike
Cursor or GitHub Actions bot commits, which the platform signs itself).
Filed upstream as anthropics/claude-code#7711, closed "not planned".

`resign-branch.sh` re-signs a branch's commits from a machine that already
has real signing config and force-pushes — the manual step that unblocked
[signalk-noaa-space-weather#216](https://github.com/mark-brannan/signalk-noaa-space-weather/pull/216),
made repeatable.

Deliberately not seeding a real signing key into ephemeral cloud sessions —
that's a worse trade than this manual step, per the same reasoning already
in `cloud-session-setup.sh`'s `.gitconfig*` refusal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a utility for re-signing branch commits with the configured signing key.
  * Verifies commit signatures before safely force-pushing the updated branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->