### PR TITLE
hooks: block blanket staging, stash pop, bare force-push, tree discards, branch -D

### DIFF
--- a/.claude/hooks/no-git-footguns.sh
+++ b/.claude/hooks/no-git-footguns.sh
@@ -49,15 +49,16 @@ function whole(t) { return t ~ /^(\.|\.\/|\.\/\*|:\/|:\/\.|\*)$/ }
 function fail(r) { print r; exit }
 # Drop every heredoc body: from the end of the line carrying <<WORD to the
 # line that is exactly WORD. The marker itself becomes a plain word.
-function strip_heredocs(b,  d, eol, endm, tail) {
+function strip_heredocs(b,  d, eol, endm, tail, start) {
   while (match(b, /<<-?[ \t]*["'\'']?[A-Za-z_][A-Za-z0-9_]*["'\'']?/)) {
-    d = substr(b, RSTART, RLENGTH); sub(/^<<-?[ \t]*/, "", d); gsub(/["'\'']/, "", d)
-    eol = index(substr(b, RSTART), "\n")
-    if (!eol) return substr(b, 1, RSTART - 1) " HEREDOC "
-    tail = substr(b, RSTART + eol)
+    start = RSTART  # match() below clobbers RSTART; keep the opener'\''s position
+    d = substr(b, start, RLENGTH); sub(/^<<-?[ \t]*/, "", d); gsub(/["'\'']/, "", d)
+    eol = index(substr(b, start), "\n")
+    if (!eol) return substr(b, 1, start - 1) " HEREDOC "
+    tail = substr(b, start + eol)
     endm = match(tail, "(^|\n)[ \t]*" d "[ \t]*(\n|$)")
-    if (!endm) return substr(b, 1, RSTART - 1) " HEREDOC "
-    b = substr(b, 1, RSTART - 1) " HEREDOC " substr(tail, endm + RLENGTH - 1)
+    if (!endm) return substr(b, 1, start - 1) " HEREDOC "
+    b = substr(b, 1, start - 1) " HEREDOC " substr(tail, endm + RLENGTH - 1)
   }
   return b
 }

--- a/.claude/hooks/no-git-footguns.sh
+++ b/.claude/hooks/no-git-footguns.sh
@@ -2,27 +2,32 @@
 # Blocks the git moves that have bitten Mark, or sit in the same class as
 # ones that have, and that a session never has a good reason to make:
 #
-#   blanket staging   git add -A / --all / . / -u with no path, git commit -a
-#                     -> on dotfiles the worktree is $HOME; elsewhere it
-#                        sweeps in a parallel session's files.
-#   stash pop         the stash stack is shared across worktrees, so a pop
-#                     can take another session's entry (reproduced 2026-08-19).
+#   blanket staging   git add -A / --all / . / ./ / -u with no path,
+#                     git commit -a  -> on dotfiles the worktree is $HOME;
+#                     elsewhere it sweeps in a parallel session's files.
+#   stash pop/drop    the stash stack is shared across worktrees, so a pop,
+#                     a bare drop or a clear can take another session's
+#                     entry (reproduced 2026-08-19). apply/drop by sha pass.
 #   force push        bare --force / -f / +refspec anywhere; --force-with-lease
-#                     to main or master. Rebasing a session branch is the one
-#                     legitimate force, and it is --force-with-lease to that
-#                     branch.
+#                     to main or master; deleting main. Rebasing a session
+#                     branch is the one legitimate force, and it is
+#                     --force-with-lease to that branch.
 #   discard           git checkout . / git restore . / git clean -f: throws
 #                     away uncommitted work, same as reset --hard.
 #   branch -D         throws away unmerged work; -d refuses, use that.
 #
 # `yadm` is treated as `git`, since on dotfiles that is what it is.
 #
-# Compound commands and `git -C <dir>` are handled by splitting on shell
-# separators and skipping git's global options; quoted strings are blanked
-# first so a commit message that *mentions* a flag doesn't trip it.
+# Parsing, in order: heredoc bodies are dropped (a doc that *mentions*
+# `git add -A` is not a git command); quotes around a single word are
+# stripped so `git add '.'` is seen; remaining quoted strings are blanked so
+# a commit message that mentions a flag doesn't trip it; then the command
+# is split on shell separators, including parens and braces, and each
+# segment whose command word is git (directly or behind sudo/env/VAR=x)
+# is checked with git's global options skipped.
 #
-# This is a GATE, so it fails closed: no jq, unreadable payload -> block.
-# `git reset --hard` has its own hook (no-git-reset-hard.sh).
+# This is a GATE, so it fails closed: no jq, no awk, unreadable payload ->
+# block. `git reset --hard` has its own hook (no-git-reset-hard.sh).
 set -u
 
 deny() {
@@ -31,7 +36,8 @@ deny() {
   exit 0
 }
 
-command -v jq >/dev/null 2>&1 || deny 'no-git-footguns: jq missing, cannot inspect the command'
+command -v jq  >/dev/null 2>&1 || deny 'no-git-footguns: jq missing, cannot inspect the command'
+command -v awk >/dev/null 2>&1 || deny 'no-git-footguns: awk missing, cannot inspect the command'
 cmd=$(jq -r '.tool_input.command // empty' 2>/dev/null) || deny 'no-git-footguns: unreadable hook payload'
 [ -n "$cmd" ] || exit 0
 
@@ -39,18 +45,47 @@ reason=$(printf '%s\n' "$cmd" | awk '
 function has(t, ch) { return t ~ ("^-[A-Za-z0-9]*" ch "[A-Za-z0-9]*$") }
 function dst(t,  i) { sub(/^\+/, "", t); i = index(t, ":"); if (i) t = substr(t, i + 1); return t }
 function ismain(t) { return t ~ /^(refs\/heads\/)?(main|master)$/ }
+function whole(t) { return t ~ /^(\.|\.\/|\.\/\*|:\/|:\/\.|\*)$/ }
 function fail(r) { print r; exit }
+# Drop every heredoc body: from the end of the line carrying <<WORD to the
+# line that is exactly WORD. The marker itself becomes a plain word.
+function strip_heredocs(b,  d, eol, endm, tail) {
+  while (match(b, /<<-?[ \t]*["'\'']?[A-Za-z_][A-Za-z0-9_]*["'\'']?/)) {
+    d = substr(b, RSTART, RLENGTH); sub(/^<<-?[ \t]*/, "", d); gsub(/["'\'']/, "", d)
+    eol = index(substr(b, RSTART), "\n")
+    if (!eol) return substr(b, 1, RSTART - 1) " HEREDOC "
+    tail = substr(b, RSTART + eol)
+    endm = match(tail, "(^|\n)[ \t]*" d "[ \t]*(\n|$)")
+    if (!endm) return substr(b, 1, RSTART - 1) " HEREDOC "
+    b = substr(b, 1, RSTART - 1) " HEREDOC " substr(tail, endm + RLENGTH - 1)
+  }
+  return b
+}
 { buf = buf $0 "\n" }
 END {
-  # Blank quoted strings: a flag inside a commit message is not a flag.
+  buf = strip_heredocs(buf)
+  # Quotes around one bare word are just quotes: git add '"'"'.'"'"' is git add .
+  while (match(buf, /'\''[^'\'' \t\n&|;()`{}]*'\''/) || match(buf, /"[^" \t\n&|;()`{}]*"/))
+    buf = substr(buf, 1, RSTART - 1) substr(buf, RSTART + 1, RLENGTH - 2) substr(buf, RSTART + RLENGTH)
+  # Anything still quoted is prose: a flag inside a commit message is not a flag.
   gsub(/'\''[^'\'']*'\''/, " Q ", buf)
   gsub(/"[^"]*"/, " Q ", buf)
   gsub(/&&|\|\||;|\||\n|[()`{}]/, "\n", buf)
   nseg = split(buf, seg, "\n")
   for (s = 1; s <= nseg; s++) {
     nt = split(seg[s], t, /[ \t]+/)
+    # git must be the command word: first token, or first after a wrapper
+    # (sudo, env, VAR=x, timeout 30 ...). `echo git add -A` is prose.
     g = 0
-    for (i = 1; i <= nt; i++) if (t[i] ~ /(^|\/)(git|yadm)$/) { g = i; break }
+    for (i = 1; i <= nt; i++) {
+      if (t[i] == "") continue
+      if (t[i] ~ /(^|\/)(git|yadm)$/) { g = i; break }
+      if (t[i] ~ /^[A-Za-z_][A-Za-z0-9_]*=/) continue
+      if (t[i] ~ /^(sudo|env|command|exec|time|nice|nohup|timeout|doas)$/) { wrap = 1; continue }
+      if (wrap && (t[i] ~ /^-/ || t[i] ~ /^[0-9]+[smhd]?$/)) continue
+      break
+    }
+    wrap = 0
     if (!g) continue
     # Skip global options; -C/-c/--git-dir/--work-tree take a value.
     i = g + 1
@@ -67,7 +102,7 @@ END {
       paths = 0; upd = 0
       for (i = 1; i <= na; i++) {
         if (a[i] ~ /^(-A|--all|--no-ignore-removal)$/ || has(a[i], "A")) fail("`git add -A` is blocked: stage by path. On dotfiles the worktree is $HOME; elsewhere it sweeps in files a parallel session is working on.")
-        if (a[i] ~ /^(\.|:\/|:\/\.|\*)$/) fail("`git add " a[i] "` is blocked: stage by path, not the whole tree.")
+        if (whole(a[i])) fail("`git add " a[i] "` is blocked: stage by path, not the whole tree.")
         if (a[i] ~ /^(-u|--update)$/ || has(a[i], "u")) upd = 1
         else if (a[i] !~ /^-/) paths++
       }
@@ -78,27 +113,33 @@ END {
         if (a[i] == "--all" || has(a[i], "a")) fail("`git commit -a` is blocked: it is `git add -u` in disguise. Stage by path, then commit.")
     }
     else if (sub_ == "stash") {
-      for (i = 1; i <= na; i++) if (a[i] !~ /^-/) { if (a[i] == "pop") fail("`git stash pop` is blocked: the stash stack is shared across worktrees and pop can take another session'\''s entry. Use `git stash apply <sha>` and drop the entry afterwards."); break }
+      op = ""; refs = 0
+      for (i = 1; i <= na; i++) if (a[i] !~ /^-/) { if (op == "") op = a[i]; else refs++ }
+      if (op == "pop") fail("`git stash pop` is blocked: the stash stack is shared across worktrees and pop can take another session'\''s entry. Use `git stash apply <sha>` and drop the entry afterwards.")
+      if (op == "clear") fail("`git stash clear` is blocked: the stash stack is shared across worktrees; it is not all yours to clear.")
+      if (op == "drop" && !refs) fail("bare `git stash drop` drops stash@{0}, which may be another session'\''s. Name the entry: `git stash drop stash@{n}` after finding it by tag.")
     }
     else if (sub_ == "push") {
-      force = 0; lease = 0; tomain = 0
+      force = 0; lease = 0; tomain = 0; del = 0
       for (i = 1; i <= na; i++) {
         if (a[i] ~ /^--force-with-lease(=|$)/ || a[i] ~ /^--force-if-includes$/) { lease = 1; continue }
         if (a[i] == "--force" || has(a[i], "f")) force = 1
+        else if (a[i] == "--delete" || has(a[i], "d")) del = 1
         else if (a[i] ~ /^\+/) force = 1
+        else if (a[i] ~ /^:/ && ismain(dst(a[i]))) { del = 1; tomain = 1 }
         else if (a[i] !~ /^-/ && ismain(dst(a[i]))) tomain = 1
       }
       if (force) fail("bare `git push --force` is blocked. Rebasing a session branch is the one legitimate force: use `--force-with-lease origin <branch>`, never to main.")
-      if (lease && tomain) fail("force-pushing main is blocked, with or without --force-with-lease. Main takes rebased branches through a PR.")
+      if (tomain && (lease || del)) fail("force-pushing or deleting main is blocked. Main takes rebased branches through a PR.")
     }
     else if (sub_ == "checkout" || sub_ == "restore") {
-      staged = 0; wt = 0; whole = ""
+      staged = 0; wt = 0; w = ""
       for (i = 1; i <= na; i++) {
         if (a[i] ~ /^(-S|--staged)$/ || has(a[i], "S")) staged = 1
         if (a[i] ~ /^(-W|--worktree)$/ || has(a[i], "W")) wt = 1
-        if (a[i] ~ /^(\.|:\/|:\/\.|\*)$/) whole = a[i]
+        if (whole(a[i])) w = a[i]
       }
-      if (whole != "" && !(sub_ == "restore" && staged && !wt)) fail("`git " sub_ " " whole "` is blocked: it discards every uncommitted change, same as reset --hard. Restore one path at a time, or ask Mark.")
+      if (w != "" && !(sub_ == "restore" && staged && !wt)) fail("`git " sub_ " " w "` is blocked: it discards every uncommitted change, same as reset --hard. Restore one path at a time, or ask Mark.")
     }
     else if (sub_ == "clean") {
       force = 0; dry = 0
@@ -118,7 +159,7 @@ END {
       if (del && force) fail("`git branch --delete --force` is blocked: same as -D.")
     }
   }
-}')
+}') || deny 'no-git-footguns: awk failed, cannot inspect the command'
 
 [ -n "$reason" ] && deny "$reason"
 exit 0

--- a/.claude/hooks/no-git-footguns.sh
+++ b/.claude/hooks/no-git-footguns.sh
@@ -1,0 +1,124 @@
+#!/bin/sh
+# Blocks the git moves that have bitten Mark, or sit in the same class as
+# ones that have, and that a session never has a good reason to make:
+#
+#   blanket staging   git add -A / --all / . / -u with no path, git commit -a
+#                     -> on dotfiles the worktree is $HOME; elsewhere it
+#                        sweeps in a parallel session's files.
+#   stash pop         the stash stack is shared across worktrees, so a pop
+#                     can take another session's entry (reproduced 2026-08-19).
+#   force push        bare --force / -f / +refspec anywhere; --force-with-lease
+#                     to main or master. Rebasing a session branch is the one
+#                     legitimate force, and it is --force-with-lease to that
+#                     branch.
+#   discard           git checkout . / git restore . / git clean -f: throws
+#                     away uncommitted work, same as reset --hard.
+#   branch -D         throws away unmerged work; -d refuses, use that.
+#
+# `yadm` is treated as `git`, since on dotfiles that is what it is.
+#
+# Compound commands and `git -C <dir>` are handled by splitting on shell
+# separators and skipping git's global options; quoted strings are blanked
+# first so a commit message that *mentions* a flag doesn't trip it.
+#
+# This is a GATE, so it fails closed: no jq, unreadable payload -> block.
+# `git reset --hard` has its own hook (no-git-reset-hard.sh).
+set -u
+
+deny() {
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' \
+    "$(printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g; s/^/"/; s/$/"/')"
+  exit 0
+}
+
+command -v jq >/dev/null 2>&1 || deny 'no-git-footguns: jq missing, cannot inspect the command'
+cmd=$(jq -r '.tool_input.command // empty' 2>/dev/null) || deny 'no-git-footguns: unreadable hook payload'
+[ -n "$cmd" ] || exit 0
+
+reason=$(printf '%s\n' "$cmd" | awk '
+function has(t, ch) { return t ~ ("^-[A-Za-z0-9]*" ch "[A-Za-z0-9]*$") }
+function dst(t,  i) { sub(/^\+/, "", t); i = index(t, ":"); if (i) t = substr(t, i + 1); return t }
+function ismain(t) { return t ~ /^(refs\/heads\/)?(main|master)$/ }
+function fail(r) { print r; exit }
+{ buf = buf $0 "\n" }
+END {
+  # Blank quoted strings: a flag inside a commit message is not a flag.
+  gsub(/'\''[^'\'']*'\''/, " Q ", buf)
+  gsub(/"[^"]*"/, " Q ", buf)
+  gsub(/&&|\|\||;|\||\n|\$\(|`/, "\n", buf)
+  nseg = split(buf, seg, "\n")
+  for (s = 1; s <= nseg; s++) {
+    nt = split(seg[s], t, /[ \t]+/)
+    g = 0
+    for (i = 1; i <= nt; i++) if (t[i] ~ /(^|\/)(git|yadm)$/) { g = i; break }
+    if (!g) continue
+    # Skip global options; -C/-c/--git-dir/--work-tree take a value.
+    i = g + 1
+    while (i <= nt && t[i] ~ /^-/) {
+      if (t[i] ~ /^(-C|-c|--git-dir|--work-tree|--namespace)$/) i++
+      i++
+    }
+    if (i > nt) continue
+    sub_ = t[i]; a0 = i + 1
+    delete a; na = 0
+    for (i = a0; i <= nt; i++) if (t[i] != "") a[++na] = t[i]
+
+    if (sub_ == "add") {
+      paths = 0; upd = 0
+      for (i = 1; i <= na; i++) {
+        if (a[i] ~ /^(-A|--all|--no-ignore-removal)$/ || has(a[i], "A")) fail("`git add -A` is blocked: stage by path. On dotfiles the worktree is $HOME; elsewhere it sweeps in files a parallel session is working on.")
+        if (a[i] ~ /^(\.|:\/|:\/\.|\*)$/) fail("`git add " a[i] "` is blocked: stage by path, not the whole tree.")
+        if (a[i] ~ /^(-u|--update)$/ || has(a[i], "u")) upd = 1
+        else if (a[i] !~ /^-/) paths++
+      }
+      if (upd && !paths) fail("`git add -u` with no path is blocked: stage by path.")
+    }
+    else if (sub_ == "commit") {
+      for (i = 1; i <= na; i++)
+        if (a[i] == "--all" || has(a[i], "a")) fail("`git commit -a` is blocked: it is `git add -u` in disguise. Stage by path, then commit.")
+    }
+    else if (sub_ == "stash") {
+      for (i = 1; i <= na; i++) if (a[i] !~ /^-/) { if (a[i] == "pop") fail("`git stash pop` is blocked: the stash stack is shared across worktrees and pop can take another session'\''s entry. Use `git stash apply <sha>` and drop the entry afterwards."); break }
+    }
+    else if (sub_ == "push") {
+      force = 0; lease = 0; tomain = 0
+      for (i = 1; i <= na; i++) {
+        if (a[i] ~ /^--force-with-lease(=|$)/ || a[i] ~ /^--force-if-includes$/) { lease = 1; continue }
+        if (a[i] == "--force" || has(a[i], "f")) force = 1
+        else if (a[i] ~ /^\+/) force = 1
+        else if (a[i] !~ /^-/ && ismain(dst(a[i]))) tomain = 1
+      }
+      if (force) fail("bare `git push --force` is blocked. Rebasing a session branch is the one legitimate force: use `--force-with-lease origin <branch>`, never to main.")
+      if (lease && tomain) fail("force-pushing main is blocked, with or without --force-with-lease. Main takes rebased branches through a PR.")
+    }
+    else if (sub_ == "checkout" || sub_ == "restore") {
+      staged = 0; wt = 0; whole = ""
+      for (i = 1; i <= na; i++) {
+        if (a[i] ~ /^(-S|--staged)$/ || has(a[i], "S")) staged = 1
+        if (a[i] ~ /^(-W|--worktree)$/ || has(a[i], "W")) wt = 1
+        if (a[i] ~ /^(\.|:\/|:\/\.|\*)$/) whole = a[i]
+      }
+      if (whole != "" && !(sub_ == "restore" && staged && !wt)) fail("`git " sub_ " " whole "` is blocked: it discards every uncommitted change, same as reset --hard. Restore one path at a time, or ask Mark.")
+    }
+    else if (sub_ == "clean") {
+      force = 0; dry = 0
+      for (i = 1; i <= na; i++) {
+        if (a[i] == "--force" || has(a[i], "f")) force = 1
+        if (a[i] == "--dry-run" || has(a[i], "n")) dry = 1
+      }
+      if (force && !dry) fail("`git clean -f` is blocked: it deletes untracked files, unrecoverably. `git clean -n` to list them, then remove by path.")
+    }
+    else if (sub_ == "branch") {
+      del = 0; force = 0
+      for (i = 1; i <= na; i++) {
+        if (a[i] == "-D" || has(a[i], "D")) fail("`git branch -D` is blocked: it deletes unmerged work. `git branch -d` refuses when there is something to lose; if it refuses, that is the answer.")
+        if (a[i] ~ /^(-d|--delete)$/ || has(a[i], "d")) del = 1
+        if (a[i] ~ /^(-f|--force)$/ || has(a[i], "f")) force = 1
+      }
+      if (del && force) fail("`git branch --delete --force` is blocked: same as -D.")
+    }
+  }
+}')
+
+[ -n "$reason" ] && deny "$reason"
+exit 0

--- a/.claude/hooks/no-git-footguns.sh
+++ b/.claude/hooks/no-git-footguns.sh
@@ -45,7 +45,7 @@ END {
   # Blank quoted strings: a flag inside a commit message is not a flag.
   gsub(/'\''[^'\'']*'\''/, " Q ", buf)
   gsub(/"[^"]*"/, " Q ", buf)
-  gsub(/&&|\|\||;|\||\n|\$\(|`/, "\n", buf)
+  gsub(/&&|\|\||;|\||\n|[()`{}]/, "\n", buf)
   nseg = split(buf, seg, "\n")
   for (s = 1; s <= nseg; s++) {
     nt = split(seg[s], t, /[ \t]+/)

--- a/.claude/hooks/no-git-footguns.test.sh
+++ b/.claude/hooks/no-git-footguns.test.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Tests for no-git-footguns.sh. Run: bash .claude/hooks/no-git-footguns.test.sh
+set -uo pipefail
+
+HOOK="$(cd "$(dirname "$0")" && pwd)/no-git-footguns.sh"
+pass=0; fail=0
+
+check() {
+  local want=$1 desc=$2 cmd=$3 out got
+  out=$(jq -n --arg c "$cmd" '{tool_name:"Bash",tool_input:{command:$c}}' | timeout 5 sh "$HOOK" 2>&1; [ "${PIPESTATUS[1]}" = 124 ] && echo TIMEOUT)
+  if printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then got=deny; else got=allow; fi
+  if [ "$got" = "$want" ]; then pass=$((pass + 1)); else
+    fail=$((fail + 1)); printf 'FAIL (want %s, got %s): %s\n  cmd: %s\n' "$want" "$got" "$desc" "$cmd"
+    [ -n "$out" ] && printf '  hook output: %s\n' "$out"
+  fi
+}
+
+# --- blanket staging ---
+check deny  'add -A'                    'git add -A'
+check deny  'add --all'                 'git add --all'
+check deny  'add .'                     'git add .'
+check deny  'add :/'                    'git add :/'
+check deny  'add -u no path'            'git add -u'
+check deny  'add cluster -Av'           'git add -Av'
+check deny  'yadm add -A'               'yadm add -A'
+check deny  'add -A in compound'        'cd foo && git add -A && git commit -m x'
+check deny  'git -C dir add -A'         'git -C /some/dir add -A'
+check deny  'commit -a'                 'git commit -a -m "x"'
+check deny  'commit -am'                'git commit -am "x"'
+check deny  'commit --all'              'git commit --all -m x'
+check allow 'add by path'               'git add .claude/hooks/foo.sh README.md'
+check allow 'add -u with path'          'git add -u src/'
+check allow 'add -p'                    'git add -p foo'
+check allow 'commit -m'                 'git commit -m "add -A everything"'
+check allow 'commit --amend'            'git commit --amend --no-edit'
+check allow 'commit message mentions -a' "git commit -m 'block git commit -a'"
+check allow 'commit -S signed'          'git commit -S -m x'
+
+# --- stash ---
+check deny  'stash pop'                 'git stash pop'
+check deny  'stash pop ref'             'git stash pop stash@{2}'
+check allow 'stash push'                'git stash push -u -m tag'
+check allow 'stash apply'               'git stash apply abc123'
+check allow 'stash list'                'git stash list --format="%H %gs"'
+check allow 'stash drop'                'git stash drop stash@{0}'
+
+# --- force push ---
+check deny  'push --force'              'git push --force origin foo'
+check deny  'push -f'                   'git push -f origin foo'
+check deny  'push -fu'                  'git push -fu origin foo'
+check deny  'push +refspec'             'git push origin +foo'
+check deny  'lease to main'             'git push --force-with-lease origin main'
+check deny  'lease to HEAD:main'        'git push --force-with-lease origin HEAD:main'
+check deny  'lease to refs/heads/main'  'git push --force-with-lease origin foo:refs/heads/main'
+check deny  'lease to master'           'git push --force-with-lease=master origin master'
+check allow 'lease to branch'           'git push --force-with-lease origin claude/foo'
+check allow 'lease to branch HEAD:'     'git push --force-with-lease origin HEAD:claude/foo'
+check allow 'lease from main to branch' 'git push --force-with-lease origin main:backup'
+check allow 'plain push main'           'git push origin HEAD:main'
+check allow 'push -u'                   'git push -u origin claude/foo'
+check allow 'push --force-if-includes'  'git push --force-with-lease --force-if-includes origin claude/foo'
+
+# --- discard ---
+check deny  'checkout .'                'git checkout .'
+check deny  'checkout -- .'             'git checkout -- .'
+check deny  'restore .'                 'git restore .'
+check deny  'restore --worktree .'      'git restore -SW .'
+check deny  'clean -f'                  'git clean -f'
+check deny  'clean -fdx'                'git clean -fdx'
+check allow 'checkout branch'           'git checkout main'
+check allow 'checkout -b'               'git checkout -b foo'
+check allow 'checkout one path'         'git checkout -- src/foo.ts'
+check allow 'restore one path'          'git restore src/foo.ts'
+check allow 'restore --staged .'        'git restore --staged .'
+check allow 'clean -n'                  'git clean -n'
+check allow 'clean -fdn'                'git clean -fdn'
+
+# --- branch ---
+check deny  'branch -D'                 'git branch -D foo'
+check deny  'branch --delete --force'   'git branch --delete --force foo'
+check deny  'branch -df'                'git branch -df foo'
+check allow 'branch -d'                 'git branch -d foo'
+check allow 'branch list'               'git branch -a'
+check allow 'branch -D in string'       'git commit -m "hooks: block git branch -D"'
+
+# --- not git at all ---
+check allow 'grep for the flag'         'grep -rn "git add -A" .'
+check allow 'gitleaks'                  'gitleaks protect --staged'
+check allow 'empty'                     ''
+check allow 'echo prose'                'echo "run git push --force later"'
+
+printf '%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/.claude/hooks/no-git-footguns.test.sh
+++ b/.claude/hooks/no-git-footguns.test.sh
@@ -86,6 +86,11 @@ check allow 'branch -D in string'       'git commit -m "hooks: block git branch 
 # --- not git at all ---
 check allow 'grep for the flag'         'grep -rn "git add -A" .'
 check allow 'gitleaks'                  'gitleaks protect --staged'
+check deny  'add -A in $(...)'           'x=$(git add -A)'
+check deny  'checkout . in $(...)'       'x=$(git checkout .)'
+check deny  'clean -f in subshell'       '(git clean -fd)'
+check deny  'stash pop in braces'        '{ git stash pop; }'
+check deny  'force push in backticks'    'x=`git push -f origin foo`'
 check allow 'empty'                     ''
 check allow 'echo prose'                'echo "run git push --force later"'
 

--- a/.claude/hooks/no-git-footguns.test.sh
+++ b/.claude/hooks/no-git-footguns.test.sh
@@ -121,6 +121,9 @@ check allow 'echo prose unquoted'       'echo git add -A'
 check allow 'heredoc body'              $'cat > doc.md <<\'EOF\'\nnever run git add -A\nEOF'
 check allow 'heredoc body unquoted tag' $'cat > doc.md <<EOF\n- `git push --force` is bad\nEOF'
 check allow 'heredoc with dash'         $'cat <<-EOF\n\tgit stash pop\n\tEOF'
+check deny  'footgun before heredoc'    $'git add -A\ncat <<EOF\nx\nEOF'
+check deny  'footgun before long heredoc' $'git checkout .\ngit commit -F- <<\'EOF\'\nfix a bug in the thing\nsecond line\nEOF'
+check allow 'clean cmd before heredoc'  $'git add foo.sh\ngit commit -F- <<\'EOF\'\nnever git add -A\nEOF'
 check allow 'printf prose'              'printf "%s\n" git checkout .'
 
 printf '%d passed, %d failed\n' "$pass" "$fail"

--- a/.claude/hooks/no-git-footguns.test.sh
+++ b/.claude/hooks/no-git-footguns.test.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Tests for no-git-footguns.sh. Run: bash .claude/hooks/no-git-footguns.test.sh
+# shellcheck disable=SC2016  # the commands under test contain $(...) on purpose
 set -uo pipefail
 
 HOOK="$(cd "$(dirname "$0")" && pwd)/no-git-footguns.sh"
@@ -93,6 +94,34 @@ check deny  'stash pop in braces'        '{ git stash pop; }'
 check deny  'force push in backticks'    'x=`git push -f origin foo`'
 check allow 'empty'                     ''
 check allow 'echo prose'                'echo "run git push --force later"'
+
+# --- bypasses found on second look ---
+check deny  'add ./'                    'git add ./'
+check deny  'add quoted .'              "git add -- '.'"
+check deny  'add dquoted .'             'git add "."'
+check deny  'add quoted star'           "git add '*'"
+check deny  'checkout quoted ./'        "git checkout -- './'"
+check deny  'stash drop bare'           'git stash drop'
+check deny  'stash clear'               'git stash clear'
+check deny  'push --delete main'        'git push --delete origin main'
+check deny  'push -d main'              'git push -d origin main'
+check deny  'push :main'                'git push origin :main'
+check deny  'sudo git add -A'           'sudo git add -A'
+check deny  'env var prefix'            'GIT_DIR=x git add -A'
+check deny  'timeout wrapper'           'timeout 30 git push -f origin foo'
+check deny  'full path git'             '/usr/bin/git add -A'
+check deny  'after heredoc command'     $'cat <<EOF > x\nhi\nEOF\ngit add -A'
+check allow 'push --delete branch'      'git push --delete origin claude/foo'
+check allow 'push :branch'              'git push origin :claude/foo'
+check allow 'stash drop by ref'         'git stash drop stash@{3}'
+check allow 'stash drop by sha'         'git stash drop abc123'
+
+# --- prose that names a footgun is not a footgun ---
+check allow 'echo prose unquoted'       'echo git add -A'
+check allow 'heredoc body'              $'cat > doc.md <<\'EOF\'\nnever run git add -A\nEOF'
+check allow 'heredoc body unquoted tag' $'cat > doc.md <<EOF\n- `git push --force` is bad\nEOF'
+check allow 'heredoc with dash'         $'cat <<-EOF\n\tgit stash pop\n\tEOF'
+check allow 'printf prose'              'printf "%s\n" git checkout .'
 
 printf '%d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -109,6 +109,11 @@
             "type": "command",
             "command": "h=\"$HOME/.claude/hooks/no-git-reset-hard.sh\"; [ -f \"$h\" ] && sh \"$h\" || true",
             "statusMessage": "Checking for git reset --hard"
+          },
+          {
+            "type": "command",
+            "command": "h=\"$HOME/.claude/hooks/no-git-footguns.sh\"; [ -f \"$h\" ] && sh \"$h\" || true",
+            "statusMessage": "Checking for git footguns"
           }
         ]
       },

--- a/.local/bin/cloud-session-setup.sh
+++ b/.local/bin/cloud-session-setup.sh
@@ -64,6 +64,7 @@ INSTALL="
 .claude/hooks/no-draft-pr.sh
 .claude/hooks/no-git-reset-hard.sh
 .claude/hooks/no-unsigned-push.sh
+.claude/hooks/no-git-footguns.sh
 .claude/hooks/session-start-seed-refresh.sh
 .claude/hooks/guard-add-repo.sh
 .claude/hooks/metrics-live.sh


### PR DESCRIPTION
New PreToolUse gate `no-git-footguns.sh` (POSIX sh + awk, fails closed), alongside the existing `reset --hard` guard. `yadm` is treated as `git`.

Blocks:
- `git add -A` / `--all` / `.` / `:/`, `git add -u` with no path, `git commit -a`/`-am` — stage by path
- `git stash pop` — shared stash stack across worktrees; use `stash apply <sha>`
- bare `git push --force` / `-f` / `+refspec` anywhere; `--force-with-lease` to `main`/`master`. `--force-with-lease` to a session branch (the rebase case) still passes
- `git checkout .` / `git restore .` (except `restore --staged .`), `git clean -f` without `-n`
- `git branch -D` / `--delete --force`; `-d` still passes

Quoted strings are blanked before matching, so a commit message that mentions a flag does not trip it. Compound commands and `git -C <dir>` are handled.

Tests: `bash .claude/hooks/no-git-footguns.test.sh` — 62 cases, all passing. Hook added to `settings.json` and the cloud-session-setup INSTALL list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safeguards that block high-risk Git operations, including destructive resets, force pushes, blanket staging, and irreversible branch or stash actions.
  * Safeguards also apply when commands use common wrappers or alternate Git-compatible tooling.
  * Added fail-closed behavior when command validation cannot be completed.

* **Tests**
  * Added comprehensive checks covering blocked operations, command variations, and attempts to bypass safeguards.

* **Chores**
  * Enabled the safeguards automatically and included them in the local setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->