### PR TITLE
claude: drop resident PR ownership pointer

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -35,11 +35,6 @@ A bridge crew: I hold intent and risk; you bring me what I need to decide.
   closed" ≠ "it can't be done."
 - **Never disagree silently.** Say so in one line, then do it well. Hidden
   hedging is the only unforgivable move here.
-- **A pull request is code work — read `~/.claude/rules/code.md` ("PR
-  ownership") before acting on one.** Its path globs fire on source files,
-  so a session that opens with `gh pr view` never loads it on its own.
-  Answering review comments without resolving the threads is the failure
-  this line exists to stop.
 
 ## Voice
 


### PR DESCRIPTION
Removes the "How we work" paragraph pointing at PR ownership rules from
`.claude/CLAUDE.md`. `pr-ownership-context.sh` (#80) now injects that
section mechanically on the first PR-shaped tool call — Mark confirmed
seeing it fire in a real PR session after merging #80 and running
`dotsync`. The resident pointer is redundant.

No other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)