### PR TITLE
hooks: salvage a work repo's uncommitted files at Stop, by policy

### DIFF
--- a/.claude/hooks/lib-stop-commit.sh
+++ b/.claude/hooks/lib-stop-commit.sh
@@ -1,78 +1,37 @@
 #!/usr/bin/env bash
-# Stop-time salvage of a work repo's uncommitted files.
+# Salvage a work repo's uncommitted files at Stop, by per-repo policy.
+# Sourced by stop-continuity.sh. Policy table: $(state_dir)/stop-commit.conf,
+# one rule per line, first match wins, no match = off:
 #
-# Sourced by stop-continuity.sh, which owns the Stop event, the transcript
-# parse, the flock and the checkpoint. This file owns one question: given
-# the repo a session was working in, where do its uncommitted files go so
-# that nothing is lost when the container is reclaimed?
+#   <owner/repo glob>  state-to-main <state path...>   state paths -> main,
+#                                                       rest -> worktree branch
+#   <owner/repo glob>  branch                           all -> worktree branch
+#   <owner/repo glob>  off
 #
-# The answer is a policy per repo, read from
+# Non-state files are only committed from an isolated worktree, never a
+# shared checkout. The repo's own hooks and signing run; gitleaks runs when
+# present; any refusal wins and is named. The main-bound commit is built in
+# a throwaway worktree so nothing here rebases, stashes or resets the
+# session's checkout. Never add -A outside a worktree, never --no-verify,
+# never force.
 #
-#   $(state_dir)/stop-commit.conf        (private state repo)
-#
-# one rule per line, first match wins, `#` comments:
-#
-#   <owner/repo glob>      <policy>       [state path ...]
-#   mark-brannan/symphony  state-to-main  intermediate_files/claude_slop
-#   mark-brannan/*         branch
-#   *                      off
-#
-# Policies:
-#   state-to-main  The listed state paths go straight to the default branch:
-#                  signed, rebased onto origin, one commit per Stop, linear.
-#                  Every other change follows the `branch` rules below.
-#   branch         In an isolated worktree, every uncommitted change is
-#                  committed on the worktree's branch and pushed to the same
-#                  branch on origin. No PR is opened. In a shared checkout
-#                  nothing is committed -- the files are only listed in the
-#                  checkpoint, because `git add -A` in a directory several
-#                  sessions share is how the destructive-command incidents
-#                  started.
-#   off            Nothing is touched. No file, no matching rule, no origin
-#                  remote and a malformed rule all mean off: a repo that has
-#                  not opted in is never pushed to.
-#
-# Why the table lives in the state repo, not in each repo or in dotfiles: an
-# interim choice (2026-09-01) made for blast radius and reversibility -- one
-# private file, no per-repo commit to opt in, no public PR to change a
-# policy, and deleting the file turns every repo off. The durable answer is
-# an open card on the global board.
-#
-# Invariants, each of which has cost something once already:
-#   - Never `git add -A` outside an isolated worktree.
-#   - Never `-c commit.gpgsign=false`. The repo's own signing config applies,
-#     and a commit that should be signed but isn't is not pushed.
-#   - Never `--no-verify`. The repo's own commit hooks run, and gitleaks runs
-#     over the staged diff whenever it is on PATH. A refusal wins.
-#   - Never rebase, stash or reset in the session's checkout. The
-#     default-branch commit is built in a throwaway worktree of
-#     origin/<default>, so a conflict or a killed hook can only damage a
-#     directory that is about to be deleted.
-#   - Never force-push.
-#   - Refuse loudly. Every path that declines writes why into the checkpoint
-#     and into the one-line status the Stop hook shows.
-#
-# Run directly to see what a repo resolves to, or to rehearse a Stop without
-# committing or pushing anything:
-#
-#   bash lib-stop-commit.sh <repo-path>
-#   bash lib-stop-commit.sh --dry-run <repo-path>
+#   bash lib-stop-commit.sh [--dry-run] <repo>    show policy / rehearse
 
 SC_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib-state.sh
 . "$SC_LIB_DIR/lib-state.sh"
 
-# Results, read by the caller after sc_run.
-SC_STATUS=""      # one line for the user: "<repo> -- a; b; c"
-SC_REASON=""      # last refusal or skip reason, empty when nothing went wrong
+SC_STATUS=""
+SC_REASON=""
 SC_DRY="${CLAUDE_STOP_COMMIT_DRY_RUN:-0}"
+SC_CKPT=""
+SC_SECTION=0
+SC_GATE_NOTE=""
+SC_COMMIT_OUT=""
 
 sc_conf() { printf '%s/stop-commit.conf' "$(state_dir)"; }
 
-# owner/repo from the origin URL: the last two path components, with .git
-# and any scheme, user or host stripped. Works for https://, ssh://,
-# scp-style git@host:owner/repo and plain paths (a local bare origin in the
-# tests resolves to its last two directories).
+# owner/repo from any origin URL form (https, ssh://, scp-style, local path).
 sc_repo_key() {
   local url key
   url=$(git -C "$1" config --get remote.origin.url 2>/dev/null) || return 1
@@ -80,67 +39,32 @@ sc_repo_key() {
   key=$(printf '%s' "$url" \
     | sed -E 's#/+$##; s#\.git$##; s#^[a-z+]+://##; s#^[^/@]*@##; s#^[^/:]*[:/]##' \
     | awk -F/ 'NF >= 2 { print $(NF-1) "/" $NF }')
-  case "$key" in
-    */*) ;;
-    *) return 1 ;;
-  esac
-  printf '%s' "$key"
+  case "$key" in */*) printf '%s' "$key" ;; *) return 1 ;; esac
 }
 
-# A state path is a plain relative path: no magic, no `..`, no leading `-`
-# or `/`. Anything else makes the rule malformed, and a malformed rule is
-# `off` rather than a guess at what was meant.
 sc_path_ok() {
-  case "$1" in
-    ''|-*|/*|*..*|*[!A-Za-z0-9_./-]*) return 1 ;;
-  esac
-  return 0
+  case "$1" in ''|-*|/*|*..*|*[!A-Za-z0-9_./-]*) return 1 ;; esac
 }
 
-# Resolve <key> against the conf. Prints "<policy>\t<paths>"; sets SC_REASON
-# when the answer is off for a reason worth telling.
+# Prints "<policy>\t<paths>". A malformed rule is off, with SC_REASON set.
 sc_policy() {
   local key=$1 conf pat pol paths p
   conf=$(sc_conf)
   SC_REASON=""
-  if [ ! -f "$conf" ]; then
-    SC_REASON="no $conf"
-    printf 'off\t'
-    return 0
-  fi
+  [ -f "$conf" ] || { SC_REASON="no $conf"; printf 'off\t'; return 0; }
   while read -r pat pol paths; do
     case "$pat" in ''|'#'*) continue ;; esac
-    # shellcheck disable=SC2254  # the pattern is meant to glob
-    case "$key" in
-      $pat) ;;
-      *) continue ;;
-    esac
+    # shellcheck disable=SC2254
+    case "$key" in $pat) ;; *) continue ;; esac
     case "$pol" in
-      off)
-        printf 'off\t'
-        return 0 ;;
-      branch)
-        printf 'branch\t'
-        return 0 ;;
+      off|branch) printf '%s\t' "$pol"; return 0 ;;
       state-to-main)
-        if [ -z "$paths" ]; then
-          SC_REASON="rule '$pat state-to-main' names no state paths"
-          printf 'off\t'
-          return 0
-        fi
+        [ -n "$paths" ] || { SC_REASON="rule '$pat' names no state paths"; printf 'off\t'; return 0; }
         for p in $paths; do
-          if ! sc_path_ok "$p"; then
-            SC_REASON="rule '$pat' has a malformed state path '$p'"
-            printf 'off\t'
-            return 0
-          fi
+          sc_path_ok "$p" || { SC_REASON="rule '$pat' has a malformed path '$p'"; printf 'off\t'; return 0; }
         done
-        printf 'state-to-main\t%s' "$paths"
-        return 0 ;;
-      *)
-        SC_REASON="rule '$pat' has unknown policy '$pol'"
-        printf 'off\t'
-        return 0 ;;
+        printf 'state-to-main\t%s' "$paths"; return 0 ;;
+      *) SC_REASON="rule '$pat' has unknown policy '$pol'"; printf 'off\t'; return 0 ;;
     esac
   done < "$conf"
   SC_REASON="no rule matches $key"
@@ -150,69 +74,44 @@ sc_policy() {
 sc_default_branch() {
   local b
   b=$(git -C "$1" symbolic-ref -q --short refs/remotes/origin/HEAD 2>/dev/null)
-  if [ -n "$b" ]; then
-    printf '%s' "${b#origin/}"
-    return
-  fi
+  [ -n "$b" ] && { printf '%s' "${b#origin/}"; return; }
   for b in main master; do
     git -C "$1" show-ref -q --verify "refs/remotes/origin/$b" 2>/dev/null && { printf '%s' "$b"; return; }
   done
   printf 'main'
 }
 
-# --- checkpoint + status ---------------------------------------------------
-
-SC_CKPT=""
-SC_SECTION=0
 sc_note() {
   if [ -n "$SC_CKPT" ]; then
-    if [ "$SC_SECTION" = 0 ]; then
-      printf '\n## Stop-commit\n\n' >> "$SC_CKPT"
-      SC_SECTION=1
-    fi
+    [ "$SC_SECTION" = 1 ] || { printf '\n## Stop-commit\n\n' >> "$SC_CKPT"; SC_SECTION=1; }
     printf -- '- %s\n' "$1" >> "$SC_CKPT"
   fi
   SC_STATUS="${SC_STATUS:+$SC_STATUS; }$1"
 }
 
-# A refusal is a note plus the reason kept for the caller. Extra detail
-# (hook output) goes to the checkpoint only.
 sc_refuse() {
   SC_REASON=$1
   sc_note "NOT COMMITTED: $1"
-  if [ -n "${2:-}" ] && [ -n "$SC_CKPT" ]; then
-    printf '\n```\n%s\n```\n' "$(printf '%s' "$2" | head -20)" >> "$SC_CKPT"
-  fi
-}
-
-# --- gates -----------------------------------------------------------------
-
-# Same check the state-repo path makes: a filter declared in .gitattributes
-# but not configured in this clone would stage mangled content.
-sc_filters_ok() {
-  local root=$1 f
-  [ -f "$root/.gitattributes" ] || return 0
-  grep -qE '(^|[[:space:]])filter=' "$root/.gitattributes" || return 0
-  for f in $(sed -nE 's/.*[[:space:]]filter=([A-Za-z0-9_.-]+).*/\1/p' "$root/.gitattributes" | sort -u); do
-    if ! git -C "$root" config --get "filter.$f.clean" >/dev/null 2>&1; then
-      sc_refuse "git filter '$f' is declared in .gitattributes but not configured in this clone; committing would mangle content"
-      return 1
-    fi
-  done
+  # shellcheck disable=SC2016
+  [ -n "${2:-}" ] && [ -n "$SC_CKPT" ] && printf '\n```\n%s\n```\n' "$(printf '%s' "$2" | head -20)" >> "$SC_CKPT"
   return 0
 }
 
-# gitleaks over the staged diff of <dir>, when gitleaks is on PATH. Exit
-# code 2 is reserved for findings so a tool failure (any other non-zero) is
-# distinguishable -- and both refuse, because "the scanner didn't run" is
-# not "the scanner found nothing".
-SC_GATE_NOTE=""
+# A filter declared in .gitattributes but unconfigured here would stage mangled content.
+sc_filters_ok() {
+  local root=$1 f
+  [ -f "$root/.gitattributes" ] && grep -qE '(^|[[:space:]])filter=' "$root/.gitattributes" || return 0
+  for f in $(sed -nE 's/.*[[:space:]]filter=([A-Za-z0-9_.-]+).*/\1/p' "$root/.gitattributes" | sort -u); do
+    git -C "$root" config --get "filter.$f.clean" >/dev/null 2>&1 && continue
+    sc_refuse "git filter '$f' is declared in .gitattributes but not configured in this clone"
+    return 1
+  done
+}
+
+# Exit 2 = findings; any other non-zero = scanner didn't run. Both refuse.
 sc_gitleaks_ok() {
   local dir=$1 out rc
-  if ! command -v gitleaks >/dev/null 2>&1; then
-    SC_GATE_NOTE="gitleaks not on PATH; only the repo's own commit hooks ran"
-    return 0
-  fi
+  command -v gitleaks >/dev/null 2>&1 || { SC_GATE_NOTE="gitleaks not on PATH; only the repo's own hooks ran"; return 0; }
   if gitleaks git --help >/dev/null 2>&1; then
     out=$(cd "$dir" && timeout 120 gitleaks git --pre-commit --staged --no-banner --redact --exit-code 2 . 2>&1)
   else
@@ -222,31 +121,23 @@ sc_gitleaks_ok() {
   case "$rc" in
     0) return 0 ;;
     2) sc_refuse "gitleaks found credential-shaped content in the staged diff" "$out" ;;
