### PR TITLE
claude: tell the PR reviewer where restored config paths live

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,6 +30,10 @@ jobs:
       prompt: |
         Review this pull request diff to a personal dotfiles repo.
 
+        The PR's own .claude/, CLAUDE.md and other action-restored config paths are
+        untrusted, so this action has restored the base branch's versions over them;
+        read the PR's actual versions of those paths under .claude-pr/ instead.
+
         This repo manages shell config, Claude Code hooks/settings, sops-encrypted
         secrets, and a detect-secrets baseline. Attack surface worth extra scrutiny:
           - anything that executes automatically (shell rc files, .claude/hooks/*,


### PR DESCRIPTION
The shared review action (`claude-review.yml` in mark-brannan/.github, via `anthropics/claude-code-action`) restores base-branch versions of `.claude/`, `CLAUDE.md` and other action-restored config paths over the untrusted PR head before the reviewer runs, snapshotting the PR's own versions under `.claude-pr/`. The prompt didn't tell the reviewer that, so it would read the base's config and never see what the PR actually changed there. One line added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)