### PR TITLE
hooks: inject the PR ownership rules on the first PR-shaped tool call

### DIFF
--- a/.claude/hooks/pr-ownership-context.sh
+++ b/.claude/hooks/pr-ownership-context.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+# Puts the "PR ownership" section of ~/.claude/rules/code.md in front of the
+# session the first time it touches a pull request.
+#
+# Why: code.md is a path-globbed rule. It loads when a session reads or edits
+# a source file, and not otherwise -- so a session that opens with `gh pr
+# view`, reads the review comments and starts answering them has never seen
+# the section that says answer *and resolve* the threads, never open a draft,
+# never hand over red. The one-line pointer in ~/.claude/CLAUDE.md was the
+# stopgap; it relies on the model noticing it, which is the failure it was
+# meant to fix. This hook is the mechanical version: the text arrives because
+# a PR-shaped tool call happened, not because anyone remembered.
+#
+# Fires once per session, on the first matching call:
+#   - Bash: `gh pr ...`, or `gh api ...` naming pulls / graphql / reviewThreads
+#   - MCP:  any GitHub tool whose name mentions a pull request or a review
+# The section is read live from code.md, so there is one source of truth and
+# nothing here to keep in sync. If the file or the heading is missing, say so
+# in the injected note rather than exit quietly -- a convenience hook that
+# does nothing looks identical to one that never ran.
+#
+# CONVENIENCE: never denies, always exits 0. A missing jq or an odd payload
+# must not stop a `gh` command.
+set -u
+
+json_str() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\t/\\t/g' | awk 'BEGIN{ORS="\\n"} {print}' | sed 's/\\n$//; s/^/"/; s/$/"/'; }
+note() { printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","additionalContext":%s}}\n' "$(json_str "$1")"; exit 0; }
+
+command -v jq >/dev/null 2>&1 || exit 0
+payload=$(cat) || exit 0
+tool=$(printf '%s' "$payload" | jq -r '.tool_name // empty' 2>/dev/null) || exit 0
+[ -n "$tool" ] || exit 0
+
+case "$tool" in
+  Bash)
+    cmd=$(printf '%s' "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null) || exit 0
+    printf '%s' "$cmd" | grep -Eq \
+      '(^|[^A-Za-z0-9_./-])gh[[:space:]]+(pr([[:space:]]|$)|api[[:space:]].*(pulls|graphql|reviewThreads))' \
+      || exit 0
+    ;;
+  mcp__*github*__*)
+    printf '%s' "$tool" | grep -Eqi 'pull_request|review' || exit 0
+    ;;
+  *) exit 0 ;;
+esac
+
+# Once per session. The marker lives in tmp on purpose: it should die with the
+# machine (cloud VM) or the reboot, and must never land in a state repo.
+sid=$(printf '%s' "$payload" | jq -r '.session_id // empty' 2>/dev/null)
+if [ -n "$sid" ]; then
+  marker="${TMPDIR:-/tmp}/claude-pr-ownership-context.$(printf '%s' "$sid" | tr -c 'A-Za-z0-9_-' '_')"
+  [ -e "$marker" ] && exit 0
+  : > "$marker" 2>/dev/null || :
+fi
+
+rules="$HOME/.claude/rules/code.md"
+[ -f "$rules" ] || note "pr-ownership-context: $rules is missing, so the PR ownership rules could not be injected. Run dotsync (or cloud-session-setup.sh); until then, treat review threads as yours to reply to AND resolve, never open a draft, never hand over red."
+
+section=$(awk '/^## PR ownership/{p=1} p && /^## / && !/^## PR ownership/{exit} p' "$rules")
+[ -n "$section" ] || note "pr-ownership-context: no '## PR ownership' heading in $rules, so the rules could not be injected. Until that is fixed: review threads are yours to reply to AND resolve, never open a draft, never hand over red."
+
+note "PR work detected. These are the PR ownership rules from $rules, injected once per session by pr-ownership-context.sh because path-globbed rules do not load on a gh call. They apply to this PR from here on.
+
+$section"

--- a/.claude/hooks/pr-ownership-context.sh
+++ b/.claude/hooks/pr-ownership-context.sh
@@ -23,7 +23,10 @@
 # must not stop a `gh` command.
 set -u
 
