### PR TITLE
claude: extract card-write skill from standing orders

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -179,7 +179,7 @@ redo that by hand and don't wait to be asked. What's left to judgment:
 
 - **On "wrap up", "log it", a hand-off, or session end, invoke `/wrapup`.**
 - **Capture ≠ activation.** Something off-goal but real → a card, written
-  at discovery (see Open loops); trivial → drop it. High importance + urgent ->
+  at discovery (`/card-write`); trivial → drop it. High importance + urgent ->
   suggest a hand-off prompt for a parallel session or delegate to sub-agent.
   Never a new workstream mid-session; focus on the goal and staying in flow.
 - **New sessions open by pulling from a board.** WIP limit ~2–3.
@@ -192,40 +192,14 @@ redo that by hand and don't wait to be asked. What's left to judgment:
 
 ## Open loops
 
-Every project keeps one board: `kanban.md` at the repo root, or the path its
-own CLAUDE.md names. A loop that belongs to no project goes to
-`claude_prompts_scratch/state/global/kanban.md`; so does the first card of a
-repo with no board — don't create a board unilaterally, a card landing
-global is the signal to decide whether that repo earns one. A question goes
-to an issue; an action goes on a board. A public repo's board never carries
-boats, hosts, or services — those cards go global, with a link back.
-
-**Write the card when the loop is found, never at the end of a session.** By
-wrap-up the context has been compacted, so the comment link, the timestamp
-and the exact wording are gone and what is left is unactionable. Discovery
-is the last moment the evidence still exists. Writing the card is capture,
-not activation — the work still waits for a pull.
+**Write the card the moment a loop is found, with `/card-write`** — which
+board, which section, and the one-line card contract live there. By wrap-up
+the context has been compacted and the evidence is gone.
 
 **A unilateral call — deleting someone else's work, cutting scope, reversing
 a prior decision — gets a card the moment it's made, not when review flags
 it.** A PR comment defending the call afterward doesn't substitute; it's
 context for the reviewer, not tracked anywhere the continuity system looks.
-
-One file, two sections — `## Solace's ` and `## Claude's` — because the useful
-edges cross between them: an agent's card is routinely blocked on mine, and
-two files would show each list clear while the work sits deadlocked. The
-card contract:
-
-- One line per card: a link, and the action in the imperative. Add
-  `blocked:` and the dependency only when the card is blocked. The link is
-  never optional — a card nobody but its author can resolve is not a card.
-- Cards die when done. This is a work-in-progress list, not a log — `git
-  log` and the session logs keep the history.
-- Keep each section short. A list nobody can hold in their head is a second
-  place to lose things; finish or delete before adding.
-- Sections and checkboxes, not a table.
-
-If a loop is not worth a card, it is not worth telling me about either.
 
 **A finding that reads like a real security or credential exposure never
 goes into a public repo's tracked files** — board, log, doc, commit

--- a/.claude/skills/card-helper/SKILL.md
+++ b/.claude/skills/card-helper/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: card
-description: Walk the user through one open-loop card, one step at a time, with exact links, click paths and copy-paste commands. Use when they say "walk me through card N", "/card", "escort me through this", or ask to work a specific item off kanban.md or a similar open-loops list. Not for doing the work autonomously — this is for loops only the user can close, in UIs and accounts an agent cannot reach.
+name: card-helper
+description: Walk the user through one open-loop card, one step at a time, with exact links, click paths and copy-paste commands. Use when they say "walk me through card N", "/card-helper", "escort me through this", or ask to work a specific item off kanban.md or a similar open-loops list. Not for doing the work autonomously — this is for loops only the user can close, in UIs and accounts an agent cannot reach.
 ---
 
 # Walking a card

--- a/.claude/skills/card-helper/SKILL.md
+++ b/.claude/skills/card-helper/SKILL.md
@@ -11,9 +11,9 @@ their screen outranks anything you believe about it.
 
 ## Pick the card
 
