### PR TITLE
Log ssh commands to the private state repo

### DIFF
--- a/.claude/hooks/log-host-commands.sh
+++ b/.claude/hooks/log-host-commands.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
-# Appends a timestamped line for any Bash command containing "ssh " to
-# intermediate_files/claude_slop/host-commands.log in the current repo, so a
-# host touched over ssh leaves a durable trail even if the session never
-# writes it up elsewhere.
+# Appends a timestamped line for any Bash command containing "ssh " to the
+# private claude_prompts_scratch state repo, so a host touched over ssh
+# leaves a durable trail even if the session never writes it up elsewhere.
+#
+# An ssh command can carry a real hostname, IP, or flag worth keeping out of
+# a public repo's tracked files -- same reasoning as log-commit.sh, which
+# this mirrors. Written per-repo under state/hosts/ so it's still obvious
+# which project a line came from.
 #
 # Fires on PostToolUse for Bash. Best-effort: never blocks the session.
 set -euo pipefail
@@ -16,11 +20,16 @@ printf '%s' "$cmd" | grep -q 'ssh ' || exit 0
 
 cwd=$(printf '%s' "$input" | jq -r '.cwd // ""')
 [ -n "$cwd" ] && cd "$cwd" 2>/dev/null || exit 0
-root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+root=$(git rev-parse --show-toplevel 2>/dev/null || echo "$cwd")
+repo=$(basename "$root")
 
-log_dir="$root/intermediate_files/claude_slop"
+# Same placement rule as log-commit.sh: this is potentially sensitive
+# content, and the project repo it came from may be public. Fall back to a
+# gitignored local dir when the private state repo isn't cloned here.
+log_dir="$HOME/claude_prompts_scratch/state/hosts"
+[ -d "$HOME/claude_prompts_scratch/.git" ] || log_dir="$HOME/.claude/journal/hosts"
 mkdir -p "$log_dir"
 
-printf '%s\t%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$cmd" >> "$log_dir/host-commands.log"
+printf '%s\t%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$cmd" >> "$log_dir/$repo-commands.log"
 
 exit 0

--- a/.claude/hooks/log-host-commands.sh
+++ b/.claude/hooks/log-host-commands.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Appends a timestamped line for any Bash command containing "ssh " to
+# intermediate_files/claude_slop/host-commands.log in the current repo, so a
+# host touched over ssh leaves a durable trail even if the session never
+# writes it up elsewhere.
+#
+# Fires on PostToolUse for Bash. Best-effort: never blocks the session.
+set -euo pipefail
+
+input=$(cat)
+tool=$(printf '%s' "$input" | jq -r '.tool_name // ""')
+[ "$tool" = "Bash" ] || exit 0
+
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
+printf '%s' "$cmd" | grep -q 'ssh ' || exit 0
+
+cwd=$(printf '%s' "$input" | jq -r '.cwd // ""')
+[ -n "$cwd" ] && cd "$cwd" 2>/dev/null || exit 0
+root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+
+log_dir="$root/intermediate_files/claude_slop"
+mkdir -p "$log_dir"
+
+printf '%s\t%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$cmd" >> "$log_dir/host-commands.log"
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -188,6 +188,10 @@
           {
             "type": "command",
             "command": "h=\"$HOME/.claude/hooks/log-commit.sh\"; [ -f \"$h\" ] && bash \"$h\" 2>/dev/null || true"
+          },
+          {
+            "type": "command",
+            "command": "h=\"$HOME/.claude/hooks/log-host-commands.sh\"; [ -f \"$h\" ] && bash \"$h\" 2>/dev/null || true"
           }
         ]
       },

--- a/.local/bin/cloud-session-setup.sh
+++ b/.local/bin/cloud-session-setup.sh
@@ -68,6 +68,7 @@ INSTALL="
 .claude/hooks/metrics-live.sh
 .claude/hooks/metrics-rollup.sh
 .claude/hooks/log-commit.sh
+.claude/hooks/log-host-commands.sh
 .claude/hooks/statusline-metrics.sh
 .claude/hooks/connector-budget.sh
 .claude/hooks/fixtures


### PR DESCRIPTION
New PostToolUse hook, `log-host-commands.sh`: any Bash command containing
`ssh ` gets a timestamped line appended to
`~/claude_prompts_scratch/state/hosts/<repo>-commands.log`, so a host
touched over ssh leaves a trail even when a session doesn't write it up
elsewhere.

Writes to the private state repo rather than the project's own tracked
files — an ssh command can carry a real hostname, IP, or flag, and the
repo it ran in may be public (same reasoning as `log-commit.sh`, which
this mirrors). Falls back to `~/.claude/journal/hosts` when the private
repo isn't cloned on that machine.

Wired into `.claude/settings.json`'s PostToolUse/Bash matcher and added to
`cloud-session-setup.sh`'s INSTALL list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)