### PR TITLE
hooks: gate the end of a turn on the PR's review threads being resolved

### DIFF
--- a/.claude/hooks/pr-ownership-context.sh
+++ b/.claude/hooks/pr-ownership-context.sh
@@ -11,6 +11,9 @@
 # meant to fix. This hook is the mechanical version: the text arrives because
 # a PR-shaped tool call happened, not because anyone remembered.
 #
+# Also, on every matching call, records the PR touched (see below) so
+# pr-threads-gate.sh can block the Stop while review threads are still open.
+#
 # Fires once per session, on the first matching call:
 #   - Bash: `gh pr ...`, or `gh api ...` naming pulls / graphql / reviewThreads
 #   - MCP:  any GitHub tool whose name mentions a pull request or a review
@@ -47,11 +50,36 @@ case "$tool" in
   *) exit 0 ;;
 esac
 
-# Once per session. The marker lives in tmp on purpose: it should die with the
-# machine (cloud VM) or the reboot, and must never land in a state repo.
+# Record which PR this call touched, every call, so pr-threads-gate.sh (Stop)
+# can re-fetch its review threads before the session hands it back. The
+# reminder below is text and fires once; the record is what the gate runs on.
+# Lines are "repo<TAB>owner/name<TAB>number" when the call names a PR, else
+# "cwd<TAB>path" and the gate asks gh which PR the branch there belongs to.
 sid=$(printf '%s' "$payload" | jq -r '.session_id // empty' 2>/dev/null)
 if [ -n "$sid" ]; then
-  marker="${TMPDIR:-/tmp}/claude-pr-ownership-context.$(printf '%s' "$sid" | tr -c 'A-Za-z0-9_-' '_')"
+  tag=$(printf '%s' "$sid" | tr -c 'A-Za-z0-9_-' '_')
+  record="${TMPDIR:-/tmp}/claude-pr-threads.$tag"
+  case "$tool" in
+    Bash)
+      repo=$(printf '%s' "$cmd" | grep -Eo -- '(^|[[:space:]])(-R|--repo)[[:space:]=]+[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+' | head -1 | sed 's/.*[[:space:]=]//')
+      num=$(printf '%s' "$cmd" | grep -Eo 'gh[[:space:]]+pr[[:space:]]+[a-z-]+[[:space:]]+[0-9]+' | head -1 | grep -Eo '[0-9]+$')
+      [ -z "$num" ] && num=$(printf '%s' "$cmd" | grep -Eo 'pulls/[0-9]+' | head -1 | grep -Eo '[0-9]+$')
+      [ -z "$num" ] && num=$(printf '%s' "$cmd" | grep -Eo 'pull/[0-9]+' | head -1 | grep -Eo '[0-9]+$')
+      [ -z "$repo" ] && repo=$(printf '%s' "$cmd" | grep -Eo '(repos|github\.com)/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pulls?/' | head -1 | sed 's#^[^/]*/##; s#/pulls\?/$##; s#/pull/$##')
+      cwd=$(printf '%s' "$payload" | jq -r '.cwd // empty' 2>/dev/null)
+      if [ -n "$repo" ] && [ -n "$num" ]; then printf 'repo\t%s\t%s\n' "$repo" "$num" >> "$record" 2>/dev/null || :
+      elif [ -n "$cwd" ]; then printf 'cwd\t%s\n' "$cwd" >> "$record" 2>/dev/null || :
+      fi
+      ;;
+    *)
+      line=$(printf '%s' "$payload" | jq -r '.tool_input | select(.owner and .repo and (.pullNumber // .pull_number // .number)) | "repo\t\(.owner)/\(.repo)\t\(.pullNumber // .pull_number // .number)"' 2>/dev/null)
+      [ -n "$line" ] && { printf '%s\n' "$line" >> "$record" 2>/dev/null || :; }
+      ;;
+  esac
+  # Once per session for the text. The marker lives in tmp on purpose: it should
+  # die with the machine (cloud VM) or the reboot, and must never land in a
+  # state repo.
+  marker="${TMPDIR:-/tmp}/claude-pr-ownership-context.$tag"
   [ -e "$marker" ] && exit 0
   : > "$marker" 2>/dev/null || :
 fi