-Find the board the way `/card-write` says to — this project's own
-`kanban.md` if it has one, else the global board. Read the whole file, then
-default to walking one card from `## Solace's` (older boards: `## Yours`):
+Find the board the way `/card-write` says to; its routing rules are the
+contract, don't paraphrase them here. Read the whole file, then default to
+walking one card from `## Solace's` (older boards: `## Yours`):
 that's the work only the user can close, which is what this skill is for.
 If the argument names a different card or section, walk that one instead.
 Never start a second card without being asked.

--- a/.claude/skills/card-write/SKILL.md
+++ b/.claude/skills/card-write/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: card-write
-description: Write or edit an open-loop card on a kanban.md board in the house format — one line, imperative, link mandatory, right section, right board. Use whenever a loop is found that must be captured ("card that", "add a card", "put it on the board", a unilateral call, a finding that doesn't belong in this session). Not for walking a card with the user — that is /card.
+description: Write or edit an open-loop card on a kanban.md board in the house format — one line, imperative, link mandatory, right section, right board. Use whenever a loop is found that must be captured ("card that", "add a card", "put it on the board", a unilateral call, a finding that doesn't belong in this session). Not for walking a card with the user — that is /card-helper.
 ---
 
 # Writing a card
@@ -45,6 +45,8 @@ and don't rename it as a side effect of adding a card.
   session to find the card.
 - Add `blocked:` and the dependency only when the card is actually blocked.
 - Sections and checkboxes, not a table.
+- **Order is priority.** The top card in a section is the next one to pull.
+  Place a new card where it belongs, not at the bottom by default.
 
 ## Lifecycle
 

--- a/.claude/skills/card-write/SKILL.md
+++ b/.claude/skills/card-write/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: card-write
+description: Write or edit an open-loop card on a kanban.md board in the house format — one line, imperative, link mandatory, right section, right board. Use whenever a loop is found that must be captured ("card that", "add a card", "put it on the board", a unilateral call, a finding that doesn't belong in this session). Not for walking a card with the user — that is /card.
+---
+
+# Writing a card
+
+A card is capture, not activation: the work still waits for a pull. Write
+it the moment the loop is found, while the comment link, timestamp and
+exact wording still exist.
+
+## Which board
+
+- Every project keeps one board: `kanban.md` at the repo root, or the path
+  its own CLAUDE.md names.
+- A loop that belongs to no project, or the first card of a repo with no
+  board, goes to `~/claude_prompts_scratch/state/global/kanban.md`. Don't
+  create a board unilaterally — a card landing global is the signal to
+  decide whether that repo earns one.
+- A **question** goes to an issue; an **action** goes on a board.
+- A **public repo's board never carries boats, hosts or services.** Those
+  cards go global, with a link back.
+- Dotfiles has no board: its cards go global, and anything with a question
+  in it becomes a dotfiles issue the card links to.
+
+## Which section
+
+One file, two sections: `## Solace's` for loops only Mark can close, and
+`## Claude's` for loops an agent can. One file, not two, because the useful
+edges cross — an agent's card is routinely blocked on one of Mark's, and two
+files would show each list clear while the work sits deadlocked. Older
+boards still head the first section `## Yours`; treat it as the same section
+and don't rename it as a side effect of adding a card.
+
+## The line
+
+```markdown
+- [ ] **Short name** — action in the imperative ([link](https://...)) blocked: <dependency>
+```
+
+- One line per card: a link, and the action in the imperative.
+- **The link is never optional** — a card nobody but its author can
+  resolve is not a card.
+- The short name or the link must be distinctive enough for a future
+  session to find the card.
+- Add `blocked:` and the dependency only when the card is actually blocked.
+- Sections and checkboxes, not a table.
+
+## Lifecycle
+
+- **Cards die when done.** Delete the line — this is a work-in-progress
+  list, not a log; `git log` and the session logs keep the history. A ticked
+  box is at most a placeholder until the next tidy.
+- Keep each section short. A list nobody can hold in their head is a second
+  place to lose things; finish or delete before adding.
+- If a loop is not worth a card, it is not worth telling Mark about either.
+- Commit the board in its own repo, and never stage one project's work
+  under another's. The Stop hook commits the global state repo; a project
+  board is committed with that project's work.

--- a/.claude/skills/card/SKILL.md
+++ b/.claude/skills/card/SKILL.md
@@ -11,12 +11,12 @@ their screen outranks anything you believe about it.
 
 ## Pick the card
 
-Find the board the way the standing orders' Continuity section says to —
-this project's own `kanban.md` if it has one, else the global board. Read
-the whole file, then default to walking one card from `## Yours`: that's
-the work only the user can close, which is what this skill is for. If the
-argument names a different card or section, walk that one instead. Never
-start a second card without being asked.
+Find the board the way `/card-write` says to — this project's own
+`kanban.md` if it has one, else the global board. Read the whole file, then
+default to walking one card from `## Solace's` (older boards: `## Yours`):
+that's the work only the user can close, which is what this skill is for.
+If the argument names a different card or section, walk that one instead.
+Never start a second card without being asked.
 
 ## Load the real context first
 

--- a/.claude/skills/wrapup/SKILL.md
+++ b/.claude/skills/wrapup/SKILL.md
@@ -46,6 +46,7 @@ decisions to the board before the session ends. Anything only Mark can do
 personally is a card, referenced by link and by a short name; either the
 link or the short name must be distinctive enough for a future session to
 find it.
+Board selection and card format: `/card-write`.
 
 ## 4. Hand-off prompt
 

--- a/.local/bin/cloud-session-setup.sh
+++ b/.local/bin/cloud-session-setup.sh
@@ -53,6 +53,7 @@ INSTALL="
 .claude/CLAUDE.md
 .claude/rules/code.md
 .claude/rules/writing.md
+.claude/skills/card-write/SKILL.md
 .claude/skills/wrapup/SKILL.md
 .claude/hooks/lib-state.sh
 .claude/hooks/session-metrics.jq

--- a/.local/bin/cloud-session-setup.sh
+++ b/.local/bin/cloud-session-setup.sh
@@ -53,6 +53,7 @@ INSTALL="
 .claude/CLAUDE.md
 .claude/rules/code.md
 .claude/rules/writing.md
+.claude/skills/card-helper/SKILL.md
 .claude/skills/card-write/SKILL.md
 .claude/skills/wrapup/SKILL.md
 .claude/hooks/lib-state.sh


### PR DESCRIPTION
Follow-up to #78. Companion to #77, which should now rebase to compression only.

## What

- New `.claude/skills/card-write/SKILL.md`, taken verbatim from #77: which board, which section, the one-line card contract, `blocked:` syntax, lifecycle, public-board rule.
- `.claude/CLAUDE.md`: Open loops shrinks to one resident line (write the card at discovery with `/card-write`) plus the unchanged unilateral-call and security-finding paragraphs. The Capture ≠ activation bullet's "(see Open loops)" becomes "(`/card-write`)".
- `.claude/skills/wrapup/SKILL.md`: step 3 points at `/card-write`.
- `.claude/skills/card/` renamed to `card-helper/` (`card` read as the noun beside `card-write`), plus the two fixes from #77 — board selection via `/card-write`, and `## Solace's` (accepting `## Yours` on older boards).
- `.local/bin/cloud-session-setup.sh`: card-write added to `INSTALL`.

## Removed rather than moved

Nothing. Every sentence deleted from Open loops is in card-write. One addition: card-write states that section order is priority and a new card is placed, not appended.

## Heads-up (carried from #77)

The live global board still heads its first section `## Yours`. card-write treats that as the same section and tells agents not to rename it as a side effect. Renaming the board is a one-line change in the private repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated workflow for creating and editing open-loop cards, including board selection, formatting, prioritization, and lifecycle guidance.
  * Added support for installing the new card-writing workflow in cloud sessions.

* **Documentation**
  * Updated open-loop, card-selection, and wrap-up guidance to reference the new card-writing workflow.
  * Clarified preferred card sections and invocation examples.
  * Shortened and centralized previously duplicated board and card-formatting instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->