### PR TITLE
gitignore: record why credentials never go in .claude.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,14 @@
 .gitconfig
 
 # --- credential material / machine identity: never sync, ever ---
+# .claude.json is co-owned with a running Claude Code, which rewrites it on its
+# own schedule -- measured mtime under a minute with no session doing anything.
+# It carries machineID, userID and oauthAccount, so it is per-machine by
+# construction and can never be synced. Both facts together are why credentials
+# NEVER go in it: there is no regeneration hook to write one from sops, and no
+# staleness detection on rotation except the 4xx you get on next use. Decided
+# 2026-09-01 after measuring an mcpServers header injection work and rejecting
+# it anyway. Do not reopen this to solve an MCP auth problem.
 .claude.json
 .claude.json.backup*
 .claude/.credentials.json


### PR DESCRIPTION
## What

One comment block in `.gitignore`, beside the `.claude.json` entry that already exists.

## Why

`.claude.json` was already NEVER-classed in three places — `.gitignore`, `.config/yadm/hooks/pre_commit` (survives `yadm add -f`), and `.local/bin/dotfiles-triage.sh`. The enforcement was there; the reasoning was not, so the rule was re-litigable by anyone who hit an MCP auth problem and noticed that injecting a header into it works.

It does work — measured. It was rejected anyway, because:

- The file is co-owned with a running Claude Code, which rewrites it on its own schedule (observed mtime under a minute with no session doing anything notable).
- It carries `machineID`, `userID` and `oauthAccount`, so it is per-machine by construction and can never be synced.
- Together: no regeneration hook to write a credential from sops, and no staleness detection on rotation except the 4xx you get on next use.

`.gitignore` is never loaded into a model prompt, so recording this next to the mechanism costs nothing in context — unlike putting it in `CLAUDE.md`.

## Context

Found while establishing why the GitHub MCP server fails under Claude Desktop. Desktop runs the same WSL CLI binary over a relay with no shell in its launch chain, so the `claude` wrapper that scopes `GITHUB_PERSONAL_ACCESS_TOKEN` never fires there. Carrier options were measured: settings `env` blocks do not feed MCP header expansion at either scope, and the server has no OAuth path (`claude mcp login` reports header-only auth). `gh` is already authenticated in both surfaces and covers the capability.

No behaviour change. Comment only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)