### PR TITLE
feat(shell): scope GITHUB_PERSONAL_ACCESS_TOKEN to the claude wrapper

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -191,7 +191,10 @@ claude() {
     _gh_tok="$HOME/.config/secrets/github-token.env"
     (
         [ -r "$_tok" ] && . "$_tok"
-        [ -r "$_gh_tok" ] && . "$_gh_tok"
+        # github-token.env follows dotfiles-add-secret.sh's plain KEY=value
+        # convention (no `export`), so export it here for the MCP server
+        # subprocess to inherit it.
+        [ -r "$_gh_tok" ] && . "$_gh_tok" && export GITHUB_PERSONAL_ACCESS_TOKEN
         command claude "$@"
     )
 }

--- a/.bashrc
+++ b/.bashrc
@@ -166,27 +166,32 @@ alias dotpush='git push && (cd ~ && dotsync)'
 # Secrets decrypted by `yadm bootstrap` (sops+age) land here, never in git.
 # See secrets/*.sops.env and .config/yadm/bootstrap. Mirrors the loop in .zshrc;
 # without it, bash-only hosts never load them. The glob is unquoted on purpose,
-# and the -r test covers the no-match case. claude-token.env is excluded on
-# purpose — see the `claude` wrapper below, which scopes
-# CLAUDE_CODE_OAUTH_TOKEN to just that command instead of exporting it into
-# every shell and everything the shell spawns.
+# and the -r test covers the no-match case. claude-token.env and
+# github-token.env are excluded on purpose — see the `claude` wrapper below,
+# which scopes CLAUDE_CODE_OAUTH_TOKEN and GITHUB_PERSONAL_ACCESS_TOKEN to
+# just that command instead of exporting them into every shell and
+# everything the shell spawns.
 for _secret_file in "$HOME"/.config/secrets/*.env; do
     case "$_secret_file" in
-        */claude-token.env) continue ;;
+        */claude-token.env|*/github-token.env) continue ;;
     esac
     [ -r "$_secret_file" ] && . "$_secret_file"
 done
 unset _secret_file
 export CLAUDE_CODE_TMPDIR="$HOME/.local/state/claude-tmpdir"
 
-# CLAUDE_CODE_OAUTH_TOKEN stays out of the general environment (see the
-# excluded loop above) and is exported only for the duration of this one
-# command, in a subshell, so it never leaks into the interactive shell.
+# CLAUDE_CODE_OAUTH_TOKEN and GITHUB_PERSONAL_ACCESS_TOKEN stay out of the
+# general environment (see the excluded loop above) and are exported only
+# for the duration of this one command, in a subshell, so they never leak
+# into the interactive shell. GITHUB_PERSONAL_ACCESS_TOKEN shares this
+# wrapper because it's only ever needed by the GitHub MCP server that
+# `claude` itself launches.
 claude() {
     _tok="$HOME/.config/secrets/claude-token.env"
-    if [ -r "$_tok" ]; then
-        ( . "$_tok" && command claude "$@" )
-    else
+    _gh_tok="$HOME/.config/secrets/github-token.env"
+    (
+        [ -r "$_tok" ] && . "$_tok"
+        [ -r "$_gh_tok" ] && . "$_gh_tok"
         command claude "$@"
-    fi
+    )
 }

--- a/.zshrc
+++ b/.zshrc
@@ -193,7 +193,10 @@ claude() {
   local _gh_tok="$HOME/.config/secrets/github-token.env"
   (
     [ -r "$_tok" ] && source "$_tok"
-    [ -r "$_gh_tok" ] && source "$_gh_tok"
+    # github-token.env follows dotfiles-add-secret.sh's plain KEY=value
+    # convention (no `export`), so export it here for the MCP server
+    # subprocess to inherit it.
+    [ -r "$_gh_tok" ] && source "$_gh_tok" && export GITHUB_PERSONAL_ACCESS_TOKEN
     command claude "$@"
   )
 }

--- a/.zshrc
+++ b/.zshrc
@@ -169,27 +169,32 @@ export NVM_DIR="$HOME/.nvm"
 [ -f ~/.zsh_aliases ] && source ~/.zsh_aliases
 
 # Secrets decrypted by `yadm bootstrap` (sops+age) land here, never in git.
-# See secrets/*.sops.env and .config/yadm/bootstrap. claude-token.env is
-# excluded from this loop on purpose — see the `claude` wrapper below, which
-# scopes CLAUDE_CODE_OAUTH_TOKEN to just that command instead of exporting it
+# See secrets/*.sops.env and .config/yadm/bootstrap. claude-token.env and
+# github-token.env are excluded from this loop on purpose — see the `claude`
+# wrapper below, which scopes CLAUDE_CODE_OAUTH_TOKEN and
+# GITHUB_PERSONAL_ACCESS_TOKEN to just that command instead of exporting them
 # into every shell and everything the shell spawns.
 for _secret_file in "$HOME"/.config/secrets/*.env(N); do
   case "$_secret_file" in
-    */claude-token.env) continue ;;
+    */claude-token.env|*/github-token.env) continue ;;
   esac
   [ -r "$_secret_file" ] && source "$_secret_file"
 done
 unset _secret_file
 
-# CLAUDE_CODE_OAUTH_TOKEN stays out of the general environment (see the
-# excluded loop above) and is exported only for the duration of this one
-# command, in a subshell, so it never leaks into the interactive shell.
+# CLAUDE_CODE_OAUTH_TOKEN and GITHUB_PERSONAL_ACCESS_TOKEN stay out of the
+# general environment (see the excluded loop above) and are exported only
+# for the duration of this one command, in a subshell, so they never leak
+# into the interactive shell. GITHUB_PERSONAL_ACCESS_TOKEN shares this
+# wrapper because it's only ever needed by the GitHub MCP server that
+# `claude` itself launches.
 claude() {
   local _tok="$HOME/.config/secrets/claude-token.env"
-  if [ -r "$_tok" ]; then
-    ( source "$_tok" && command claude "$@" )
-  else
+  local _gh_tok="$HOME/.config/secrets/github-token.env"
+  (
+    [ -r "$_tok" ] && source "$_tok"
+    [ -r "$_gh_tok" ] && source "$_gh_tok"
     command claude "$@"
-  fi
+  )
 }
 


### PR DESCRIPTION
Wires GITHUB_PERSONAL_ACCESS_TOKEN into the existing claude-token.env
wrapper convention (see .config/yadm/bootstrap) rather than a second
wrapper — it's only ever needed by the GitHub MCP server that `claude`
itself launches.

- .zshrc/.bashrc: exclude github-token.env from the shell-wide secrets
  loop, source it inside the `claude()` wrapper subshell only, export it
  explicitly there (github-token.env follows dotfiles-add-secret.sh's
  plain KEY=value convention, no `export`).
- Ciphertext for the actual token lands separately at
  secrets/github-token.sops.env (already committed to main via
  dotfiles-add-secret.sh, not part of this branch).

Verified: GITHUB_PERSONAL_ACCESS_TOKEN resolves inside the claude wrapper
subshell and stays unset in a plain new shell.