-    *) sc_refuse "gitleaks failed to run (exit $rc), so the staged diff was not scanned" "$out" ;;
+    *) sc_refuse "gitleaks failed to run (exit $rc)" "$out" ;;
   esac
   return 1
 }
 
-# Commit what is staged in <dir>. The repo's own identity and signing config
-# apply; the only override is a fallback identity when the clone has none.
-# Hooks run. Output is captured so a refusing hook can be quoted.
-SC_COMMIT_OUT=""
+# Repo identity and signing apply; fallback identity only when the clone has none.
 sc_commit() {
   local dir=$1 msg=$2
   local -a ident=()
-  if [ -z "$(git -C "$dir" config --get user.email 2>/dev/null)" ]; then
-    ident=(-c "user.name=${GIT_AUTHOR_NAME:-Claude}" -c "user.email=${GIT_AUTHOR_EMAIL:-noreply@anthropic.com}")
-  fi
+  [ -n "$(git -C "$dir" config --get user.email 2>/dev/null)" ] \
+    || ident=(-c "user.name=${GIT_AUTHOR_NAME:-Claude}" -c "user.email=${GIT_AUTHOR_EMAIL:-noreply@anthropic.com}")
   SC_COMMIT_OUT=$(timeout 120 git -C "$dir" "${ident[@]}" commit -q -m "$msg" 2>&1)
 }
 
-# When the repo says commits are signed, an unsigned one does not leave the
-# machine. git already fails the commit when signing fails; this catches a
-# config that quietly turned signing off between commit and push.
 sc_signed_ok() {
-  local dir=$1
-  [ "$(git -C "$dir" config --get --type=bool commit.gpgsign 2>/dev/null)" = true ] || return 0
-  git -C "$dir" cat-file commit HEAD 2>/dev/null | grep -q '^gpgsig' && return 0
+  [ "$(git -C "$1" config --get --type=bool commit.gpgsign 2>/dev/null)" = true ] || return 0
+  git -C "$1" cat-file commit HEAD 2>/dev/null | grep -q '^gpgsig' && return 0
   sc_refuse "commit.gpgsign is on but the commit carries no signature"
   return 1
 }
@@ -258,27 +149,11 @@ sc_is_worktree() {
   [ -n "$gd" ] && [ -n "$cd" ] && [ "$gd" != "$cd" ]
 }
 
