### PR TITLE
ci: let Mergify keep open pull requests up to date with main

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -27,5 +27,14 @@ pull_request_rules:
       - -conflict
       - -closed
       - '#commits-behind>0'
+      # Automatic rules are not covered by commands_restrictions, and anyone
+      # with read access can open a pull request off an existing branch of a
+      # public repo. Without this, that stranger's pull request would have
+      # Mergify write a merge commit into a branch they cannot push to.
+      - or:
+          - author=mark-brannan
+          - author=dependabot[bot]
+          # A fork's head branch is outside this repository.
+          - from-fork
     actions:
       update: {}

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -14,3 +14,18 @@ queue_rules:
       - check-success=secrets-encrypted
       - check-success=shellcheck
       - check-success=seeded
+
+# Keeps open pull requests up to date with main. Nothing here auto-merges:
+# main has no ruleset and no required approvals, and this repo's worktree is
+# $HOME on every machine -- a merge lands in a live home directory at the next
+# dotsync, so it stays a deliberate act.
+pull_request_rules:
+  - name: Update pull requests that have fallen behind main
+    conditions:
+      - base=main
+      - -draft
+      - -conflict
+      - -closed
+      - '#commits-behind>0'
+    actions:
+      update: {}


### PR DESCRIPTION
The `queue_rules` block here defines how a PR merges, not what enters the queue — so nothing happened without an `@mergifyio queue` comment.

Adds the update rule: open, non-draft, non-conflicting PRs on `main` get their branch refreshed automatically.

No auto-merge in this repo, deliberately. `main` has no ruleset and no required approvals, and this worktree is `$HOME` on every machine — a merge lands in a live home directory at the next `dotsync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)