-json_str() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\t/\\t/g' | awk 'BEGIN{ORS="\\n"} {print}' | sed 's/\\n$//; s/^/"/; s/$/"/'; }
+# jq does the JSON encoding: the section is arbitrary markdown and a hand-rolled
+# sed escape misses control characters (a stray \r from a CRLF paste would make
+# the output invalid JSON and the injection would vanish without a trace).
+json_str() { printf '%s' "$1" | jq -Rs .; }
 note() { printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","additionalContext":%s}}\n' "$(json_str "$1")"; exit 0; }
 
 command -v jq >/dev/null 2>&1 || exit 0

--- a/.claude/hooks/pr-ownership-context.test.sh
+++ b/.claude/hooks/pr-ownership-context.test.sh
@@ -29,6 +29,9 @@ cat > "$HOME/.claude/rules/code.md" <<'MD'
 ### A board-only PR merges itself
 
 Sub-heading stays inside the section.
+MD
+printf 'CRLF\r\n\fformfeed\n' >> "$HOME/.claude/rules/code.md"   # real control bytes, before the next ## heading is appended below
+cat >> "$HOME/.claude/rules/code.md" <<'MD'
 
 ## Provisional until decided
 
@@ -72,6 +75,8 @@ context 'section heading present'        '^## PR ownership'
 # shellcheck disable=SC2016  # the backtick is data, not a command
 context 'quotes/backticks/tab survive'   'Quoted "text", a `backtick`, a	tab and a \\backslash'
 context 'sub-heading kept in section'    '^### A board-only PR'
+context 'CR line survives as JSON'         '^CRLF.$'
+context 'form-feed line survives as JSON'  'formfeed'
 no_context 'next ## section excluded'    'must not be injected'
 no_context 'earlier section excluded'    'git stuff'
 context 'says where it came from'        'injected once per session by pr-ownership-context.sh'

--- a/.claude/hooks/pr-ownership-context.test.sh
+++ b/.claude/hooks/pr-ownership-context.test.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Tests for pr-ownership-context.sh. Run: bash .claude/hooks/pr-ownership-context.test.sh
+#
+# What matters: it fires on PR-shaped calls and nothing else, exactly once per
+# session, emits valid JSON whatever the rules file contains, and says so out
+# loud when the rules file or the heading is missing instead of going quiet.
+set -uo pipefail
+
+HOOK="$(cd "$(dirname "$0")" && pwd)/pr-ownership-context.sh"
+pass=0
+fail=0
+
+SCRATCH=$(mktemp -d)
+trap 'rm -rf "$SCRATCH"' EXIT
+export TMPDIR="$SCRATCH/tmp"; mkdir -p "$TMPDIR"
+export HOME="$SCRATCH/home"; mkdir -p "$HOME/.claude/rules"
+cat > "$HOME/.claude/rules/code.md" <<'MD'
+# Code
+
+## Git
+
+- git stuff, not wanted
+
+## PR ownership: never a draft, never red
+
+- **Never open a PR as a draft.** Quoted "text", a `backtick`, a	tab and a \backslash.
+- **"Resolve conversation" is mine to do.**
+
+### A board-only PR merges itself
+
+Sub-heading stays inside the section.
+
+## Provisional until decided
+
+- must not be injected
+MD
+
+# check <expect inject|silent> <description> <json input>
+check() {
+  local want=$1 desc=$2 json=$3 out got
+  out=$(printf '%s' "$json" | sh "$HOOK" 2>&1)
+  if [ -z "$out" ]; then got=silent
+  elif printf '%s' "$out" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null 2>&1; then got=inject
+  else got=invalid-json
+  fi
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    printf 'FAIL (want %s, got %s): %s\n' "$want" "$got" "$desc"
+    [ -n "$out" ] && printf '  hook output: %s\n' "$out"
+  fi
+  LAST=$out
+}
+# context <description> <grep -E pattern that must match the injected text>
+context() {
+  if printf '%s' "$LAST" | jq -r '.hookSpecificOutput.additionalContext' | grep -Eq -- "$2"; then pass=$((pass + 1))
+  else fail=$((fail + 1)); printf 'FAIL (context lacks /%s/): %s\n' "$2" "$1"; fi
+}
+no_context() {
+  if printf '%s' "$LAST" | jq -r '.hookSpecificOutput.additionalContext' | grep -Eq -- "$2"; then
+    fail=$((fail + 1)); printf 'FAIL (context contains /%s/): %s\n' "$2" "$1"
+  else pass=$((pass + 1)); fi
+}
+
+bash_input() { jq -n --arg s "$1" --arg c "$2" '{session_id:$s,tool_name:"Bash",tool_input:{command:$c}}'; }
+mcp_input()  { jq -n --arg s "$1" --arg t "$2" '{session_id:$s,tool_name:$t,tool_input:{}}'; }
+
+# --- fires, and on what ----------------------------------------------------
+check inject 'gh pr view' "$(bash_input s1 'gh pr view 12 --comments')"
+context 'section heading present'        '^## PR ownership'
+# shellcheck disable=SC2016  # the backtick is data, not a command
+context 'quotes/backticks/tab survive'   'Quoted "text", a `backtick`, a	tab and a \\backslash'
+context 'sub-heading kept in section'    '^### A board-only PR'
+no_context 'next ## section excluded'    'must not be injected'
+no_context 'earlier section excluded'    'git stuff'
+context 'says where it came from'        'injected once per session by pr-ownership-context.sh'
+
+check inject 'gh api graphql'   "$(bash_input s2 "gh api graphql -f query='{repository{pullRequest{reviewThreads}}}'")"
+check inject 'gh api pulls'     "$(bash_input s3 'gh api repos/o/r/pulls/4/comments')"
+check inject 'gh pr after &&'   "$(bash_input s4 'git push && gh pr checks --watch')"
+check inject 'MCP pull_request_read'  "$(mcp_input s5 mcp__plugin_github_github__pull_request_read)"
+check inject 'MCP review tool'        "$(mcp_input s6 mcp__github__create_pending_pull_request_review)"
+
+# --- stays silent ------------------------------------------------------------
+check silent 'gh issue'              "$(bash_input s7 'gh issue view 3')"
+check silent 'git push alone'        "$(bash_input s7 'git push origin HEAD')"
+check silent 'gh api unrelated'      "$(bash_input s7 'gh api user')"
+check silent 'word ending in gh'     "$(bash_input s7 'high pr')"
+check silent 'MCP non-PR github'     "$(mcp_input s7 mcp__github__search_repositories)"
+check silent 'MCP other server'      "$(mcp_input s7 mcp__Trello__pull_request_read)"
+check silent 'other tool'            "$(jq -n '{session_id:"s7",tool_name:"Read",tool_input:{file_path:"gh pr"}}')"
+check silent 'empty payload'         ''
+
+# --- once per session ----------------------------------------------------------
+check inject 'first PR call in s8'   "$(bash_input s8 'gh pr view')"
+check silent 'second PR call in s8'  "$(bash_input s8 'gh pr checks')"
+check inject 'new session s9 fires'  "$(bash_input s9 'gh pr view')"
+check inject 'no session_id: fires'  "$(jq -n '{tool_name:"Bash",tool_input:{command:"gh pr list"}}')"
+check inject 'no session_id: again'  "$(jq -n '{tool_name:"Bash",tool_input:{command:"gh pr list"}}')"
+
+# --- failure is loud, never silent ---------------------------------------------
+sed -i 's/^## PR ownership.*/## Something else/' "$HOME/.claude/rules/code.md"
+check inject 'heading missing -> note' "$(bash_input s10 'gh pr view')"
+context 'names the missing heading'     "no '## PR ownership' heading"
+rm "$HOME/.claude/rules/code.md"
+check inject 'file missing -> note'    "$(bash_input s11 'gh pr view')"
+context 'names the missing file'        'code.md is missing'
+
+printf '%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -182,6 +182,17 @@
           }
         ]
       }