-# --- state-to-main ---------------------------------------------------------
-#
-# 1. A scratch commit of the state paths on top of the session's HEAD, built
-#    through a temporary index. The session's own index and worktree are
-#    never touched, and the object is never pushed.
-# 2. A throwaway worktree at origin/<default>; the scratch commit is
-#    cherry-picked into it without committing. That is a real three-way
-#    merge, so a state file another session pushed meanwhile merges rather
-#    than being overwritten, and a genuine conflict refuses.
-# 3. gitleaks, then a normal `git commit` there: the repo's hooks and
-#    signing run in a clean tree, so nothing is stashed and nothing needs
-#    restoring if a hook dies.
-# 4. Push to the default branch; if origin moved in between, rebase the one
-#    commit in the throwaway worktree and push again. Linear by construction.
-# 5. If the session's checkout is on the default branch and was at the old
-#    tip, move its branch pointer forward and refresh the index for the
-#    state paths, so the next `git status` there is clean instead of one
-#    commit behind with files that look modified. Best effort: an index.lock
-#    held by someone else just leaves it behind, which `git pull --autostash`
-#    resolves later.
-# shellcheck disable=SC2086  # $paths is a validated, space-separated pathspec list
+# State paths -> origin/<default>: scratch commit via a temp index, cherry-picked
+# (three-way) into a throwaway worktree of origin/<default>, committed there,
+# pushed; rebased in the throwaway on a race. Then fast-forward the session's
+# local default branch if it was at the old tip.
+# shellcheck disable=SC2086
 sc_state_to_main() {
   local root=$1 sid=$2 paths=$3 repo default head base tree scratch wt tmpidx
   local pending n new attempt
@@ -288,7 +163,6 @@ sc_state_to_main() {
   pending=$(git -C "$root" status --porcelain -- $paths 2>/dev/null)
   [ -n "$pending" ] || return 0
   n=$(printf '%s\n' "$pending" | wc -l | tr -d ' ')
-
   head=$(git -C "$root" rev-parse HEAD 2>/dev/null) || { sc_refuse "no HEAD in $root"; return 1; }
 
   tmpidx=$(mktemp "${TMPDIR:-/tmp}/stop-commit-index.XXXXXX") || return 1
@@ -305,10 +179,8 @@ sc_state_to_main() {
               commit-tree --no-gpg-sign "$tree" -p "$head" -m "scratch: state paths at Stop" 2>/dev/null)
   [ -n "$scratch" ] || { sc_refuse "could not build the scratch commit"; return 1; }
 
-  if ! timeout 60 git -C "$root" fetch -q origin "$default" 2>/dev/null; then
-    sc_refuse "fetch of origin/$default failed; $n state file(s) left uncommitted"
-    return 1
-  fi
+  timeout 60 git -C "$root" fetch -q origin "$default" 2>/dev/null \
+    || { sc_refuse "fetch of origin/$default failed; $n state file(s) left uncommitted"; return 1; }
   base=$(git -C "$root" rev-parse "refs/remotes/origin/$default" 2>/dev/null)
   [ -n "$base" ] || { sc_refuse "origin/$default does not exist"; return 1; }
 
@@ -318,7 +190,6 @@ sc_state_to_main() {
     sc_refuse "could not create a throwaway worktree at origin/$default"
     return 1
   fi
-  # Everything after this point cleans up through sc_wt_done.
   sc_wt_done() {
     git -C "$root" worktree remove --force "$wt" >/dev/null 2>&1
     rm -rf "$(dirname "$wt")"
@@ -335,10 +206,7 @@ sc_state_to_main() {
     sc_note "state paths already match origin/$default"
     return 0
   fi
-  if ! sc_gitleaks_ok "$wt"; then
-    sc_wt_done
-    return 1
-  fi
+  sc_gitleaks_ok "$wt" || { sc_wt_done; return 1; }
   if [ "$SC_DRY" = 1 ]; then
     sc_wt_done
     sc_note "dry-run: $n state file(s) would go to origin/$default"
@@ -348,18 +216,13 @@ sc_state_to_main() {
   sc_commit "$wt" "State: $repo session ${sid:0:8} ($(date -u +%Y-%m-%d))"
   if ! git -C "$wt" diff --cached --quiet 2>/dev/null || [ "$(git -C "$wt" rev-parse HEAD)" = "$base" ]; then
     sc_wt_done
-    sc_refuse "commit on origin/$default refused by a hook; $n state file(s) left uncommitted" "$SC_COMMIT_OUT"
+    sc_refuse "commit on origin/$default refused; $n state file(s) left uncommitted" "$SC_COMMIT_OUT"
     return 1
   fi
-  if ! sc_signed_ok "$wt"; then
-    sc_wt_done
-    return 1
-  fi
+  sc_signed_ok "$wt" || { sc_wt_done; return 1; }
 
   for attempt in 1 2 3; do
-    if timeout 60 git -C "$wt" push -q origin "HEAD:refs/heads/$default" >/dev/null 2>&1; then
-      break
-    fi
+    timeout 60 git -C "$wt" push -q origin "HEAD:refs/heads/$default" >/dev/null 2>&1 && break
     if [ "$attempt" = 3 ]; then
       sc_wt_done
       sc_refuse "push to origin/$default rejected three times; $n state file(s) left uncommitted"
@@ -372,34 +235,26 @@ sc_state_to_main() {
       sc_refuse "origin/$default moved and the state commit no longer rebases cleanly"
       return 1
     fi
+    sc_signed_ok "$wt" || { sc_wt_done; return 1; }
   done
   new=$(git -C "$wt" rev-parse HEAD)
   sc_wt_done
   git -C "$root" fetch -q origin "$default" 2>/dev/null
   sc_note "$n state file(s) -> origin/$default @${new:0:7}"
 
-  if [ "$(git -C "$root" symbolic-ref -q --short HEAD 2>/dev/null)" = "$default" ] \
-     && [ "$head" = "$base" ] \
-     && git -C "$root" diff --cached --quiet -- $paths 2>/dev/null; then
-    if git -C "$root" update-ref -m "stop-continuity: state salvage" "refs/heads/$default" "$new" "$head" 2>/dev/null; then
-      git -C "$root" add -- $paths >/dev/null 2>&1 \
-        || sc_note "local $default moved to @${new:0:7} but its index could not be refreshed (index.lock held?)"
-    else
-      sc_note "local $default is one commit behind origin/$default; pull --autostash"
-    fi
-  elif [ "$(git -C "$root" symbolic-ref -q --short HEAD 2>/dev/null)" = "$default" ]; then
+  [ "$(git -C "$root" symbolic-ref -q --short HEAD 2>/dev/null)" = "$default" ] || return 0
+  if [ "$head" = "$base" ] && git -C "$root" diff --cached --quiet -- $paths 2>/dev/null \
+     && git -C "$root" update-ref -m "stop-continuity: state salvage" "refs/heads/$default" "$new" "$head" 2>/dev/null; then
+    git -C "$root" add -- $paths >/dev/null 2>&1 \
+      || sc_note "local $default moved to @${new:0:7} but its index could not be refreshed"
+  else
     sc_note "local $default is behind origin/$default; pull --autostash"
   fi
   return 0
 }
 
-# --- branch ----------------------------------------------------------------
-#
-# Only in an isolated worktree, only on a branch that is not the default.
-# Stages everything (minus the state paths a state-to-main rule already
-# routed to main), runs gitleaks, commits with the repo's hooks and signing,
-# pushes to the same branch name on origin. A refusal puts the index back
-# exactly as the session left it.
+# Everything (minus $excl) -> the worktree's own branch on origin. A refusal
+# restores the index as the session left it.
 sc_branch() {
   local root=$1 sid=$2 excl=$3 repo default branch pending n idx bak p new
   local -a spec=(.)
@@ -411,23 +266,10 @@ sc_branch() {
   [ -n "$pending" ] || return 0
   n=$(printf '%s\n' "$pending" | wc -l | tr -d ' ')
 
-  if ! sc_is_worktree "$root"; then
-    sc_note "$n file(s) uncommitted in the shared checkout (recorded, not committed)"
-    return 0
-  fi
+  sc_is_worktree "$root" || { sc_note "$n file(s) uncommitted in the shared checkout (recorded, not committed)"; return 0; }
   branch=$(git -C "$root" symbolic-ref -q --short HEAD 2>/dev/null)
-  if [ -z "$branch" ]; then
-    sc_note "$n file(s) uncommitted on a detached HEAD (recorded, not committed)"
-    return 0
-  fi
-  if [ "$branch" = "$default" ]; then
-    sc_note "$n file(s) uncommitted on $default in a worktree (recorded, not committed)"
-    return 0
-  fi
-  if [ "$SC_DRY" = 1 ]; then
-    sc_note "dry-run: $n file(s) would go to origin/$branch"
-    return 0
-  fi
+  [ -n "$branch" ] || { sc_note "$n file(s) uncommitted on a detached HEAD (recorded, not committed)"; return 0; }
+  [ "$branch" != "$default" ] || { sc_note "$n file(s) uncommitted on $default in a worktree (recorded, not committed)"; return 0; }
 
   idx=$(git -C "$root" rev-parse --path-format=absolute --git-path index 2>/dev/null)
   bak="$idx.stop-continuity"
@@ -438,25 +280,21 @@ sc_branch() {
     if [ -f "$bak" ]; then mv -f "$bak" "$idx" 2>/dev/null; else rm -f "$idx"; fi
   }
 
-  if ! git -C "$root" add -A -- "${spec[@]}" >/dev/null 2>&1; then
+  git -C "$root" add -A -- "${spec[@]}" >/dev/null 2>&1 || { sc_idx_restore; sc_refuse "git add failed in $root"; return 1; }
+  sc_gitleaks_ok "$root" || { sc_idx_restore; return 1; }
+  if [ "$SC_DRY" = 1 ]; then
     sc_idx_restore
-    sc_refuse "git add failed in $root"
-    return 1
-  fi
-  if ! sc_gitleaks_ok "$root"; then
-    sc_idx_restore
-    return 1
+    sc_note "dry-run: $n file(s) would go to origin/$branch"
+    return 0
   fi
   sc_commit "$root" "Stop: salvage uncommitted files ($repo session ${sid:0:8})"
   if ! git -C "$root" diff --cached --quiet 2>/dev/null; then
     sc_idx_restore
-    sc_refuse "commit on $branch refused by a hook; $n file(s) left uncommitted" "$SC_COMMIT_OUT"
+    sc_refuse "commit on $branch refused; $n file(s) left uncommitted" "$SC_COMMIT_OUT"
     return 1
   fi
   rm -f "$bak"
-  if ! sc_signed_ok "$root"; then
-    return 1
-  fi
+  sc_signed_ok "$root" || return 1
   new=$(git -C "$root" rev-parse HEAD)
   if timeout 60 git -C "$root" push -q -u origin "HEAD:refs/heads/$branch" >/dev/null 2>&1; then
     sc_note "$n file(s) -> origin/$branch @${new:0:7}"
@@ -464,59 +302,41 @@ sc_branch() {
     sc_refuse "$n file(s) committed on $branch @${new:0:7} but the push to origin/$branch was rejected"
     return 1
   fi
-  return 0
 }
 
-# --- entry point -----------------------------------------------------------
-# sc_run <work-root> <session-id> [checkpoint-file]
+# sc_run <work-root> <session-id> [checkpoint-file]; result in SC_STATUS.
 sc_run() {
   local root=$1 sid=$2 key pol paths repo
   SC_CKPT=${3:-}
-  SC_SECTION=0
-  SC_STATUS=""
-  SC_REASON=""
-  SC_GATE_NOTE=""
+  SC_SECTION=0; SC_STATUS=""; SC_REASON=""; SC_GATE_NOTE=""
   repo=$(basename "$root")
 
-  [ -d "$root" ] || return 0
-  git -C "$root" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
-
+  [ -d "$root" ] && git -C "$root" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
   if ! key=$(sc_repo_key "$root"); then
     [ -n "$SC_CKPT" ] && sc_note "off: no origin remote" && SC_STATUS=""
     return 0
   fi
   IFS=$'\t' read -r pol paths <<<"$(sc_policy "$key")"
   if [ "$pol" = off ]; then
-    if [ -n "$SC_CKPT" ]; then
-      sc_note "off for $key${SC_REASON:+ ($SC_REASON)}"
-      SC_STATUS=""
-    fi
+    [ -n "$SC_CKPT" ] && sc_note "off for $key${SC_REASON:+ ($SC_REASON)}" && SC_STATUS=""
     return 0
   fi
   [ -n "$SC_CKPT" ] && sc_note "policy $pol for $key${paths:+ ($paths)}" && SC_STATUS=""
-
   sc_filters_ok "$root" || return 0
 
   case "$pol" in
-    state-to-main)
-      sc_state_to_main "$root" "$sid" "$paths"
-      sc_branch "$root" "$sid" "$paths"
-      ;;
-    branch)
-      sc_branch "$root" "$sid" ""
-      ;;
+    state-to-main) sc_state_to_main "$root" "$sid" "$paths"; sc_branch "$root" "$sid" "$paths" ;;
+    branch)        sc_branch "$root" "$sid" "" ;;
   esac
   [ -n "$SC_GATE_NOTE" ] && sc_note "$SC_GATE_NOTE"
   [ -n "$SC_STATUS" ] && SC_STATUS="$repo -- $SC_STATUS"
   return 0
 }
 
-# --- direct invocation -----------------------------------------------------
 if [ "${BASH_SOURCE[0]}" = "$0" ]; then
   set -u
-  if [ "${1:-}" = "--dry-run" ]; then SC_DRY=1; shift; fi
-  target=${1:-$PWD}
-  root=$(git -C "$target" rev-parse --show-toplevel 2>/dev/null) || { echo "not a git repo: $target" >&2; exit 1; }
+  [ "${1:-}" = "--dry-run" ] && { SC_DRY=1; shift; }
+  root=$(git -C "${1:-$PWD}" rev-parse --show-toplevel 2>/dev/null) || { echo "not a git repo: ${1:-$PWD}" >&2; exit 1; }
   echo "repo:     $root"
   echo "conf:     $(sc_conf)"
   if key=$(sc_repo_key "$root"); then
@@ -528,7 +348,7 @@ if [ "${BASH_SOURCE[0]}" = "$0" ]; then
     echo "key:      (no origin remote)"
     echo "policy:   off"
   fi
-  if sc_is_worktree "$root"; then echo "checkout: isolated worktree"; else echo "checkout: shared"; fi
+  sc_is_worktree "$root" && echo "checkout: isolated worktree" || echo "checkout: shared"
   echo "branch:   $(git -C "$root" symbolic-ref -q --short HEAD 2>/dev/null || echo detached) (default: $(sc_default_branch "$root"))"
   echo "pending:  $(git -C "$root" status --porcelain 2>/dev/null | wc -l | tr -d ' ') file(s)"
   if [ "$SC_DRY" = 1 ]; then

--- a/.claude/hooks/lib-stop-commit.sh
+++ b/.claude/hooks/lib-stop-commit.sh
@@ -1,0 +1,541 @@
+#!/usr/bin/env bash
+# Stop-time salvage of a work repo's uncommitted files.
+#
+# Sourced by stop-continuity.sh, which owns the Stop event, the transcript
+# parse, the flock and the checkpoint. This file owns one question: given
+# the repo a session was working in, where do its uncommitted files go so
+# that nothing is lost when the container is reclaimed?
+#
+# The answer is a policy per repo, read from
+#
+#   $(state_dir)/stop-commit.conf        (private state repo)
+#
+# one rule per line, first match wins, `#` comments:
+#
+#   <owner/repo glob>      <policy>       [state path ...]
+#   mark-brannan/symphony  state-to-main  intermediate_files/claude_slop
+#   mark-brannan/*         branch
+#   *                      off
+#
+# Policies:
+#   state-to-main  The listed state paths go straight to the default branch:
+#                  signed, rebased onto origin, one commit per Stop, linear.
+#                  Every other change follows the `branch` rules below.
+#   branch         In an isolated worktree, every uncommitted change is
+#                  committed on the worktree's branch and pushed to the same
+#                  branch on origin. No PR is opened. In a shared checkout
+#                  nothing is committed -- the files are only listed in the
+#                  checkpoint, because `git add -A` in a directory several
+#                  sessions share is how the destructive-command incidents
+#                  started.
+#   off            Nothing is touched. No file, no matching rule, no origin
+#                  remote and a malformed rule all mean off: a repo that has
+#                  not opted in is never pushed to.
+#
+# Why the table lives in the state repo, not in each repo or in dotfiles: an
+# interim choice (2026-09-01) made for blast radius and reversibility -- one
+# private file, no per-repo commit to opt in, no public PR to change a
+# policy, and deleting the file turns every repo off. The durable answer is
+# an open card on the global board.
+#
+# Invariants, each of which has cost something once already:
+#   - Never `git add -A` outside an isolated worktree.
+#   - Never `-c commit.gpgsign=false`. The repo's own signing config applies,
+#     and a commit that should be signed but isn't is not pushed.
+#   - Never `--no-verify`. The repo's own commit hooks run, and gitleaks runs
+#     over the staged diff whenever it is on PATH. A refusal wins.
+#   - Never rebase, stash or reset in the session's checkout. The
+#     default-branch commit is built in a throwaway worktree of
+#     origin/<default>, so a conflict or a killed hook can only damage a
+#     directory that is about to be deleted.
+#   - Never force-push.
+#   - Refuse loudly. Every path that declines writes why into the checkpoint
+#     and into the one-line status the Stop hook shows.
+#
+# Run directly to see what a repo resolves to, or to rehearse a Stop without
+# committing or pushing anything:
+#
+#   bash lib-stop-commit.sh <repo-path>
+#   bash lib-stop-commit.sh --dry-run <repo-path>
+
+SC_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib-state.sh
+. "$SC_LIB_DIR/lib-state.sh"
+
+# Results, read by the caller after sc_run.
+SC_STATUS=""      # one line for the user: "<repo> -- a; b; c"
+SC_REASON=""      # last refusal or skip reason, empty when nothing went wrong
+SC_DRY="${CLAUDE_STOP_COMMIT_DRY_RUN:-0}"
+
+sc_conf() { printf '%s/stop-commit.conf' "$(state_dir)"; }
+
+# owner/repo from the origin URL: the last two path components, with .git
+# and any scheme, user or host stripped. Works for https://, ssh://,
+# scp-style git@host:owner/repo and plain paths (a local bare origin in the
+# tests resolves to its last two directories).
+sc_repo_key() {
+  local url key
+  url=$(git -C "$1" config --get remote.origin.url 2>/dev/null) || return 1
+  [ -n "$url" ] || return 1
+  key=$(printf '%s' "$url" \
+    | sed -E 's#/+$##; s#\.git$##; s#^[a-z+]+://##; s#^[^/@]*@##; s#^[^/:]*[:/]##' \
+    | awk -F/ 'NF >= 2 { print $(NF-1) "/" $NF }')
+  case "$key" in
+    */*) ;;
+    *) return 1 ;;
+  esac
+  printf '%s' "$key"
+}
+
+# A state path is a plain relative path: no magic, no `..`, no leading `-`
+# or `/`. Anything else makes the rule malformed, and a malformed rule is
+# `off` rather than a guess at what was meant.
+sc_path_ok() {
+  case "$1" in
+    ''|-*|/*|*..*|*[!A-Za-z0-9_./-]*) return 1 ;;
+  esac
+  return 0
+}
+
+# Resolve <key> against the conf. Prints "<policy>\t<paths>"; sets SC_REASON
+# when the answer is off for a reason worth telling.
+sc_policy() {
+  local key=$1 conf pat pol paths p
+  conf=$(sc_conf)
+  SC_REASON=""
+  if [ ! -f "$conf" ]; then
+    SC_REASON="no $conf"
+    printf 'off\t'
+    return 0
+  fi
+  while read -r pat pol paths; do
+    case "$pat" in ''|'#'*) continue ;; esac
+    # shellcheck disable=SC2254  # the pattern is meant to glob
+    case "$key" in
+      $pat) ;;
+      *) continue ;;
+    esac
+    case "$pol" in
+      off)
+        printf 'off\t'
+        return 0 ;;
+      branch)
+        printf 'branch\t'
+        return 0 ;;
+      state-to-main)
+        if [ -z "$paths" ]; then
+          SC_REASON="rule '$pat state-to-main' names no state paths"
+          printf 'off\t'
+          return 0
+        fi
+        for p in $paths; do
+          if ! sc_path_ok "$p"; then
+            SC_REASON="rule '$pat' has a malformed state path '$p'"
+            printf 'off\t'
+            return 0
+          fi
+        done
+        printf 'state-to-main\t%s' "$paths"
+        return 0 ;;
+      *)
+        SC_REASON="rule '$pat' has unknown policy '$pol'"
+        printf 'off\t'
+        return 0 ;;
+    esac
+  done < "$conf"
+  SC_REASON="no rule matches $key"
+  printf 'off\t'
+}
+
+sc_default_branch() {
+  local b
+  b=$(git -C "$1" symbolic-ref -q --short refs/remotes/origin/HEAD 2>/dev/null)
+  if [ -n "$b" ]; then
+    printf '%s' "${b#origin/}"
+    return
+  fi
+  for b in main master; do
+    git -C "$1" show-ref -q --verify "refs/remotes/origin/$b" 2>/dev/null && { printf '%s' "$b"; return; }
+  done
+  printf 'main'
+}
+
+# --- checkpoint + status ---------------------------------------------------
+
+SC_CKPT=""
+SC_SECTION=0
+sc_note() {
+  if [ -n "$SC_CKPT" ]; then
+    if [ "$SC_SECTION" = 0 ]; then
+      printf '\n## Stop-commit\n\n' >> "$SC_CKPT"
+      SC_SECTION=1
+    fi
+    printf -- '- %s\n' "$1" >> "$SC_CKPT"
+  fi
+  SC_STATUS="${SC_STATUS:+$SC_STATUS; }$1"
+}
+
+# A refusal is a note plus the reason kept for the caller. Extra detail
+# (hook output) goes to the checkpoint only.
+sc_refuse() {
+  SC_REASON=$1
+  sc_note "NOT COMMITTED: $1"
+  if [ -n "${2:-}" ] && [ -n "$SC_CKPT" ]; then
+    printf '\n```\n%s\n```\n' "$(printf '%s' "$2" | head -20)" >> "$SC_CKPT"
+  fi
+}
+
+# --- gates -----------------------------------------------------------------
+
+# Same check the state-repo path makes: a filter declared in .gitattributes
+# but not configured in this clone would stage mangled content.
+sc_filters_ok() {
+  local root=$1 f
+  [ -f "$root/.gitattributes" ] || return 0
+  grep -qE '(^|[[:space:]])filter=' "$root/.gitattributes" || return 0
+  for f in $(sed -nE 's/.*[[:space:]]filter=([A-Za-z0-9_.-]+).*/\1/p' "$root/.gitattributes" | sort -u); do
+    if ! git -C "$root" config --get "filter.$f.clean" >/dev/null 2>&1; then
+      sc_refuse "git filter '$f' is declared in .gitattributes but not configured in this clone; committing would mangle content"
+      return 1
+    fi
+  done
+  return 0
+}
+
+# gitleaks over the staged diff of <dir>, when gitleaks is on PATH. Exit
+# code 2 is reserved for findings so a tool failure (any other non-zero) is
+# distinguishable -- and both refuse, because "the scanner didn't run" is
+# not "the scanner found nothing".
+SC_GATE_NOTE=""
+sc_gitleaks_ok() {
+  local dir=$1 out rc
+  if ! command -v gitleaks >/dev/null 2>&1; then
+    SC_GATE_NOTE="gitleaks not on PATH; only the repo's own commit hooks ran"
+    return 0
+  fi
+  if gitleaks git --help >/dev/null 2>&1; then
+    out=$(cd "$dir" && timeout 120 gitleaks git --pre-commit --staged --no-banner --redact --exit-code 2 . 2>&1)
+  else
+    out=$(cd "$dir" && timeout 120 gitleaks protect --staged --no-banner --redact --exit-code 2 -s . 2>&1)
+  fi
+  rc=$?
+  case "$rc" in
+    0) return 0 ;;
+    2) sc_refuse "gitleaks found credential-shaped content in the staged diff" "$out" ;;
+    *) sc_refuse "gitleaks failed to run (exit $rc), so the staged diff was not scanned" "$out" ;;
+  esac
+  return 1
+}
+
+# Commit what is staged in <dir>. The repo's own identity and signing config
+# apply; the only override is a fallback identity when the clone has none.
+# Hooks run. Output is captured so a refusing hook can be quoted.
+SC_COMMIT_OUT=""
+sc_commit() {
+  local dir=$1 msg=$2
+  local -a ident=()
+  if [ -z "$(git -C "$dir" config --get user.email 2>/dev/null)" ]; then
+    ident=(-c "user.name=${GIT_AUTHOR_NAME:-Claude}" -c "user.email=${GIT_AUTHOR_EMAIL:-noreply@anthropic.com}")
+  fi
+  SC_COMMIT_OUT=$(timeout 120 git -C "$dir" "${ident[@]}" commit -q -m "$msg" 2>&1)
+}
+
+# When the repo says commits are signed, an unsigned one does not leave the
+# machine. git already fails the commit when signing fails; this catches a
+# config that quietly turned signing off between commit and push.
+sc_signed_ok() {
+  local dir=$1
+  [ "$(git -C "$dir" config --get --type=bool commit.gpgsign 2>/dev/null)" = true ] || return 0
+  git -C "$dir" cat-file commit HEAD 2>/dev/null | grep -q '^gpgsig' && return 0
+  sc_refuse "commit.gpgsign is on but the commit carries no signature"
+  return 1
+}
+
+sc_is_worktree() {
+  local gd cd
+  gd=$(git -C "$1" rev-parse --path-format=absolute --git-dir 2>/dev/null)
+  cd=$(git -C "$1" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
+  [ -n "$gd" ] && [ -n "$cd" ] && [ "$gd" != "$cd" ]
+}
+
+# --- state-to-main ---------------------------------------------------------
+#
+# 1. A scratch commit of the state paths on top of the session's HEAD, built
+#    through a temporary index. The session's own index and worktree are
+#    never touched, and the object is never pushed.
+# 2. A throwaway worktree at origin/<default>; the scratch commit is
+#    cherry-picked into it without committing. That is a real three-way
+#    merge, so a state file another session pushed meanwhile merges rather
+#    than being overwritten, and a genuine conflict refuses.
+# 3. gitleaks, then a normal `git commit` there: the repo's hooks and
+#    signing run in a clean tree, so nothing is stashed and nothing needs
+#    restoring if a hook dies.
+# 4. Push to the default branch; if origin moved in between, rebase the one
+#    commit in the throwaway worktree and push again. Linear by construction.
+# 5. If the session's checkout is on the default branch and was at the old
+#    tip, move its branch pointer forward and refresh the index for the
+#    state paths, so the next `git status` there is clean instead of one
+#    commit behind with files that look modified. Best effort: an index.lock
+#    held by someone else just leaves it behind, which `git pull --autostash`
+#    resolves later.
+# shellcheck disable=SC2086  # $paths is a validated, space-separated pathspec list
+sc_state_to_main() {
+  local root=$1 sid=$2 paths=$3 repo default head base tree scratch wt tmpidx
+  local pending n new attempt
+  default=$(sc_default_branch "$root")
+  repo=$(basename "$root")
+
+  pending=$(git -C "$root" status --porcelain -- $paths 2>/dev/null)
+  [ -n "$pending" ] || return 0
+  n=$(printf '%s\n' "$pending" | wc -l | tr -d ' ')
+
+  head=$(git -C "$root" rev-parse HEAD 2>/dev/null) || { sc_refuse "no HEAD in $root"; return 1; }
+
+  tmpidx=$(mktemp "${TMPDIR:-/tmp}/stop-commit-index.XXXXXX") || return 1
+  rm -f "$tmpidx"
+  if ! GIT_INDEX_FILE=$tmpidx git -C "$root" read-tree "$head" 2>/dev/null \
+     || ! GIT_INDEX_FILE=$tmpidx git -C "$root" add -A -- $paths 2>/dev/null; then
+    rm -f "$tmpidx"
+    sc_refuse "could not stage $paths into a scratch index"
+    return 1
+  fi
+  tree=$(GIT_INDEX_FILE=$tmpidx git -C "$root" write-tree 2>/dev/null)
+  rm -f "$tmpidx"
+  scratch=$(git -C "$root" -c user.name=stop-continuity -c user.email=noreply@anthropic.com \
+              commit-tree --no-gpg-sign "$tree" -p "$head" -m "scratch: state paths at Stop" 2>/dev/null)
+  [ -n "$scratch" ] || { sc_refuse "could not build the scratch commit"; return 1; }
+
+  if ! timeout 60 git -C "$root" fetch -q origin "$default" 2>/dev/null; then
+    sc_refuse "fetch of origin/$default failed; $n state file(s) left uncommitted"
+    return 1
+  fi
+  base=$(git -C "$root" rev-parse "refs/remotes/origin/$default" 2>/dev/null)
+  [ -n "$base" ] || { sc_refuse "origin/$default does not exist"; return 1; }
+
+  wt=$(mktemp -d "${TMPDIR:-/tmp}/stop-commit-wt.XXXXXX")/wt || return 1
+  if ! git -C "$root" worktree add -q --detach "$wt" "$base" 2>/dev/null; then
+    rm -rf "$(dirname "$wt")"
+    sc_refuse "could not create a throwaway worktree at origin/$default"
+    return 1
+  fi
+  # Everything after this point cleans up through sc_wt_done.
+  sc_wt_done() {
+    git -C "$root" worktree remove --force "$wt" >/dev/null 2>&1
+    rm -rf "$(dirname "$wt")"
+    git -C "$root" worktree prune >/dev/null 2>&1
+  }
+
+  if ! git -C "$wt" cherry-pick -n "$scratch" >/dev/null 2>&1; then
+    sc_wt_done
+    sc_refuse "state paths conflict with origin/$default; merge by hand ($n file(s) left uncommitted)"
+    return 1
+  fi
+  if git -C "$wt" diff --cached --quiet 2>/dev/null; then
+    sc_wt_done
+    sc_note "state paths already match origin/$default"
+    return 0
+  fi
+  if ! sc_gitleaks_ok "$wt"; then
+    sc_wt_done
+    return 1
+  fi
+  if [ "$SC_DRY" = 1 ]; then
+    sc_wt_done
+    sc_note "dry-run: $n state file(s) would go to origin/$default"
+    return 0
+  fi
+
+  sc_commit "$wt" "State: $repo session ${sid:0:8} ($(date -u +%Y-%m-%d))"
+  if ! git -C "$wt" diff --cached --quiet 2>/dev/null || [ "$(git -C "$wt" rev-parse HEAD)" = "$base" ]; then
+    sc_wt_done
+    sc_refuse "commit on origin/$default refused by a hook; $n state file(s) left uncommitted" "$SC_COMMIT_OUT"
+    return 1
+  fi
+  if ! sc_signed_ok "$wt"; then
+    sc_wt_done
+    return 1
+  fi
+
+  for attempt in 1 2 3; do
+    if timeout 60 git -C "$wt" push -q origin "HEAD:refs/heads/$default" >/dev/null 2>&1; then
+      break
+    fi
+    if [ "$attempt" = 3 ]; then
+      sc_wt_done
+      sc_refuse "push to origin/$default rejected three times; $n state file(s) left uncommitted"
+      return 1
+    fi
+    timeout 60 git -C "$root" fetch -q origin "$default" 2>/dev/null
+    if ! git -C "$wt" rebase -q "refs/remotes/origin/$default" >/dev/null 2>&1; then
+      git -C "$wt" rebase --abort >/dev/null 2>&1
+      sc_wt_done
+      sc_refuse "origin/$default moved and the state commit no longer rebases cleanly"
+      return 1
+    fi
+  done
+  new=$(git -C "$wt" rev-parse HEAD)
+  sc_wt_done
+  git -C "$root" fetch -q origin "$default" 2>/dev/null
+  sc_note "$n state file(s) -> origin/$default @${new:0:7}"
+
+  if [ "$(git -C "$root" symbolic-ref -q --short HEAD 2>/dev/null)" = "$default" ] \
+     && [ "$head" = "$base" ] \
+     && git -C "$root" diff --cached --quiet -- $paths 2>/dev/null; then
+    if git -C "$root" update-ref -m "stop-continuity: state salvage" "refs/heads/$default" "$new" "$head" 2>/dev/null; then
+      git -C "$root" add -- $paths >/dev/null 2>&1 \
+        || sc_note "local $default moved to @${new:0:7} but its index could not be refreshed (index.lock held?)"
+    else
+      sc_note "local $default is one commit behind origin/$default; pull --autostash"
+    fi
+  elif [ "$(git -C "$root" symbolic-ref -q --short HEAD 2>/dev/null)" = "$default" ]; then
+    sc_note "local $default is behind origin/$default; pull --autostash"
+  fi
+  return 0
+}
+
+# --- branch ----------------------------------------------------------------
+#
+# Only in an isolated worktree, only on a branch that is not the default.
+# Stages everything (minus the state paths a state-to-main rule already
+# routed to main), runs gitleaks, commits with the repo's hooks and signing,
+# pushes to the same branch name on origin. A refusal puts the index back
+# exactly as the session left it.
+sc_branch() {
+  local root=$1 sid=$2 excl=$3 repo default branch pending n idx bak p new
+  local -a spec=(.)
+  for p in $excl; do spec+=(":(exclude)$p"); done
+  default=$(sc_default_branch "$root")
+  repo=$(basename "$root")
+
+  pending=$(git -C "$root" status --porcelain -- "${spec[@]}" 2>/dev/null)
+  [ -n "$pending" ] || return 0
+  n=$(printf '%s\n' "$pending" | wc -l | tr -d ' ')
+
+  if ! sc_is_worktree "$root"; then
+    sc_note "$n file(s) uncommitted in the shared checkout (recorded, not committed)"
+    return 0
+  fi
+  branch=$(git -C "$root" symbolic-ref -q --short HEAD 2>/dev/null)
+  if [ -z "$branch" ]; then
+    sc_note "$n file(s) uncommitted on a detached HEAD (recorded, not committed)"
+    return 0
+  fi
+  if [ "$branch" = "$default" ]; then
+    sc_note "$n file(s) uncommitted on $default in a worktree (recorded, not committed)"
+    return 0
+  fi
+  if [ "$SC_DRY" = 1 ]; then
+    sc_note "dry-run: $n file(s) would go to origin/$branch"
+    return 0
+  fi
+
+  idx=$(git -C "$root" rev-parse --path-format=absolute --git-path index 2>/dev/null)
+  bak="$idx.stop-continuity"
+  if [ -f "$idx" ]; then
+    cp -p "$idx" "$bak" 2>/dev/null || { sc_refuse "could not back up the index"; return 1; }
+  fi
+  sc_idx_restore() {
+    if [ -f "$bak" ]; then mv -f "$bak" "$idx" 2>/dev/null; else rm -f "$idx"; fi
+  }
+
+  if ! git -C "$root" add -A -- "${spec[@]}" >/dev/null 2>&1; then
+    sc_idx_restore
+    sc_refuse "git add failed in $root"
+    return 1
+  fi
+  if ! sc_gitleaks_ok "$root"; then
+    sc_idx_restore
+    return 1
+  fi
+  sc_commit "$root" "Stop: salvage uncommitted files ($repo session ${sid:0:8})"
+  if ! git -C "$root" diff --cached --quiet 2>/dev/null; then
+    sc_idx_restore
+    sc_refuse "commit on $branch refused by a hook; $n file(s) left uncommitted" "$SC_COMMIT_OUT"
+    return 1
+  fi
+  rm -f "$bak"
+  if ! sc_signed_ok "$root"; then
+    return 1
+  fi
+  new=$(git -C "$root" rev-parse HEAD)
+  if timeout 60 git -C "$root" push -q -u origin "HEAD:refs/heads/$branch" >/dev/null 2>&1; then
+    sc_note "$n file(s) -> origin/$branch @${new:0:7}"
+  else
+    sc_refuse "$n file(s) committed on $branch @${new:0:7} but the push to origin/$branch was rejected"
+    return 1
+  fi
+  return 0
+}
+
+# --- entry point -----------------------------------------------------------
+# sc_run <work-root> <session-id> [checkpoint-file]
+sc_run() {
+  local root=$1 sid=$2 key pol paths repo
+  SC_CKPT=${3:-}
+  SC_SECTION=0
+  SC_STATUS=""
+  SC_REASON=""
+  SC_GATE_NOTE=""
+  repo=$(basename "$root")
+
+  [ -d "$root" ] || return 0
+  git -C "$root" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
+
+  if ! key=$(sc_repo_key "$root"); then
+    [ -n "$SC_CKPT" ] && sc_note "off: no origin remote" && SC_STATUS=""
+    return 0
+  fi
+  IFS=$'\t' read -r pol paths <<<"$(sc_policy "$key")"
+  if [ "$pol" = off ]; then
+    if [ -n "$SC_CKPT" ]; then
+      sc_note "off for $key${SC_REASON:+ ($SC_REASON)}"
+      SC_STATUS=""
+    fi
+    return 0
+  fi
+  [ -n "$SC_CKPT" ] && sc_note "policy $pol for $key${paths:+ ($paths)}" && SC_STATUS=""
+
+  sc_filters_ok "$root" || return 0
+
+  case "$pol" in
+    state-to-main)
+      sc_state_to_main "$root" "$sid" "$paths"
+      sc_branch "$root" "$sid" "$paths"
+      ;;
+    branch)
+      sc_branch "$root" "$sid" ""
+      ;;
+  esac
+  [ -n "$SC_GATE_NOTE" ] && sc_note "$SC_GATE_NOTE"
+  [ -n "$SC_STATUS" ] && SC_STATUS="$repo -- $SC_STATUS"
+  return 0
+}
+
+# --- direct invocation -----------------------------------------------------
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  set -u
+  if [ "${1:-}" = "--dry-run" ]; then SC_DRY=1; shift; fi
+  target=${1:-$PWD}
+  root=$(git -C "$target" rev-parse --show-toplevel 2>/dev/null) || { echo "not a git repo: $target" >&2; exit 1; }
+  echo "repo:     $root"
+  echo "conf:     $(sc_conf)"
+  if key=$(sc_repo_key "$root"); then
+    IFS=$'\t' read -r pol paths <<<"$(sc_policy "$key")"
+    echo "key:      $key"
+    echo "policy:   $pol${SC_REASON:+ ($SC_REASON)}"
+    [ -n "$paths" ] && echo "state:    $paths"
+  else
+    echo "key:      (no origin remote)"
+    echo "policy:   off"
+  fi
+  if sc_is_worktree "$root"; then echo "checkout: isolated worktree"; else echo "checkout: shared"; fi
+  echo "branch:   $(git -C "$root" symbolic-ref -q --short HEAD 2>/dev/null || echo detached) (default: $(sc_default_branch "$root"))"
+  echo "pending:  $(git -C "$root" status --porcelain 2>/dev/null | wc -l | tr -d ' ') file(s)"
+  if [ "$SC_DRY" = 1 ]; then
+    ck=$(mktemp)
+    sc_run "$root" "dry-run-0000" "$ck"
+    echo
+    sed -n '/^## Stop-commit/,$p' "$ck"
+    rm -f "$ck"
+  fi
+fi

