### PR TITLE
Enable Mergify merge queue

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,6 @@
+# Enables the Mergify merge queue. Queue a PR with `@mergifyio queue`
+# instead of clicking "Update branch" and waiting for it to go green;
+# Mergify rebases/updates it, runs CI, and merges once checks pass.
+queue_rules:
+  - name: default
+    merge_method: squash

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,6 +1,16 @@
 # Enables the Mergify merge queue. Queue a PR with `@mergifyio queue`
 # instead of clicking "Update branch" and waiting for it to go green;
 # Mergify rebases/updates it, runs CI, and merges once checks pass.
+#
+# main has no branch protection, so queue_conditions is explicit here --
+# without it Mergify falls back to branch-protection required checks,
+# which is none, and would merge without waiting on CI at all.
 queue_rules:
   - name: default
     merge_method: squash
+    queue_conditions:
+      - check-success=gitleaks
+      - check-success=trufflehog
+      - check-success=secrets-encrypted
+      - check-success=shellcheck
+      - check-success=seeded


### PR DESCRIPTION
Adds a minimal `.mergify.yml` defining the default merge queue. GitHub App is already installed. Queue a PR with `@mergifyio queue` instead of clicking "Update branch" and waiting for it to go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)