### PR TITLE
claude: extract wrapup skill from standing orders

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -177,10 +177,7 @@ the board and the last sessions' checkpoints in front of every session.
 an auto-checkpoint, then commits and pushes — every Stop, unprompted. Don't
 redo that by hand and don't wait to be asked. What's left to judgment:
 
-- **Narrative beats the auto-checkpoint.** The hook records what happened;
-  only you can record what it meant and what should happen next. On "wrap
-  up" / "log it", write that to `log/YYYY-MM-DD-<slug>.md`. The machine one
-  is evidence, not a substitute.
+- **On "wrap up", "log it", a hand-off, or session end, invoke `/wrapup`.**
 - **Capture ≠ activation.** Something off-goal but real → a card, written
   at discovery (see Open loops); trivial → drop it. High importance + urgent ->
   suggest a hand-off prompt for a parallel session or delegate to sub-agent.
@@ -190,23 +187,8 @@ redo that by hand and don't wait to be asked. What's left to judgment:
   is cheap — context is fresh and a wrong assumption would have cost the
   whole session. The same question mid-flight makes me reload context I
   haven't been carrying. Front-load them; ask inline only when the answer
-  blocks the current task; card the rest as they come up and bring them for
-  batch accept/edit/delete at wrap-up. The decision log types every ask
-  this way, so the ratio is checkable rather than remembered.
-- **Where state lands, settled 2026-08-19:** a project's session state
-  stays in that project's own repo. Symphony's is
-  `~/symphony/intermediate_files/claude_slop/` (kanban.md + log.md); its
-  human-facing `maintenance/log.md` and `priorities.md` get only finished,
-  high-level results. **Global and cross-cutting state** — standing
-  orders, rules, hooks, Claude tooling, anything spanning projects — goes
-  to the private repo `~/claude_prompts_scratch`, under
-  `state/global/kanban.md` and `state/global/log/`; so does state for any
-  project with no private repo of its own. Work on `main` there; `git pull
-  --rebase` before pushing. **Never into dotfiles** — it is public, and
-  session notes name boats, hosts and services. Dotfiles therefore has no
-  board of its own: its cards sit on the global board, and anything with a
-  question in it becomes a dotfiles issue the card links to. Never stage
-  one project's work under another's.
+  blocks the current task; card the rest as they come up. The decision log
+  types every ask this way, so the ratio is checkable rather than remembered.
 
 ## Open loops
 
@@ -244,17 +226,6 @@ card contract:
 - Sections and checkboxes, not a table.
 
 If a loop is not worth a card, it is not worth telling me about either.
-
-**End with a prompt, not a status bullet or observation.** A closing summary that reads
-"the vague thing is borked, your call" costs a read and returns nothing actionable
-When session ends with work still to do, provide an explicit hand-off prompt.
-A hand-off prompt must be ready to paste, and names the branch, PR, file, etc to act on.
-**Every handoff prompt names a recommended model and difficulty setting**, 
-Anything only I can do personally is a card, referenced by link and with a short name.
-Either the link or the short name must be distinctive enough for future sessions to easily find the card
-Nothing else goes in a closing message. Both forms must survive the session — written so somebody
-who was not in it can act on them.
-
 
 **A finding that reads like a real security or credential exposure never
 goes into a public repo's tracked files** — board, log, doc, commit