--- a/.claude/hooks/stop-commit.test.sh
+++ b/.claude/hooks/stop-commit.test.sh
@@ -208,6 +208,7 @@ ok 'branch wt: status' strhas "$SC_STATUS" '3 file(s) -> origin/claude/y'
 # --- gitleaks refusal restores the index ----------------------------------
 if command -v gitleaks >/dev/null 2>&1; then
   echo more > "$WB/README.md"; git -C "$WB" add README.md
+  # An invented key, never issued; allowlisted for this file in .gitleaks.toml.
   printf 'aws_key = "AKIAQ7Z2M4X9J1B5K8T3"\n' > "$WB/creds.txt"
   run "$WB"
   ok 'gitleaks: refused' has "$CKPT" 'NOT COMMITTED: gitleaks found'

--- a/.claude/hooks/stop-commit.test.sh
+++ b/.claude/hooks/stop-commit.test.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+# Tests for lib-stop-commit.sh. Run: bash .claude/hooks/stop-commit.test.sh
+#
+# Everything happens under one temp dir: a private "state repo" holding the
+# policy table, local bare origins, clones, worktrees, and a throwaway SSH
+# signing key so the signed-commit invariant is exercised for real. No
+# network, no global git config, nothing outside $T is touched.
+set -uo pipefail
+
+HOOKS="$(cd "$(dirname "$0")" && pwd)"
+T=$(mktemp -d "${TMPDIR:-/tmp}/stop-commit-test.XXXXXX")
+trap 'rm -rf "$T"' EXIT
+export TMPDIR="$T/tmp"; mkdir -p "$TMPDIR"
+export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+export CLAUDE_STATE_REPO="$T/state"
+unset CLAUDE_STOP_COMMIT_DRY_RUN
+
+git init -q -b main "$T/state"
+mkdir -p "$T/state/state/global"
+CONF="$T/state/state/global/stop-commit.conf"
+
+ssh-keygen -q -t ed25519 -N '' -f "$T/signkey" >/dev/null 2>&1
+
+# shellcheck source=lib-stop-commit.sh
+. "$HOOKS/lib-stop-commit.sh"
+
+pass=0; fail=0
+ok() {  # ok <description> <command...>
+  local desc=$1; shift
+  if "$@" >/dev/null 2>&1; then pass=$((pass + 1)); else fail=$((fail + 1)); printf 'FAIL: %s\n' "$desc"; fi
+}
+not() { ! "$@"; }
+has() { grep -q -- "$2" "$1"; }         # has <file> <pattern>
+strhas() { printf '%s' "$1" | grep -q -- "$2"; }
+
+CKPT="$T/ckpt"
+run() { : > "$CKPT"; sc_run "$1" "${2:-sess0000}" "$CKPT"; }
+
+# mkrepo <owner> <name>: bare origin + clone on main with one state file.
+mkrepo() {
+  local origin="$T/origins/$1/$2.git" clone="$T/$1-$2"
+  git init -q --bare -b main "$origin"
+  git clone -q "$origin" "$clone" 2>/dev/null
+  git -C "$clone" config user.name t; git -C "$clone" config user.email t@t
+  git -C "$clone" config gpg.format ssh
+  git -C "$clone" config user.signingkey "$T/signkey.pub"
+  git -C "$clone" config commit.gpgsign true
+  mkdir -p "$clone/intermediate_files/claude_slop"
+  printf 'line1\nline2\nline3\n' > "$clone/intermediate_files/claude_slop/kanban.md"
+  echo readme > "$clone/README.md"
+  git -C "$clone" add -A && git -C "$clone" commit -q -m init && git -C "$clone" push -q -u origin main 2>/dev/null
+  printf '%s' "$clone"
+}
+# other <clone> <shell...>: another session lands a commit on origin/main.
+other() {
+  local c=$1; shift
+  local w="$T/other.$$"
+  rm -rf "$w"; git clone -q "$(git -C "$c" config --get remote.origin.url)" "$w" 2>/dev/null
+  git -C "$w" config user.name o; git -C "$w" config user.email o@o
+  (cd "$w" && eval "$*")
+  git -C "$w" add -A && git -C "$w" commit -q -m other && git -C "$w" push -q origin main 2>/dev/null
+  rm -rf "$w"
+}
+signed() { git -C "$1" cat-file commit "${2:-HEAD}" | grep -q '^gpgsig'; }
+origin_tip() { git -C "$1" ls-remote -q origin "refs/heads/$2" | cut -f1; }
+files_in() { git -C "$1" show --pretty=format: --name-only "$2"; }
+nworktrees() { git -C "$1" worktree list | wc -l; }
+leftover_tmp() { find "$TMPDIR" -mindepth 1 -maxdepth 1 -name 'stop-commit-*' | grep -q .; }
+
+# --- policy resolution ---------------------------------------------------
+A=$(mkrepo owner alpha)
+ok 'key from local path' [ "$(sc_repo_key "$A")" = owner/alpha ]
+K=$(mktemp -d); git init -q "$K"
+for url in https://github.com/mark-brannan/symphony.git git@github.com:mark-brannan/symphony \
+           ssh://git@github.com/mark-brannan/symphony.git https://x@github.com/mark-brannan/symphony/; do
+  git -C "$K" remote remove origin 2>/dev/null; git -C "$K" remote add origin "$url"
+  ok "key from $url" [ "$(sc_repo_key "$K")" = mark-brannan/symphony ]
+done
+git -C "$K" remote remove origin
+ok 'no origin -> no key' not sc_repo_key "$K"
+
+rm -f "$CONF"
+ok 'no conf -> off' [ "$(sc_policy owner/alpha)" = "$(printf 'off\t')" ]
+cat > "$CONF" <<'EOF'
+# comment
+owner/alpha   state-to-main  intermediate_files/claude_slop
+owner/bad1    state-to-main
+owner/bad2    state-to-main  ../etc
+owner/bad3    frobnicate
+owner/*       branch
+*             off
+EOF
+ok 'first match wins' [ "$(sc_policy owner/alpha)" = "$(printf 'state-to-main\tintermediate_files/claude_slop')" ]
+ok 'glob rule' [ "$(sc_policy owner/beta)" = "$(printf 'branch\t')" ]
+ok 'catch-all off' [ "$(sc_policy someone/else)" = "$(printf 'off\t')" ]
+ok 'state-to-main without paths -> off' [ "$(sc_policy owner/bad1)" = "$(printf 'off\t')" ]
+ok 'malformed path -> off' [ "$(sc_policy owner/bad2)" = "$(printf 'off\t')" ]
+ok 'unknown policy -> off' [ "$(sc_policy owner/bad3)" = "$(printf 'off\t')" ]
+
+# --- off: nothing happens --------------------------------------------------
+Z=$(mkrepo someone else)
+echo x > "$Z/scratch.txt"
+run "$Z"
+ok 'off: nothing committed' [ "$(git -C "$Z" status --porcelain)" = "?? scratch.txt" ]
+ok 'off: recorded in checkpoint' has "$CKPT" 'off for someone/else'
+ok 'off: silent status' [ -z "$SC_STATUS" ]
+
+# --- state-to-main, shared checkout on main --------------------------------
+old=$(git -C "$A" rev-parse HEAD)
+sed -i '1s/.*/edited by session/' "$A/intermediate_files/claude_slop/kanban.md"
+echo new > "$A/intermediate_files/claude_slop/new.md"
+echo code > "$A/code.py"
+echo changed > "$A/README.md"
+run "$A" abcdef0123
+tip=$(origin_tip "$A" main)
+ok 's2m shared: origin/main advanced' [ "$tip" != "$old" ]
+ok 's2m shared: linear on old tip' [ "$(git -C "$A" rev-parse "$tip^")" = "$old" ]
+ok 's2m shared: signed' signed "$A" "$tip"
+ok 's2m shared: only state paths in commit' [ "$(files_in "$A" "$tip" | sort | tr '\n' ' ')" = "intermediate_files/claude_slop/kanban.md intermediate_files/claude_slop/new.md " ]
+ok 's2m shared: message names session' strhas "$(git -C "$A" log -1 --format=%s "$tip")" 'State: owner-alpha session abcdef01'
+ok 's2m shared: local main synced' [ "$(git -C "$A" rev-parse HEAD)" = "$tip" ]
+ok 's2m shared: state paths clean locally' [ -z "$(git -C "$A" status --porcelain -- intermediate_files)" ]
+ok 's2m shared: other files untouched' [ "$(git -C "$A" status --porcelain | sort | tr '\n' ' ')" = " M README.md ?? code.py " ]
+ok 's2m shared: status line' strhas "$SC_STATUS" '2 state file(s) -> origin/main'
+ok 's2m shared: shared files recorded' strhas "$SC_STATUS" '2 file(s) uncommitted in the shared checkout'
+ok 's2m shared: no worktree left' [ "$(nworktrees "$A")" = 1 ]
+ok 's2m shared: no tmp left' not leftover_tmp
+
+# --- state-to-main from a worktree while origin/main moves -----------------
+git -C "$A" checkout -q -- README.md; rm -f "$A/code.py"
+W="$T/alpha-wt"
+git -C "$A" worktree add -q "$W" -b claude/x origin/main 2>/dev/null
+other "$A" 'echo other > other.txt; echo appended >> intermediate_files/claude_slop/kanban.md'
+moved=$(origin_tip "$A" main)
+sed -i '1s/.*/edited in worktree/' "$W/intermediate_files/claude_slop/kanban.md"
+echo code > "$W/code.py"
+run "$W"
+tip=$(origin_tip "$A" main)
+ok 's2m wt: on top of moved main' [ "$(git -C "$A" rev-parse "$tip^")" = "$moved" ]
+ok 's2m wt: three-way merged' [ "$(git -C "$A" show "$tip:intermediate_files/claude_slop/kanban.md")" = "$(printf 'edited in worktree\nline2\nline3\nappended')" ]
+ok 's2m wt: signed' signed "$A" "$tip"
+btip=$(origin_tip "$A" claude/x)
+ok 's2m wt: other files on origin/branch' [ -n "$btip" ] && [ "$(files_in "$A" "$btip")" = "code.py" ]
+ok 's2m wt: branch commit signed' signed "$W"
+ok 's2m wt: branch commit message' strhas "$(git -C "$W" log -1 --format=%s)" 'Stop: salvage uncommitted files'
+ok 's2m wt: state file still dirty in worktree (on main, not on branch)' [ "$(git -C "$W" status --porcelain)" = " M intermediate_files/claude_slop/kanban.md" ]
+ok 's2m wt: status line' strhas "$SC_STATUS" 'origin/claude/x'
+ok 's2m wt: no worktree left' [ "$(nworktrees "$A")" = 2 ]
+
+# --- state-to-main conflict refuses ---------------------------------------
+other "$A" 'sed -i "1s/.*/theirs/" intermediate_files/claude_slop/kanban.md'
+moved=$(origin_tip "$A" main)
+sed -i '1s/.*/ours/' "$W/intermediate_files/claude_slop/kanban.md"
+run "$W"
+ok 's2m conflict: origin/main untouched' [ "$(origin_tip "$A" main)" = "$moved" ]
+ok 's2m conflict: refused loudly' has "$CKPT" 'NOT COMMITTED: state paths conflict'
+ok 's2m conflict: status says so' strhas "$SC_STATUS" 'NOT COMMITTED'
+ok 's2m conflict: no worktree left' [ "$(nworktrees "$A")" = 2 ]
+ok 's2m conflict: no tmp left' not leftover_tmp
+ok 's2m conflict: worktree file untouched' [ "$(head -1 "$W/intermediate_files/claude_slop/kanban.md")" = ours ]
+
+# --- state paths already on origin ----------------------------------------
+git -C "$W" checkout -q -- .
+git -C "$W" fetch -q origin && git -C "$W" reset -q --hard origin/main
+other "$A" 'echo again >> intermediate_files/claude_slop/kanban.md'
+moved=$(origin_tip "$A" main)
+echo again >> "$W/intermediate_files/claude_slop/kanban.md"
+run "$W"
+ok 's2m same: origin/main untouched' [ "$(origin_tip "$A" main)" = "$moved" ]
+ok 's2m same: noted' has "$CKPT" 'already match origin/main'
+
+# --- dry run ---------------------------------------------------------------
+git -C "$W" checkout -q -- .
+sed -i '1s/.*/dry/' "$W/intermediate_files/claude_slop/kanban.md"; echo d > "$W/dry.py"
+moved=$(origin_tip "$A" main); bt=$(origin_tip "$A" claude/x); wh=$(git -C "$W" rev-parse HEAD)
+SC_DRY=1 run "$W"
+ok 'dry: origin/main untouched' [ "$(origin_tip "$A" main)" = "$moved" ]
+ok 'dry: origin/branch untouched' [ "$(origin_tip "$A" claude/x)" = "$bt" ]
+ok 'dry: nothing committed locally' [ "$(git -C "$W" rev-parse HEAD)" = "$wh" ]
+ok 'dry: says what would happen' has "$CKPT" 'dry-run: 1 state file(s) would go to origin/main'
+ok 'dry: says branch half too' has "$CKPT" 'dry-run: 1 file(s) would go to origin/claude/x'
+ok 'dry: no worktree left' [ "$(nworktrees "$A")" = 2 ]
+git -C "$W" checkout -q -- .; rm -f "$W/dry.py"
+
+# --- branch policy, shared checkout: record only ---------------------------
+B=$(mkrepo owner beta)
+echo x > "$B/scratch.txt"
+old=$(origin_tip "$B" main)
+run "$B"
+ok 'branch shared: nothing pushed' [ "$(origin_tip "$B" main)" = "$old" ]
+ok 'branch shared: nothing committed' [ "$(git -C "$B" status --porcelain)" = "?? scratch.txt" ]
+ok 'branch shared: recorded' strhas "$SC_STATUS" '1 file(s) uncommitted in the shared checkout'
+
+# --- branch policy, worktree: everything goes ------------------------------
+WB="$T/beta-wt"
+git -C "$B" worktree add -q "$WB" -b claude/y origin/main 2>/dev/null
+echo a > "$WB/a.txt"; echo changed > "$WB/README.md"; git -C "$WB" rm -q intermediate_files/claude_slop/kanban.md
+run "$WB" feedbeef00
+btip=$(origin_tip "$B" claude/y)
+ok 'branch wt: pushed' [ -n "$btip" ] && [ "$btip" = "$(git -C "$WB" rev-parse HEAD)" ]
+ok 'branch wt: all files' [ "$(files_in "$B" "$btip" | sort | tr '\n' ' ')" = "README.md a.txt intermediate_files/claude_slop/kanban.md " ]
+ok 'branch wt: clean after' [ -z "$(git -C "$WB" status --porcelain)" ]
+ok 'branch wt: signed' signed "$WB"
+ok 'branch wt: upstream set' [ "$(git -C "$WB" rev-parse --abbrev-ref '@{u}')" = origin/claude/y ]
+ok 'branch wt: main untouched' [ "$(origin_tip "$B" main)" = "$old" ]
+ok 'branch wt: status' strhas "$SC_STATUS" '3 file(s) -> origin/claude/y'
+
+# --- gitleaks refusal restores the index ----------------------------------
+if command -v gitleaks >/dev/null 2>&1; then
+  echo more > "$WB/README.md"; git -C "$WB" add README.md
+  printf 'aws_key = "AKIAQ7Z2M4X9J1B5K8T3"\n' > "$WB/creds.txt"
+  run "$WB"
+  ok 'gitleaks: refused' has "$CKPT" 'NOT COMMITTED: gitleaks found'
+  ok 'gitleaks: nothing pushed' [ "$(origin_tip "$B" claude/y)" = "$btip" ]
+  ok 'gitleaks: no commit' [ "$(git -C "$WB" rev-parse HEAD)" = "$btip" ]
+  ok 'gitleaks: index restored' [ "$(git -C "$WB" diff --cached --name-only)" = "README.md" ]
+  ok 'gitleaks: file left untracked' [ "$(git -C "$WB" status --porcelain creds.txt)" = "?? creds.txt" ]
+  rm -f "$WB/creds.txt"; git -C "$WB" reset -q; git -C "$WB" checkout -q -- .
+else
+  echo "skip: gitleaks not on PATH"
+fi
+
+# --- a refusing repo hook wins ---------------------------------------------
+hook="$(git -C "$B" rev-parse --path-format=absolute --git-path hooks)/pre-commit"
+mkdir -p "$(dirname "$hook")"
+printf '#!/bin/sh\necho "nope from hook"\nexit 1\n' > "$hook"; chmod +x "$hook"
+echo h > "$WB/h.txt"
+run "$WB"
+ok 'hook: refused' has "$CKPT" 'NOT COMMITTED: commit on claude/y refused'
+ok 'hook: output quoted' has "$CKPT" 'nope from hook'
+ok 'hook: no commit' [ "$(git -C "$WB" rev-parse HEAD)" = "$btip" ]
+ok 'hook: index restored' [ "$(git -C "$WB" status --porcelain)" = "?? h.txt" ]
+rm -f "$hook"
+
+# --- a hook that refuses on the main path too ------------------------------
+printf '#!/bin/sh\nexit 1\n' > "$hook"; chmod +x "$hook"
+WA2="$T/alpha-wt2"; git -C "$A" worktree add -q "$WA2" -b claude/w origin/main 2>/dev/null
+moved=$(origin_tip "$A" main)
+sed -i '1s/.*/hooked/' "$WA2/intermediate_files/claude_slop/kanban.md"
+hookA="$(git -C "$A" rev-parse --path-format=absolute --git-path hooks)/pre-commit"
+cp "$hook" "$hookA"; chmod +x "$hookA"
+run "$WA2"
+ok 's2m hook: refused' has "$CKPT" 'NOT COMMITTED: commit on origin/main refused'
+ok 's2m hook: origin untouched' [ "$(origin_tip "$A" main)" = "$moved" ]
+ok 's2m hook: no worktree left' [ "$(nworktrees "$A")" = 3 ]
+rm -f "$hook" "$hookA"
+
+# --- signing failure never pushes -----------------------------------------
+git -C "$WB" config user.signingkey "$T/missing.pub"
+echo s > "$WB/s.txt"
+run "$WB"
+ok 'signing: refused' has "$CKPT" 'NOT COMMITTED'
+ok 'signing: no commit' [ "$(git -C "$WB" rev-parse HEAD)" = "$btip" ]
+ok 'signing: index restored' [ "$(git -C "$WB" status --porcelain | sort | tr '\n' ' ')" = "?? h.txt ?? s.txt " ]
+git -C "$WB" config user.signingkey "$T/signkey.pub"
+
+# --- unconfigured filter refuses before anything ---------------------------
+F=$(mkrepo owner filt)
+printf '*.enc filter=sops\n' > "$F/.gitattributes"
+git -C "$F" add .gitattributes && git -C "$F" commit -q -m attrs && git -C "$F" push -q origin main 2>/dev/null
+WF="$T/filt-wt"; git -C "$F" worktree add -q "$WF" -b claude/f origin/main 2>/dev/null
+echo x > "$WF/x.txt"
+run "$WF"
+ok 'filter: refused' has "$CKPT" "git filter 'sops' is declared"
+ok 'filter: nothing committed' [ "$(git -C "$WF" status --porcelain)" = "?? x.txt" ]
+ok 'filter: nothing pushed' [ -z "$(origin_tip "$F" claude/f)" ]
+
+# --- direct invocation ------------------------------------------------------
+out=$(bash "$HOOKS/lib-stop-commit.sh" "$WB" 2>&1)
+ok 'direct: key' strhas "$out" 'key:      owner/beta'
+ok 'direct: policy' strhas "$out" 'policy:   branch'
+ok 'direct: worktree' strhas "$out" 'checkout: isolated worktree'
+out=$(bash "$HOOKS/lib-stop-commit.sh" --dry-run "$WB" 2>&1)
+ok 'direct dry-run: rehearses' strhas "$out" 'dry-run: 2 file(s) would go to origin/claude/y'
+ok 'direct dry-run: no commit' [ "$(git -C "$WB" rev-parse HEAD)" = "$btip" ]
+
+printf '%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" = 0 ]