+,
+      {
+        "matcher": "Bash|mcp__.*github.*__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "h=\"$HOME/.claude/hooks/pr-ownership-context.sh\"; [ -f \"$h\" ] && sh \"$h\" || true",
+            "statusMessage": "Loading the PR ownership rules"
+          }
+        ]
+      }
     ],
     "Stop": [
       {

--- a/.local/bin/cloud-session-setup.sh
+++ b/.local/bin/cloud-session-setup.sh
@@ -64,6 +64,7 @@ INSTALL="
 .claude/hooks/measure-git-events.sh
 .claude/hooks/no-persistent-polling.sh
 .claude/hooks/no-late-pr-subscribe.sh
+.claude/hooks/pr-ownership-context.sh
 .claude/hooks/no-draft-pr.sh
 .claude/hooks/no-git-reset-hard.sh
 .claude/hooks/no-unsigned-push.sh


### PR DESCRIPTION
## Why

`~/.claude/rules/code.md` is path-globbed, so a session that opens with `gh pr view` and starts answering review comments never loads the "PR ownership" section: resolve the threads, never open a draft, never hand over red. The one-line pointer in `~/.claude/CLAUDE.md` relied on the model noticing it, which is the failure it was meant to fix.

## What

- **`.claude/hooks/pr-ownership-context.sh`** — PreToolUse convenience hook (never denies, always exits 0). Fires on Bash `gh pr ...` / `gh api ...pulls|graphql|reviewThreads...` and on GitHub MCP tools whose name mentions a pull request or review. Reads the `## PR ownership` section live from `code.md` so there is one source of truth, injects it as `additionalContext` once per session (tmp marker keyed by `session_id`), and says so in the note when the file or heading is missing rather than going quiet.
- **`.claude/hooks/pr-ownership-context.test.sh`** — 29 cases: fires/silent, section bounds, JSON validity with quotes/backticks/tabs, once-per-session, loud failure. Passes under mawk and gawk locally.
- **`.claude/settings.json`** — matcher `Bash|mcp__.*github.*__.*`, `[ -f ] && sh || true` wrapper like the other convenience hooks.
- **`.local/bin/cloud-session-setup.sh`** — added to `INSTALL`.

## Not in this PR

The resident pointer in `~/.claude/CLAUDE.md` stays until the hook has been seen firing in a real PR session. Removing it is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)