--- a/.claude/skills/wrapup/SKILL.md
+++ b/.claude/skills/wrapup/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: wrapup
+description: Close a session — write the narrative log to the right state repo, bring the session's cards for batch accept/edit/delete, and end with a paste-ready hand-off prompt. Use when Mark says "wrap up", "log it", "hand off", "hand-off prompt", "call it there", or when a session is ending with work still open.
+---
+
+# Wrapping up
+
+The Stop hook (`stop-continuity.sh`) already writes the session record, the
+typed decision log and an auto-checkpoint, then commits and pushes the state
+repo — every Stop, unprompted. Don't redo any of that by hand and don't wait
+to be asked. This skill covers what only you can write: what the session
+meant, what is still open, and how the next one starts.
+
+## 1. Where state lands
+
+Settled 2026-08-19. A project's session state stays in that project's own
+repo. Never stage one project's work under another's.
+
+| Work | State goes to |
+|---|---|
+| Symphony | `~/symphony/intermediate_files/claude_slop/` (`kanban.md` + `log.md`). Its human-facing `maintenance/log.md` and `priorities.md` get only finished, high-level results. |
+| Global and cross-cutting — standing orders, rules, hooks, Claude tooling, anything spanning projects | The private repo `~/claude_prompts_scratch`, under `state/global/kanban.md` and `state/global/log/`. Work on `main` there; `git pull --rebase` before pushing. |
+| Any project with no private repo of its own | The same global paths. |
+| Dotfiles | **Never** — it is public, and session notes name boats, hosts and services. Dotfiles has no board of its own: its cards sit on the global board, and anything with a question in it becomes a dotfiles issue the card links to. |
+| Any other project with its own board | That repo, at the path its CLAUDE.md names. |
+
+## 2. Narrative log
+
+Write `log/YYYY-MM-DD-<slug>.md` under the state directory above. The
+auto-checkpoint records what happened; only you can record what it meant
+and what should happen next. The machine one is evidence, not a substitute.
+Put in it:
+
+- what was decided, and why — including calls that reversed or narrowed an
+  earlier one;
+- what was tried and abandoned, so the next session doesn't retry it;
+- what comes next: the hand-off prompt from step 4, verbatim;
+- observations worth keeping. They go here, silently — never as an aside in
+  chat.
+
+## 3. Cards
+
+Bring every card written during the session for batch accept / edit /
+delete: one list, one line per card, each with its link. Apply Mark's
+decisions to the board before the session ends. Anything only Mark can do
+personally is a card, referenced by link and by a short name; either the
+link or the short name must be distinctive enough for a future session to
+find it.
+
+## 4. Hand-off prompt
+
+When the session ends with work still to do, write the prompt that starts
+the next one. It must:
+
+- be **ready to paste** — no "as discussed", no context the reader has to
+  supply;
+- name the **branch, PR, file, card, etc.** it acts on;
+- name a **recommended model and difficulty (effort) setting**;
+- be written so somebody who was not in this session can act on it.
+
+Put it in the narrative log as well as the chat. The log survives; the chat
+does not.
+
+## 5. The closing message
+
+End with a prompt, not a status bullet or observation. A closing that reads
+"the vague thing is borked, your call" costs a read and returns nothing
+actionable. The closing message holds exactly two things: the hand-off
+prompt, and the cards only Mark can act on, by link and short name. Nothing
+else goes in it.

--- a/.local/bin/cloud-session-setup.sh
+++ b/.local/bin/cloud-session-setup.sh
@@ -53,6 +53,7 @@ INSTALL="
 .claude/CLAUDE.md
 .claude/rules/code.md
 .claude/rules/writing.md
+.claude/skills/wrapup/SKILL.md
 .claude/hooks/lib-state.sh
 .claude/hooks/session-metrics.jq
 .claude/hooks/lib-metrics-fmt.jq


### PR DESCRIPTION
## What

- New `.claude/skills/wrapup/SKILL.md`. Moved from `.claude/CLAUDE.md`: where state lands (now a table, dated 2026-08-19 as before), the narrative log path `log/YYYY-MM-DD-<slug>.md` and what goes in it, the card batch accept/edit/delete step, the hand-off prompt spec (paste-ready; names branch, PR, file, card; recommended model and difficulty), and "nothing else goes in a closing message". Description fires on "wrap up", "log it", "hand off", and a session ending with work open.
- `.claude/CLAUDE.md`: 276 → 247 lines. One resident line in Continuity: invoke `/wrapup` on wrap-up. Everything that stays is untouched apart from re-wrapping the one bullet the batch-cards clause was cut from.
- `.local/bin/cloud-session-setup.sh`: adds the skill to `INSTALL`, otherwise the resident line is a silent no-op in every cloud session. Not verified on a VM: `--dry-run` refuses on a yadm-managed machine by design, so only `sh -n` ran here.

## Removed rather than moved

Nothing. The skill reads the Stop hook and references it in one sentence instead of restating it; the "mechanics are hooks" paragraph stays in CLAUDE.md untouched.

## Overlap with #77

#77 creates the same file and rewrites the same two sections of CLAUDE.md, plus a full compression of the file and a `card-write` skill. The two cannot both merge as-is; whichever lands second must rebase, and the `wrapup` skill will conflict line for line. This PR is the narrow version: same skill scope, no other edits to CLAUDE.md, no `card-write`. If #77 is preferred, close this; if this is preferred, #77's wrapup file and Continuity/Open-loops edits should be dropped from it and its remaining compression rebased on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)