--- a/.claude/hooks/pr-threads-gate.sh
+++ b/.claude/hooks/pr-threads-gate.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+# Blocks the end of a turn while a PR this session touched still has an
+# unresolved review thread.
+#
+# Why: the PR ownership rules say review threads are mine to reply to AND
+# resolve, and pr-ownership-context.sh puts that text in front of the session.
+# Text is not a gate. 2026-09-07, colregs-engine#25: a session twice reported
+# "all comments resolved" while a thread stayed open, with the rules in
+# context both times. So the check moves from the model's memory to here:
+# when the session tries to end its turn, re-fetch every touched PR's
+# threads over GraphQL and refuse the stop if any is open or the fetch
+# failed. The reason names each thread by id so the session can read it and
+# resolve it, one at a time, or say plainly in its final message which ones
+# stay open and why.
+#
+# Runs on Stop. Reads the record pr-ownership-context.sh appends to on each
+# PR-shaped call (repo + number, or the cwd whose branch gh resolves to a PR).
+# No record -> nothing to do, exit 0 -- most turns never touch a PR.
+#
+# Blocks at most once per turn: the harness sets stop_hook_active on the
+# retry, and a second block would just loop against a thread only Mark can
+# close. One forced re-check is the whole point; the honest report after it
+# is the model's job.
+#
+# GATE: no jq, no gh, gh failing, PR not found -> block once, saying the
+# state could not be verified. A gate that goes quiet when it can't look is
+# indistinguishable from one that looked and found nothing.
+set -u
+
+json_str() { printf '%s' "$1" | jq -Rs .; }
+block() { printf '{"decision":"block","reason":%s}\n' "$(json_str "$1")"; exit 0; }
+
+command -v jq >/dev/null 2>&1 || { printf '{"decision":"block","reason":"pr-threads-gate: jq is missing, so review threads on the PR you worked could not be re-checked. State in your final message, per thread id, which are resolved and which are open, then end the turn again."}\n'; exit 0; }
+payload=$(cat) || exit 0
+sid=$(printf '%s' "$payload" | jq -r '.session_id // empty' 2>/dev/null)
+[ -n "$sid" ] || exit 0
+record="${TMPDIR:-/tmp}/claude-pr-threads.$(printf '%s' "$sid" | tr -c 'A-Za-z0-9_-' '_')"
+[ -s "$record" ] || exit 0
+[ "$(printf '%s' "$payload" | jq -r '.stop_hook_active // false')" = "true" ] && exit 0
+
+command -v gh >/dev/null 2>&1 || block "pr-threads-gate: gh is not installed here, so review threads on the PR you worked could not be re-checked. State in your final message, per thread id, which are resolved and which are open, then end the turn again."
+
+# Every distinct PR the session touched, as owner/name<TAB>number. A cwd line
+# resolves through gh to whatever PR its current branch has; no PR there is
+# fine (a `gh pr list` from a repo with no branch PR, say).
+prs=$(sort -u "$record" | while IFS="$(printf '\t')" read -r kind a b; do
+  case "$kind" in
+    repo) printf '%s\t%s\n' "$a" "$b" ;;
+    cwd)
+      [ -d "$a" ] || continue
+      # The PR url names the base repo, which is where the threads live; the
+      # head repo would be wrong for a PR from a fork.
+      (cd "$a" && gh pr view --json url -q .url 2>/dev/null | sed -n 's#^https://github\.com/\([^/]*/[^/]*\)/pull/\([0-9]*\)$#\1\t\2#p') || :
+      ;;
+  esac
+done | sort -u)
+[ -n "$prs" ] || exit 0
+
+open=""
+failed=""
+n=0
+while IFS="$(printf '\t')" read -r repo num; do
+  [ -n "$repo" ] && [ -n "$num" ] || continue
+  n=$((n + 1)); [ "$n" -gt 5 ] && break
+  owner=${repo%%/*}; name=${repo#*/}
+  out=$(gh api graphql -f owner="$owner" -f name="$name" -F number="$num" -f query='
+    query($owner:String!,$name:String!,$number:Int!){
+      repository(owner:$owner,name:$name){ pullRequest(number:$number){
+        state
+        reviewThreads(first:100){ nodes{ id isResolved path
+          comments(first:1){ nodes{ author{login} body } } } } } } }' 2>&1) \
+    || { failed="$failed
+- $repo#$num: $(printf '%s' "$out" | head -3 | tr '\n' ' ')"; continue; }
+  state=$(printf '%s' "$out" | jq -r '.data.repository.pullRequest.state // empty')
+  [ -n "$state" ] || { failed="$failed
+- $repo#$num: not found (no pullRequest in the GraphQL reply)"; continue; }
+  [ "$state" = "OPEN" ] || continue
+  threads=$(printf '%s' "$out" | jq -r '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved|not)
+    | "  - \(.id)  \(.path // "(no file)")  @\(.comments.nodes[0].author.login // "?"): \((.comments.nodes[0].body // "") | split("\n")[0] | .[0:100])"')
+  [ -n "$threads" ] && open="$open
+- $repo#$num has $(printf '%s\n' "$threads" | wc -l | tr -d ' ') unresolved review thread(s):
+$threads"
+done <<EOF
+$prs
+EOF
+
+[ -z "$open" ] && [ -z "$failed" ] && exit 0
+
+msg="pr-threads-gate: this turn cannot end yet. Live GraphQL re-check of the PR(s) this session worked:"
+[ -n "$open" ] && msg="$msg
+$open"
+[ -n "$failed" ] && msg="$msg
+
+Could not verify:$failed"
+msg="$msg
+
+For each open thread, in this order: read it (gh api graphql on the thread id, or the PR's review comments), fix or answer it, reply on the thread with the evidence, then resolve it by id --
+  gh api graphql -f query='mutation(\$id:ID!){resolveReviewThread(input:{threadId:\$id}){thread{isResolved}}}' -f id=<threadId>
+One thread at a time, never a loop over all unresolved ids. A thread only Mark can close (a decision, a question to him) stays open: say so in your final message, by id, with what he needs to decide. Never report 'all threads resolved' unless this check passes. Then end the turn again; this gate does not fire twice in one turn."
+block "$msg"

--- a/.claude/hooks/pr-threads-gate.sh
+++ b/.claude/hooks/pr-threads-gate.sh
@@ -60,9 +60,14 @@ open=""
 failed=""
 n=0
 while IFS="$(printf '\t')" read -r repo num; do
-  [ -n "$repo" ] && [ -n "$num" ] || continue
-  n=$((n + 1)); [ "$n" -gt 5 ] && break
+  if [ -z "$repo" ] || [ -z "$num" ]; then continue; fi
+  # Cap the network calls, but never silently: a PR past the cap is reported
+  # as unverified so the turn still blocks instead of reading as clean.
+  n=$((n + 1))
+  [ "$n" -gt 5 ] && { failed="$failed
+- $repo#$num: not checked, more than 5 PRs recorded this session"; continue; }
   owner=${repo%%/*}; name=${repo#*/}
+  # shellcheck disable=SC2016  # GraphQL variables, not shell ones
   out=$(gh api graphql -f owner="$owner" -f name="$name" -F number="$num" -f query='
     query($owner:String!,$name:String!,$number:Int!){
       repository(owner:$owner,name:$name){ pullRequest(number:$number){

--- a/.claude/hooks/pr-threads-gate.test.sh
+++ b/.claude/hooks/pr-threads-gate.test.sh
@@ -107,5 +107,12 @@ out=$(stop_input s8 | PATH="$SCRATCH/nogh" GH_MODE=open /bin/sh "$HOOK" 2>&1); L
 if [ "$(printf '%s' "$out" | jq -r .decision 2>/dev/null)" = block ]; then pass=$((pass+1)); else fail=$((fail+1)); echo "FAIL: gh absent should block: $out"; fi
 reason 'names gh as missing'           'gh is not installed'
 
+# --- more PRs than the cap are unverified, not clean ---------------------------
+for i in 1 2 3 4 5 6 7; do record s9 "$(printf 'repo\to/r\t%s' "$i")"; done
+: > "$GH_LOG"
+check block 'over the cap -> block'     resolved "$(stop_input s9)"
+reason 'names the unchecked PR'         'o/r#7: not checked, more than 5'
+t 'only 5 queried' 5 "$(grep -c 'api graphql' "$GH_LOG")"
+
 printf '%d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/.claude/hooks/pr-threads-gate.test.sh
+++ b/.claude/hooks/pr-threads-gate.test.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Tests for pr-threads-gate.sh. Run: bash .claude/hooks/pr-threads-gate.test.sh
+#
+# What matters: silent when the session touched no PR, silent when every
+# thread is resolved or the PR is closed, blocks once (and only once) with the
+# thread ids when one is open, and blocks -- never goes quiet -- when the
+# check itself could not run. gh is faked; each case picks a reply via GH_MODE.
+set -uo pipefail
+
+HOOK="$(cd "$(dirname "$0")" && pwd)/pr-threads-gate.sh"
+RECORDER="$(cd "$(dirname "$0")" && pwd)/pr-ownership-context.sh"
+pass=0; fail=0
+SCRATCH=$(mktemp -d); trap 'rm -rf "$SCRATCH"' EXIT
+export TMPDIR="$SCRATCH/tmp"; mkdir -p "$TMPDIR"
+export HOME="$SCRATCH/home"; mkdir -p "$HOME/.claude/rules" "$SCRATCH/bin" "$SCRATCH/repo"
+printf '## PR ownership\n- rules\n' > "$HOME/.claude/rules/code.md"
+
+cat > "$SCRATCH/bin/gh" <<'GH'
+#!/bin/sh
+echo "$*" >> "$GH_LOG"
+case "$1 $2" in
+  "pr view") printf 'https://github.com/o/r/pull/7\n'; exit 0 ;;
+esac
+case "${GH_MODE:-}" in
+  open)     printf '{"data":{"repository":{"pullRequest":{"state":"OPEN","reviewThreads":{"nodes":[{"id":"PRRT_a","isResolved":true,"path":"a.ts","comments":{"nodes":[{"author":{"login":"bot"},"body":"done"}]}},{"id":"PRRT_b","isResolved":false,"path":"b.ts","comments":{"nodes":[{"author":{"login":"coderabbitai"},"body":"Disable the pre-commit hook\\nsecond line"}]}}]}}}}}' ;;
+  resolved) printf '{"data":{"repository":{"pullRequest":{"state":"OPEN","reviewThreads":{"nodes":[{"id":"PRRT_a","isResolved":true,"path":"a.ts","comments":{"nodes":[]}}]}}}}}' ;;
+  merged)   printf '{"data":{"repository":{"pullRequest":{"state":"MERGED","reviewThreads":{"nodes":[{"id":"PRRT_z","isResolved":false,"path":null,"comments":{"nodes":[]}}]}}}}}' ;;
+  missing)  printf '{"data":{"repository":{"pullRequest":null}}}' ;;
+  fail)     echo "gh: HTTP 401: Bad credentials" >&2; exit 1 ;;
+esac
+GH
+chmod +x "$SCRATCH/bin/gh"
+export PATH="$SCRATCH/bin:$PATH" GH_LOG="$SCRATCH/gh.log"
+
+stop_input() { jq -n --arg s "$1" --argjson a "${2:-false}" '{session_id:$s,stop_hook_active:$a,cwd:"/x"}'; }
+record() { printf '%s\n' "$2" >> "$TMPDIR/claude-pr-threads.$1"; }
+# check <block|silent> <desc> <mode> <json>
+check() {
+  local want=$1 desc=$2 json=$4 out got
+  out=$(printf '%s' "$json" | GH_MODE=$3 sh "$HOOK" 2>&1)
+  if [ -z "$out" ]; then got=silent
+  elif [ "$(printf '%s' "$out" | jq -r '.decision' 2>/dev/null)" = block ]; then got=block
+  else got=invalid; fi
+  if [ "$got" = "$want" ]; then pass=$((pass+1)); else fail=$((fail+1)); printf 'FAIL (want %s, got %s): %s\n  %s\n' "$want" "$got" "$desc" "$out"; fi
+  LAST=$out
+}
+reason() { if printf '%s' "$LAST" | jq -r '.reason' | grep -Eq -- "$2"; then pass=$((pass+1)); else fail=$((fail+1)); printf 'FAIL (reason lacks /%s/): %s\n' "$2" "$1"; fi; }
+no_reason() { if printf '%s' "$LAST" | jq -r '.reason' | grep -Eq -- "$2"; then fail=$((fail+1)); printf 'FAIL (reason has /%s/): %s\n' "$2" "$1"; else pass=$((pass+1)); fi; }
+
+# --- nothing to check --------------------------------------------------------
+check silent 'no record for session'   open "$(stop_input s0)"
+check silent 'no session id'           open "$(jq -n '{stop_hook_active:false}')"
+check silent 'empty payload'           open ''
+
+# --- the recorder writes what the gate reads -----------------------------------
+rec() { printf '%s' "$2" | sh "$RECORDER" >/dev/null; cat "$TMPDIR/claude-pr-threads.$1" 2>/dev/null | tail -1; }
+bash_in() { jq -n --arg s "$1" --arg c "$2" '{session_id:$s,cwd:"/work/here",tool_name:"Bash",tool_input:{command:$c}}'; }
+t() { if [ "$2" = "$3" ]; then pass=$((pass+1)); else fail=$((fail+1)); printf 'FAIL: %s\n  want [%s]\n  got  [%s]\n' "$1" "$2" "$3"; fi; }
+t 'gh pr view N --repo'      "$(printf 'repo\to/r\t25')"  "$(rec r1 "$(bash_in r1 'gh pr view 25 --repo o/r --comments')")"
+t 'gh pr checks -R'          "$(printf 'repo\to/r\t3')"   "$(rec r1 "$(bash_in r1 'gh pr checks 3 -R o/r')")"
+t 'gh api pulls url'         "$(printf 'repo\to/r\t4')"   "$(rec r1 "$(bash_in r1 'gh api repos/o/r/pulls/4/comments')")"
+t 'gh pr view no number'     "$(printf 'cwd\t/work/here')" "$(rec r1 "$(bash_in r1 'gh pr view --json url')")"
+t 'gh pr N without repo'     "$(printf 'cwd\t/work/here')" "$(rec r1 "$(bash_in r1 'gh pr view 9')")"
+t 'MCP pull_request_read'    "$(printf 'repo\to/r\t8')"   "$(rec r1 "$(jq -n '{session_id:"r1",tool_name:"mcp__github__pull_request_read",tool_input:{owner:"o",repo:"r",pullNumber:8}}')")"
+t 'MCP without a PR number'  "$(printf 'repo\to/r\t8')"   "$(rec r1 "$(jq -n '{session_id:"r1",tool_name:"mcp__github__get_pull_request_review",tool_input:{owner:"o",repo:"r"}}')")"
+t 'second call still records' "$(printf 'repo\to/r\t26')" "$(rec r1 "$(bash_in r1 'gh pr merge 26 --repo o/r')")"
+
+# --- open thread blocks, once --------------------------------------------------
+record s1 "$(printf 'repo\to/r\t25')"
+check block 'open thread -> block'    open "$(stop_input s1)"
+reason 'names the PR'                  'o/r#25 has 1 unresolved'
+reason 'names the thread id'           'PRRT_b'
+reason 'shows path, author, first line' 'b.ts  @coderabbitai: Disable the pre-commit hook$'
+no_reason 'resolved thread not listed' 'PRRT_a'
+reason 'gives the resolve mutation'    'resolveReviewThread'
+reason 'one at a time'                 'never a loop'
+check silent 'retry with stop_hook_active' open "$(stop_input s1 true)"
+
+# --- quiet when there is nothing open ------------------------------------------
+record s2 "$(printf 'repo\to/r\t25')"
+check silent 'all resolved'            resolved "$(stop_input s2)"
+record s3 "$(printf 'repo\to/r\t25')"
+check silent 'merged PR ignored'       merged "$(stop_input s3)"
+
+# --- cwd records resolve through gh pr view ------------------------------------
+record s4 "$(printf 'cwd\t%s' "$SCRATCH/repo")"
+record s4 "$(printf 'cwd\t%s' "$SCRATCH/repo")"
+record s4 "$(printf 'repo\to/r\t7')"
+: > "$GH_LOG"
+check block 'cwd -> PR via gh pr view' open "$(stop_input s4)"
+reason 'resolved to o/r#7'             'o/r#7 has'
+t 'same PR queried once' 1 "$(grep -c 'api graphql' "$GH_LOG")"
+record s5 "$(printf 'cwd\t%s/nope' "$SCRATCH")"
+check silent 'cwd that no longer exists' open "$(stop_input s5)"
+
+# --- cannot verify is loud ---------------------------------------------------
+record s6 "$(printf 'repo\to/r\t25')"
+check block 'gh fails -> block'        fail "$(stop_input s6)"
+reason 'says it could not verify'      'Could not verify'
+reason 'carries the gh error'          'Bad credentials'
+record s7 "$(printf 'repo\to/r\t25')"
+check block 'PR not found -> block'    missing "$(stop_input s7)"
+reason 'says not found'                'not found'
+record s8 "$(printf 'repo\to/r\t25')"
+mkdir -p "$SCRATCH/nogh"; for b in jq cat tr sort head wc sed; do ln -s "$(command -v $b)" "$SCRATCH/nogh/$b"; done
+out=$(stop_input s8 | PATH="$SCRATCH/nogh" GH_MODE=open /bin/sh "$HOOK" 2>&1); LAST=$out
+if [ "$(printf '%s' "$out" | jq -r .decision 2>/dev/null)" = block ]; then pass=$((pass+1)); else fail=$((fail+1)); echo "FAIL: gh absent should block: $out"; fi
+reason 'names gh as missing'           'gh is not installed'
+
+printf '%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -205,6 +205,16 @@
         "hooks": [
           {
             "type": "command",
+            "command": "h=\"$HOME/.claude/hooks/pr-threads-gate.sh\"; { [ -f \"$h\" ] && sh \"$h\"; } || printf '%s\\n' '{\"decision\":\"block\",\"reason\":\"pr-threads-gate.sh is missing from $HOME/.claude/hooks or crashed, so review threads on the PR this session worked could not be re-checked. This is a gate and fails closed: if you touched a PR this session, state per thread id which are resolved and which are open, then end the turn again.\"}'",
+            "timeout": 60,
+            "statusMessage": "Re-checking review threads on PRs this session touched"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
             "command": "h=\"$HOME/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] && bash \"$h\" stop 0 show 2>/dev/null || true"
           }
         ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -205,7 +205,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "h=\"$HOME/.claude/hooks/pr-threads-gate.sh\"; { [ -f \"$h\" ] && sh \"$h\"; } || printf '%s\\n' '{\"decision\":\"block\",\"reason\":\"pr-threads-gate.sh is missing from $HOME/.claude/hooks or crashed, so review threads on the PR this session worked could not be re-checked. This is a gate and fails closed: if you touched a PR this session, state per thread id which are resolved and which are open, then end the turn again.\"}'",
+            "command": "p=$(cat); [ \"$(printf '%s' \"$p\" | jq -r '.stop_hook_active // false' 2>/dev/null)\" = true ] && exit 0; h=\"$HOME/.claude/hooks/pr-threads-gate.sh\"; { [ -f \"$h\" ] && printf '%s' \"$p\" | sh \"$h\"; } || printf '%s\\n' '{\"decision\":\"block\",\"reason\":\"pr-threads-gate.sh is missing from $HOME/.claude/hooks or crashed, so review threads on the PR this session worked could not be re-checked. This is a gate and fails closed: if you touched a PR this session, state per thread id which are resolved and which are open, then end the turn again.\"}'",
             "timeout": 60,
             "statusMessage": "Re-checking review threads on PRs this session touched"
           }

--- a/.local/bin/cloud-session-setup.sh
+++ b/.local/bin/cloud-session-setup.sh
@@ -65,6 +65,7 @@ INSTALL="
 .claude/hooks/no-persistent-polling.sh
 .claude/hooks/no-late-pr-subscribe.sh
 .claude/hooks/pr-ownership-context.sh
+.claude/hooks/pr-threads-gate.sh
 .claude/hooks/no-draft-pr.sh
 .claude/hooks/no-git-reset-hard.sh
 .claude/hooks/no-unsigned-push.sh


### PR DESCRIPTION
## Why

pr-ownership-context.sh injects the "reply AND resolve" rule once per session and nothing checks afterwards. colregs-engine#25 shipped an "all comments resolved" claim twice with a thread still open, rules in context both times. Text is not a gate.

## What

- **`pr-threads-gate.sh`** (new, Stop hook): re-fetches review threads over GraphQL for every PR the session touched. If any is unresolved, or the check cannot run, it blocks the turn once with each open thread listed by id, path, author and first line, plus the resolve mutation. Never blocks twice in a turn (`stop_hook_active`), so a thread only Mark can close ends in an honest report, not a loop. Merged/closed PRs are skipped. Fails closed when `gh`/`jq` are absent.
- **`pr-ownership-context.sh`**: now records the PR touched on *every* matching call (repo+number from the `gh` command or MCP input, else the cwd, which the gate resolves via the PR url), not just the first. The once-per-session text reminder is unchanged.
- `settings.json` Stop entry fails closed if the script is missing; `cloud-session-setup.sh` INSTALL list carries the new hook.

## Verified

- 32 gate tests + 31 recorder tests, faked `gh`; whole `*.test.sh` suite green.
- Live: silent on a merged PR (colregs-engine#25) and an open PR with no threads (colregs-engine#27); blocks on colregs#53 naming the open thread id; silent on the `stop_hook_active` retry.

Closes the "Fix the PR-thread-resolution hook, not just the model" card on the global board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)