--- a/.claude/hooks/stop-continuity.sh
+++ b/.claude/hooks/stop-continuity.sh
@@ -15,6 +15,13 @@
 #                                  2026-08-21-friction-metric-spec.md
 #   log/auto/<date>-<repo>-<id>.md  a resumable checkpoint the next session reads
 #
+# Then, before the state repo is pushed, it salvages the work repo: whatever
+# the session left uncommitted goes where that repo's policy says -- its
+# state paths to main, everything else to the worktree's branch, or nowhere
+# at all for a repo that has not opted in. The routing lives in
+# lib-stop-commit.sh; the policy table lives in the state repo. The outcome
+# is written into the checkpoint and shown to Mark as a one-line status.
+#
 # One file per session, not one shared append-only log: parallel sessions are
 # normal here, and per-session paths mean two of them never touch the same
 # file and so never conflict on push.
@@ -120,16 +127,32 @@ ckpt="$SD/log/auto/$today-$work_repo-${sid:0:8}.md"
   fi
 } > "$ckpt" 2>/dev/null
 
-# ------------------------------------------------------------ commit + push
-state_is_repo || exit 0
-SR=$(state_repo) || exit 0
-
 # One pusher at a time. Parallel sessions are the norm, and two concurrent
-# rebase-and-push loops in the same worktree corrupt each other's index.
+# rebase-and-push loops in the same worktree corrupt each other's index. The
+# same lock covers the work-repo salvage below: two sessions in one repo
+# must not race each other onto its main.
 LOCK="${TMPDIR:-/tmp}/claude-state-push.lock"
 exec 9>"$LOCK" 2>/dev/null || exit 0
 flock -w 90 9 2>/dev/null || exit 0
 
+# ------------------------------------------------------------ work repo
+# The state repo is handled by the loop below, never here.
+SC_STATUS=""
+if [ -n "$work_root" ] && [ "$work_root" != "$(state_repo 2>/dev/null)" ] \
+   && [ -f "$HOOK_DIR/lib-stop-commit.sh" ]; then
+  # shellcheck source=lib-stop-commit.sh
+  . "$HOOK_DIR/lib-stop-commit.sh"
+  sc_run "$work_root" "$sid" "$ckpt" 2>/dev/null
+fi
+# A successful hook's stdout is never shown; systemMessage is. Print only
+# when the policy did something or refused to -- an `off` repo stays silent.
+if [ -n "$SC_STATUS" ]; then
+  jq -n --arg m "stop-continuity: $SC_STATUS" '{systemMessage: $m}'
+fi
+
+# ------------------------------------------------------------ commit + push
+state_is_repo || exit 0
+SR=$(state_repo) || exit 0
 cd "$SR" 2>/dev/null || exit 0
 
 # A fresh cloud clone has no git filters wired: the clean/smudge programs

--- a/.claude/hooks/stop-continuity.sh
+++ b/.claude/hooks/stop-continuity.sh
@@ -15,12 +15,8 @@
 #                                  2026-08-21-friction-metric-spec.md
 #   log/auto/<date>-<repo>-<id>.md  a resumable checkpoint the next session reads
 #
-# Then, before the state repo is pushed, it salvages the work repo: whatever
-# the session left uncommitted goes where that repo's policy says -- its
-# state paths to main, everything else to the worktree's branch, or nowhere
-# at all for a repo that has not opted in. The routing lives in
-# lib-stop-commit.sh; the policy table lives in the state repo. The outcome
-# is written into the checkpoint and shown to Mark as a one-line status.
+# Then it commits the work repo's uncommitted files per policy (see
+# lib-stop-commit.sh) and finally commits and pushes the state repo.
 #
 # One file per session, not one shared append-only log: parallel sessions are
 # normal here, and per-session paths mean two of them never touch the same
@@ -128,47 +124,34 @@ ckpt="$SD/log/auto/$today-$work_repo-${sid:0:8}.md"
 } > "$ckpt" 2>/dev/null
 
 # One pusher at a time. Parallel sessions are the norm, and two concurrent
-# rebase-and-push loops in the same worktree corrupt each other's index. The
-# same lock covers the work-repo salvage below: two sessions in one repo
-# must not race each other onto its main.
+# rebase-and-push loops in the same worktree corrupt each other's index.
 LOCK="${TMPDIR:-/tmp}/claude-state-push.lock"
 exec 9>"$LOCK" 2>/dev/null || exit 0
 flock -w 90 9 2>/dev/null || exit 0
 
 # ------------------------------------------------------------ work repo
-# The state repo is handled by the loop below, never here.
 SC_STATUS=""
-if [ -n "$work_root" ] && [ "$work_root" != "$(state_repo 2>/dev/null)" ] \
-   && [ -f "$HOOK_DIR/lib-stop-commit.sh" ]; then
-  # shellcheck source=lib-stop-commit.sh
-  . "$HOOK_DIR/lib-stop-commit.sh"
+# shellcheck source=lib-stop-commit.sh
+. "$HOOK_DIR/lib-stop-commit.sh" 2>/dev/null \
+  || { echo '**NOT COMMITTED** — lib-stop-commit.sh is missing' >> "$ckpt"; exit 0; }
+if [ -n "$work_root" ] && [ "$work_root" != "$(state_repo 2>/dev/null)" ]; then
   sc_run "$work_root" "$sid" "$ckpt" 2>/dev/null
 fi
-# A successful hook's stdout is never shown; systemMessage is. Print only
-# when the policy did something or refused to -- an `off` repo stays silent.
-if [ -n "$SC_STATUS" ]; then
-  jq -n --arg m "stop-continuity: $SC_STATUS" '{systemMessage: $m}'
-fi
+# Plain stdout is never shown on a successful hook; systemMessage is.
+[ -n "$SC_STATUS" ] && jq -n --arg m "stop-continuity: $SC_STATUS" '{systemMessage: $m}'
 
 # ------------------------------------------------------------ commit + push
 state_is_repo || exit 0
 SR=$(state_repo) || exit 0
 cd "$SR" 2>/dev/null || exit 0
 
-# A fresh cloud clone has no git filters wired: the clean/smudge programs
-# (sops and friends) are not on PATH, so `git add` through an unconfigured
-# filter writes mangled content and the damage is only visible later. Refuse
-# instead, and say so in the checkpoint rather than skipping quietly.
-if [ -f .gitattributes ] && grep -qE '(^|[[:space:]])filter=' .gitattributes; then
-  for f in $(sed -nE 's/.*[[:space:]]filter=([A-Za-z0-9_.-]+).*/\1/p' .gitattributes \
-             | sort -u); do
-    if ! git config --get "filter.$f.clean" >/dev/null 2>&1; then
-      printf '\n**NOT COMMITTED** — git filter `%s` is declared in .gitattributes\n' "$f" >> "$ckpt"
-      printf 'but not configured in this clone, so committing would mangle content.\n' >> "$ckpt"
-      printf 'Run the repo'"'"'s filter setup, or commit by hand from a real machine.\n' >> "$ckpt"
-      exit 0
-    fi
-  done
+# A fresh cloud clone has no git filters wired; staging through one would
+# mangle content. Refuse and say so in the checkpoint.
+# shellcheck disable=SC2034
+SC_CKPT=""
+if ! sc_filters_ok "$SR"; then
+  printf '\n**NOT COMMITTED** — %s\n' "$SC_REASON" >> "$ckpt"
+  exit 0
 fi
 
 git add state/ >/dev/null 2>&1

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -171,7 +171,7 @@
           {
             "type": "command",
             "command": "h=\"$HOME/.claude/hooks/stop-continuity.sh\"; [ -f \"$h\" ] && bash \"$h\" 2>/dev/null || true",
-            "timeout": 180
+            "timeout": 300
           }
         ]
       }

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -26,3 +26,13 @@ regexes = [
   '''ENC\[AES256_GCM,data:[A-Za-z0-9+/=,_-]+\]''',
   '''age1[0-9a-z]{58}''',
 ]
+
+# stop-commit.test.sh proves the Stop hook's gitleaks gate refuses a
+# credential-shaped string. The string has to exist in the test for the
+# test to mean anything; it is an invented AKIA key that was never issued.
+# Exact string, exact file, nothing else on that file is silenced.
+[[allowlists]]
+description = "the invented AWS key the stop-commit test feeds its own gitleaks gate"
+condition = "AND"
+paths = ['''^\.claude/hooks/stop-commit\.test\.sh$''']
+regexes = ['''AKIAQ7Z2M4X9J1B5K8T3''']

--- a/.local/bin/cloud-session-setup.sh
+++ b/.local/bin/cloud-session-setup.sh
@@ -54,6 +54,7 @@ INSTALL="
 .claude/rules/code.md
 .claude/rules/writing.md
 .claude/hooks/lib-state.sh
+.claude/hooks/lib-stop-commit.sh
 .claude/hooks/session-metrics.jq
 .claude/hooks/lib-metrics-fmt.jq
 .claude/hooks/session-start-continuity.sh

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ degrades to `~/.claude/state/global` if it isn't checked out.
 | --- | --- | --- |
 | `session-start-seed-refresh.sh` | SessionStart | re-runs the cloud seed so a reused container tracks this repo, not the commit it was provisioned from |
 | `session-start-continuity.sh` | SessionStart | injects the open board, where the last three sessions left off, and the week's decision load |
-| `stop-continuity.sh` | Stop | writes the session record, the decision log and an auto-checkpoint, salvages the work repo's uncommitted files per policy, then commits and pushes the state repo |
-| `lib-stop-commit.sh` | (sourced by Stop) | routes a work repo's uncommitted files by the policy table in the state repo: state paths to `main`, the rest to the worktree's branch, or nothing at all |
+| `stop-continuity.sh` | Stop | writes the session record, the decision log and an auto-checkpoint, then commits and pushes the state repo |
+| `lib-stop-commit.sh` | (sourced by Stop) | commits the work repo's uncommitted files per `stop-commit.conf` in the state repo — see RUNBOOK |
 | `measure-git-events.sh` | PostToolUse | logs branches created, PRs opened, cherry-picks |
 | `no-persistent-polling.sh` | PreToolUse | denies wakeups bound to a live session, which re-send its whole context on every fire |
 
@@ -90,20 +90,6 @@ wired.** The clean/smudge programs (sops among them) are not on `PATH`, so a
 and the damage only shows up later. `stop-continuity.sh` checks
 `.gitattributes` against `git config filter.<name>.clean` before staging and
 refuses, recording the refusal in the checkpoint rather than skipping quietly.
-
-A fourth, added 2026-09-01, is a set of refusals rather than a scar: **the
-Stop hook never loses a file, and never touches a repo that hasn't opted
-in.** Where a session's uncommitted files go is a policy per repo, held in
-one private file in the state repo so that opting in is a line, not a PR,
-and turning it all off is deleting the file. The routing keeps four
-invariants that each cost something once elsewhere: no `git add -A` outside
-an isolated worktree; the repo's own signing and commit hooks always run,
-plus gitleaks when it is on `PATH`, and a refusal wins; the commit bound for
-`main` is built in a throwaway worktree of `origin/main`, so a conflict or a
-killed hook can only damage a directory about to be deleted; and no PR is
-opened — a salvaged branch is a backup, not a handoff. The policy table is
-an interim home; whether it should live in each repo instead is an open
-question on the global board.
 
 `session-metrics.jq` types each question put to Mark by what it cost him:
 `scoping` (before any file was written — cheap), `inline` (a bounded choice

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ degrades to `~/.claude/state/global` if it isn't checked out.
 | --- | --- | --- |
 | `session-start-seed-refresh.sh` | SessionStart | re-runs the cloud seed so a reused container tracks this repo, not the commit it was provisioned from |
 | `session-start-continuity.sh` | SessionStart | injects the open board, where the last three sessions left off, and the week's decision load |
-| `stop-continuity.sh` | Stop | writes the session record, the decision log and an auto-checkpoint, then commits and pushes the state repo |
+| `stop-continuity.sh` | Stop | writes the session record, the decision log and an auto-checkpoint, salvages the work repo's uncommitted files per policy, then commits and pushes the state repo |
+| `lib-stop-commit.sh` | (sourced by Stop) | routes a work repo's uncommitted files by the policy table in the state repo: state paths to `main`, the rest to the worktree's branch, or nothing at all |
 | `measure-git-events.sh` | PostToolUse | logs branches created, PRs opened, cherry-picks |
 | `no-persistent-polling.sh` | PreToolUse | denies wakeups bound to a live session, which re-send its whole context on every fire |
 
@@ -89,6 +90,20 @@ wired.** The clean/smudge programs (sops among them) are not on `PATH`, so a
 and the damage only shows up later. `stop-continuity.sh` checks
 `.gitattributes` against `git config filter.<name>.clean` before staging and
 refuses, recording the refusal in the checkpoint rather than skipping quietly.
+
+A fourth, added 2026-09-01, is a set of refusals rather than a scar: **the
+Stop hook never loses a file, and never touches a repo that hasn't opted
+in.** Where a session's uncommitted files go is a policy per repo, held in
+one private file in the state repo so that opting in is a line, not a PR,
+and turning it all off is deleting the file. The routing keeps four
+invariants that each cost something once elsewhere: no `git add -A` outside
+an isolated worktree; the repo's own signing and commit hooks always run,
+plus gitleaks when it is on `PATH`, and a refusal wins; the commit bound for
+`main` is built in a throwaway worktree of `origin/main`, so a conflict or a
+killed hook can only damage a directory about to be deleted; and no PR is
+opened — a salvaged branch is a backup, not a handoff. The policy table is
+an interim home; whether it should live in each repo instead is an open
+question on the global board.
 
 `session-metrics.jq` types each question put to Mark by what it cost him:
 `scoping` (before any file was written — cheap), `inline` (a bounded choice

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -306,59 +306,23 @@ end-to-end proof.
 
 ## Route a repo's uncommitted files at Stop
 
-The Stop hook salvages whatever a session left uncommitted in the repo it was
-working in, per the policy table in the private state repo:
+The Stop hook commits what a session left uncommitted, per
+`~/claude_prompts_scratch/state/global/stop-commit.conf` (one rule per line,
+first match wins, no match = off; the file's header has the format).
 
-```
-~/claude_prompts_scratch/state/global/stop-commit.conf
-```
-
-One rule per line, first match wins:
-
-```
-<owner/repo glob>   state-to-main   <state path> [more paths]
-<owner/repo glob>   branch
-<owner/repo glob>   off
-```
-
-`state-to-main` sends the listed paths straight to `main` (signed, rebased,
-one commit per Stop) and everything else to the worktree's branch on origin.
-`branch` sends everything to the worktree's branch on origin, no PR. Both
-only ever commit non-state files from an isolated worktree; in a shared
-checkout they are listed in the checkpoint and left alone. A repo with no
-matching rule is `off`. Don't skip the rehearsal step: a rule that names the
-wrong state path silently routes to `off`, and the only place that shows is
-the dry run.
-
-1. Add the rule above the catch-all line. Paths are plain relative paths, no
-   globs, no `..`.
-2. Rehearse from any checkout of that repo, dirty or clean:
+1. Add the rule above the catch-all line.
+2. Rehearse — a `NOT COMMITTED:` line names the gate that would refuse:
 
    ```bash
    bash ~/.claude/hooks/lib-stop-commit.sh --dry-run ~/path/to/repo
    ```
 
-   Expect `policy:` to name the rule you wrote, then a `dry-run: N file(s)
-   would go to origin/...` line per destination. A `NOT COMMITTED:` line
-   names the gate that refused — an unconfigured git filter, a gitleaks
-   finding, a conflict with `origin/main` — and is what the real Stop would
-   report too.
-3. Nothing to install. The table is under `state/`, so the next Stop commits
-   and pushes it with the rest of the state repo, and every machine picks it
-   up at its next SessionStart.
+3. Nothing to install; the next Stop pushes the table with the state repo.
 
-To confirm it fired: after the next Stop in that repo, the auto-checkpoint
-`state/global/log/auto/<date>-<repo>-<id>.md` has a `## Stop-commit` section,
-and the terminal shows one `stop-continuity:` line. An `off` repo shows
-nothing.
-
-To turn everything off at once, delete the file. To check the mechanism
-itself on a machine, run the suite — it builds its own origins and signing
-key and touches nothing outside a temp dir:
-
-```bash
-bash ~/.claude/hooks/stop-commit.test.sh   # expect "..., 0 failed"
-```
+Confirm after the next Stop in that repo: the terminal shows one
+`stop-continuity:` line and the auto-checkpoint has a `## Stop-commit`
+section. Delete the file to turn everything off. To check the mechanism
+itself: `bash ~/.claude/hooks/stop-commit.test.sh` (expect `0 failed`).
 
 ## Change what the metrics readouts show
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -33,6 +33,7 @@ and the scars behind them — see [README.md § Conventions](README.md).
 
 **Claude Code — a real machine**
 - [Wire the hooks on a real machine](#wire-the-hooks-on-a-real-machine)
+- [Route a repo's uncommitted files at Stop](#route-a-repos-uncommitted-files-at-stop)
 - [Change what the metrics readouts show](#change-what-the-metrics-readouts-show)
 
 **GitHub repository**
@@ -302,6 +303,62 @@ bash ~/.claude/hooks/statusline-metrics.sh   # prints the status line, or nothin
 
 Then start a session: `session-start-continuity.sh` injecting the board is the
 end-to-end proof.
+
+## Route a repo's uncommitted files at Stop
+
+The Stop hook salvages whatever a session left uncommitted in the repo it was
+working in, per the policy table in the private state repo:
+
+```
+~/claude_prompts_scratch/state/global/stop-commit.conf
+```
+
+One rule per line, first match wins:
+
+```
+<owner/repo glob>   state-to-main   <state path> [more paths]
+<owner/repo glob>   branch
+<owner/repo glob>   off
+```
+
+`state-to-main` sends the listed paths straight to `main` (signed, rebased,
+one commit per Stop) and everything else to the worktree's branch on origin.
+`branch` sends everything to the worktree's branch on origin, no PR. Both
+only ever commit non-state files from an isolated worktree; in a shared
+checkout they are listed in the checkpoint and left alone. A repo with no
+matching rule is `off`. Don't skip the rehearsal step: a rule that names the
+wrong state path silently routes to `off`, and the only place that shows is
+the dry run.
+
+1. Add the rule above the catch-all line. Paths are plain relative paths, no
+   globs, no `..`.
+2. Rehearse from any checkout of that repo, dirty or clean:
+
+   ```bash
+   bash ~/.claude/hooks/lib-stop-commit.sh --dry-run ~/path/to/repo
+   ```
+
+   Expect `policy:` to name the rule you wrote, then a `dry-run: N file(s)
+   would go to origin/...` line per destination. A `NOT COMMITTED:` line
+   names the gate that refused — an unconfigured git filter, a gitleaks
+   finding, a conflict with `origin/main` — and is what the real Stop would
+   report too.
+3. Nothing to install. The table is under `state/`, so the next Stop commits
+   and pushes it with the rest of the state repo, and every machine picks it
+   up at its next SessionStart.
+
+To confirm it fired: after the next Stop in that repo, the auto-checkpoint
+`state/global/log/auto/<date>-<repo>-<id>.md` has a `## Stop-commit` section,
+and the terminal shows one `stop-continuity:` line. An `off` repo shows
+nothing.
+
+To turn everything off at once, delete the file. To check the mechanism
+itself on a machine, run the suite — it builds its own origins and signing
+key and touches nothing outside a temp dir:
+
+```bash
+bash ~/.claude/hooks/stop-commit.test.sh   # expect "..., 0 failed"
+```
 
 ## Change what the metrics readouts show
 


### PR DESCRIPTION
## What

The Stop hook now salvages whatever a session left uncommitted in the repo it was working in, routed by a per-repo policy. Before this it committed only the state repo and listed the work repo's dirty files in the checkpoint, so a reclaimed container lost them.

- `.claude/hooks/lib-stop-commit.sh` — the routing. Policy table is one private file in the state repo (`state/global/stop-commit.conf`, glob on `owner/repo`, first match wins, no match = off). Three policies: `state-to-main` (state paths → `main`, signed, three-way merged onto `origin/main` in a throwaway worktree, rebased, linear; everything else → the worktree's branch on origin), `branch` (everything → the worktree's branch, no PR), `off`.
- `stop-continuity.sh` — calls it under the existing flock, before the state-repo push; appends a `## Stop-commit` section to the checkpoint and emits a one-line `systemMessage` when something happened or was refused. `off` repos stay silent.
- `stop-commit.test.sh` — 84 tests against local bare origins with a throwaway SSH signing key: policy resolution, both paths from shared checkout and worktree, three-way merge when `origin/main` moved, conflict refusal, already-on-main, dry-run, gitleaks refusal restores the index, a refusing repo hook wins on both paths, signing failure never pushes, unconfigured filter refuses, direct invocation.
- Stop hook timeout 180 → 300; lib added to the cloud `INSTALL` list; runbook procedure (§ Route a repo's uncommitted files at Stop) and README rationale.

## Invariants

Never `git add -A` outside an isolated worktree. Never `--no-verify`. Never `-c commit.gpgsign=false` on the work-repo path, and an unsigned commit where signing is configured is not pushed. Never rebase, stash or reset in the session's checkout — the `main`-bound commit is built in a temp worktree that is removed on every exit. Never force-push. Every refusal is named.

## Decisions taken with Mark this session

Policy source is the state-repo table as an interim (small blast radius, one file to delete); the in-repo vs central question is carded for a separate investigation. No PR is opened by the hook — salvage goes to a remote branch. Default for undeclared `mark-brannan/*` repos is `branch`; dotfiles itself is `off` (its worktree is `$HOME` on real machines and a plain git commit bypasses the yadm `pre_commit` gate).

## Verified

- `bash .claude/hooks/stop-commit.test.sh` → 84 passed, 0 failed
- `shellcheck -x -S warning` clean on the three scripts
- Dry run against symphony's shared checkout (records, doesn't commit) and against a throwaway symphony worktree with a `claude_slop` edit (1 state file → `origin/main`, 1 other → the branch), 3.2 s, temp worktree removed
- `systemMessage` on Stop confirmed against the hooks reference (universal field; Stop is not among the events that discard it)

Not verified: a live Stop through the installed hook — that needs this merged and `dotsync`ed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)