### PR TITLE
feat: prose-budget, one engine for the prose guardrails of every repo

### DIFF
--- a/.claude/hooks/prose-budget-commit.sh
+++ b/.claude/hooks/prose-budget-commit.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# PreToolUse Bash: runs `prose-budget --staged` before a `git commit` and
+# denies the commit on findings, so documentation bloat is caught at the
+# moment it is written rather than in CI. The rules and every threshold
+# live in the repo's own config (docs/budgets.json or .prose-budgets.json);
+# a repo without one is never touched.
+#
+# Fails open: no jq, no awk, no engine, no config, or an engine crash all
+# exit 0 silently. CI (--base) is the real gate; this is the fast local one.
+# Detection is structural via lib-shell-words.awk, so a commit message that
+# mentions `git commit` is not a commit. `cd DIR && git commit` and
+# `git -C DIR commit` run the engine in DIR.
+set -uo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+LIB="$HERE/lib-shell-words.awk"
+ENGINE="${PROSE_BUDGET:-$(command -v prose-budget 2>/dev/null || echo "$HERE/../../.local/bin/prose-budget")}"
+
+command -v jq >/dev/null 2>&1 || exit 0
+command -v awk >/dev/null 2>&1 || exit 0
+[ -r "$LIB" ] && [ -x "$ENGINE" ] || exit 0
+
+input=$(cat)
+[ "$(printf '%s' "$input" | jq -r '.tool_name // ""')" = "Bash" ] || exit 0
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null) || exit 0
+[ -n "$cmd" ] || exit 0
+cwd=$(printf '%s' "$input" | jq -r '.cwd // ""')
+[ -n "$cwd" ] || cwd=$PWD
+
+# Prints "COMMIT<TAB>cd-dir<TAB>-C-dir" for the first git/yadm commit found.
+hit=$(printf '%s\n' "$cmd" | awk "$(cat "$LIB")"'
+{ buf = buf $0 "\n" }
+END {
+  buf = strip_heredocs(buf)
+  ntexts = texts_of(buf, texts, nested)
+  for (x = 1; x <= ntexts; x++) {
+    n = scan(texts[x], w, k, q)
+    a0 = 1
+    for (i = 1; i <= n + 1; i++) {
+      if (i <= n && k[i] != ";") continue
+      if (a0 < i) segment(a0, i - 1, nested[x])
+      a0 = i + 1
+    }
+  }
+}
+function segment(lo, hi, nested,   g, i, dir) {
+  if (w[lo] == "cd" && k[lo + 1] == "w") CD = w[lo + 1]
+  g = cmd_index(w, k, lo, hi, "(^|/)(git|yadm)$", nested, "")
+  if (!g) return
+  i = g + 1; dir = ""
+  while (i <= hi && w[i] ~ /^-/) {
+    if (w[i] == "-C") { dir = w[i + 1]; i++ }
+    else if (w[i] ~ /^(-c|--git-dir|--work-tree|--namespace)$/) i++
+    i++
+  }
+  if (i <= hi && w[i] == "commit") { print "COMMIT\t" CD "\t" dir; exit }
+}')
+case "$hit" in COMMIT*) ;; *) exit 0 ;; esac
+
+cd_dir=$(printf '%s' "$hit" | cut -f2)
+c_dir=$(printf '%s' "$hit" | cut -f3)
+dir=$cwd
+for step in "$cd_dir" "$c_dir"; do
+  [ -n "$step" ] || continue
+  dir=$(cd "$dir" 2>/dev/null && cd "$step" 2>/dev/null && pwd) || exit 0
+done
+
+out=$(cd "$dir" && "$ENGINE" --staged 2>&1)
+rc=$?
+case "$rc" in 1|2) ;; *) exit 0 ;; esac
+
+jq -n --arg r "Blocked by ~/.claude/hooks/prose-budget-commit.sh: prose-budget --staged found:
+$out
+Fix the prose and retry the same commit. Do not ask the user; this is settled." \
+  '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $r}}'
+exit 0

--- a/.claude/hooks/prose-budget-commit.test.sh
+++ b/.claude/hooks/prose-budget-commit.test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Tests for prose-budget-commit.sh. Run: bash .claude/hooks/prose-budget-commit.test.sh
+# Set AWK_PATH to a directory whose `awk` is another implementation to test
+# the shared scanner under it, as hook-tests.yml does.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$HERE/prose-budget-commit.sh"
+export PROSE_BUDGET="$HERE/../../.local/bin/prose-budget"
+[ -n "${AWK_PATH:-}" ] && PATH="$AWK_PATH:$PATH"
+pass=0; fail=0
+
+# check <deny|allow> <description> <command> [cwd]
+check() {
+  local want=$1 desc=$2 cmd=$3 dir=${4:-$DIRTY} out got
+  out=$(jq -n --arg c "$cmd" --arg d "$dir" '{tool_name:"Bash",tool_input:{command:$c},cwd:$d}' | timeout 20 bash "$HOOK" 2>&1)
+  if printf '%s' "$out" | grep -q '"permissionDecision": *"deny"'; then got=deny; else got=allow; fi
+  if [ "$got" = "$want" ]; then pass=$((pass + 1)); else
+    fail=$((fail + 1)); printf 'FAIL (want %s, got %s): %s\n  cmd: %s\n' "$want" "$got" "$desc" "$cmd"
+    [ -n "$out" ] && printf '  hook output: %s\n' "$out"
+  fi
+  LAST=$out
+}
+
+# A repo whose staged README adds too much prose, and one whose staging is clean.
+mkrepo() {
+  local d; d=$(mktemp -d)
+  git -C "$d" init -q -b main
+  git -C "$d" config user.email t@example.com; git -C "$d" config user.name t; git -C "$d" config commit.gpgsign false
+  printf '{}\n' > "$d/.prose-budgets.json"
+  printf 'seed\n' > "$d/README.md"
+  git -C "$d" add .prose-budgets.json README.md; git -C "$d" commit -qm seed
+  echo "$d"
+}
+DIRTY=$(mkrepo)
+{ echo '## A'; echo; for _ in $(seq 60); do printf 'word '; done; echo; } > "$DIRTY/README.md"
+git -C "$DIRTY" add README.md
+CLEAN=$(mkrepo)
+printf 'seed plus one\n' > "$CLEAN/README.md"; git -C "$CLEAN" add README.md
+NOCONF=$(mktemp -d); git -C "$NOCONF" init -q -b main; printf 'x\n' > "$NOCONF/a.md"; git -C "$NOCONF" add a.md
+mkdir -p "$DIRTY/sub"
+trap 'rm -rf "$DIRTY" "$CLEAN" "$NOCONF"' EXIT
+
+check deny  'plain commit'                    'git commit -m "docs: more"'
+check deny  'after a separator'               'git add README.md && git commit -m x'
+check deny  'yadm commit'                     'yadm commit -m x'
+check deny  'git -C dir commit'               "git -C $DIRTY commit -m x" "$CLEAN"
+check deny  'cd dir && git commit'            "cd $DIRTY && git commit -m x" "$CLEAN"
+check deny  'commit from a subdirectory'      'git commit -m x' "$DIRTY/sub"
+printf '%s' "$LAST" | grep -q 'delta' || { fail=$((fail + 1)); echo 'FAIL: deny reason lacks the findings'; }
+printf '%s' "$LAST" | grep -q 'Do not ask the user' || { fail=$((fail + 1)); echo 'FAIL: deny reason lacks the retry instruction'; }
+
+check allow 'clean staging'                   'git commit -m x' "$CLEAN"
+check allow 'no config in the repo'           'git commit -m x' "$NOCONF"
+check allow 'not a commit'                    'git status'
+check allow 'commit mentioned in a message'   'git add x && git commit -m "git commit -m later"' "$CLEAN"
+check allow 'commit as prose'                 'echo "run git commit -m x"'
+check allow 'commit in a heredoc body'        $'cat <<EOF\ngit commit -m x\nEOF'
+check allow 'a different tool'                'gh pr create --title x'
+
+# Fail-open: no jq, and no engine.
+BARE=$(mktemp -d); for t in bash sh awk cat cut dirname git timeout; do p=$(command -v $t) && ln -s "$p" "$BARE/$t"; done
+out=$(jq -n --arg d "$DIRTY" '{tool_name:"Bash",tool_input:{command:"git commit -m x"},cwd:$d}' | PATH=$BARE bash "$HOOK" 2>&1)
+if [ -z "$out" ]; then pass=$((pass + 1)); else fail=$((fail + 1)); echo "FAIL: without jq the hook should be silent, got: $out"; fi
+out=$(jq -n --arg d "$DIRTY" '{tool_name:"Bash",tool_input:{command:"git commit -m x"},cwd:$d}' | PROSE_BUDGET=/nonexistent bash "$HOOK" 2>&1)
+if [ -z "$out" ]; then pass=$((pass + 1)); else fail=$((fail + 1)); echo "FAIL: without the engine the hook should be silent, got: $out"; fi
+rm -rf "$BARE"
+
+printf '%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/.claude/hooks/prose-budget-edit.sh
+++ b/.claude/hooks/prose-budget-edit.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# PostToolUse Edit|Write|MultiEdit: after a markdown or JSON file is written
+# inside a repo that has a prose-budget config, run the tree rules on that
+# one file and hand any findings back as additionalContext. Advisory only:
+# it never blocks, and the commit hook and CI are the gates.
+#
+# Silent on the quiet path (no jq, no engine, no config, other file types,
+# clean file): every line printed here is charged to the session.
+set -uo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+ENGINE="${PROSE_BUDGET:-$(command -v prose-budget 2>/dev/null || echo "$HERE/../../.local/bin/prose-budget")}"
+
+command -v jq >/dev/null 2>&1 || exit 0
+[ -x "$ENGINE" ] || exit 0
+
+input=$(cat)
+file=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || exit 0
+case "$file" in *.md|*.json) ;; *) exit 0 ;; esac
+[ -f "$file" ] || exit 0
+
+out=$(cd "$(dirname "$file")" && "$ENGINE" --tree --file "$file" 2>&1)
+rc=$?
+case "$rc" in 1|2) ;; *) exit 0 ;; esac
+
+printf '%s\n' "prose-budget on $file:" "$out" "Fix these before committing; the commit hook will deny the commit otherwise." \
+  | jq -Rn --rawfile ctx /dev/stdin '{hookSpecificOutput: {hookEventName: "PostToolUse", additionalContext: $ctx}}'
+exit 0

--- a/.claude/hooks/prose-budget-edit.test.sh
+++ b/.claude/hooks/prose-budget-edit.test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Tests for prose-budget-edit.sh. Run: bash .claude/hooks/prose-budget-edit.test.sh
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$HERE/prose-budget-edit.sh"
+export PROSE_BUDGET="$HERE/../../.local/bin/prose-budget"
+pass=0; fail=0
+
+# check <context|silent> <description> <file path>
+check() {
+  local want=$1 desc=$2 file=$3 out got
+  out=$(jq -n --arg f "$file" '{tool_name:"Edit",tool_input:{file_path:$f}}' | timeout 20 bash "$HOOK" 2>&1)
+  if printf '%s' "$out" | grep -q '"additionalContext"'; then got=context; else got=silent; fi
+  if [ "$got" = "$want" ]; then pass=$((pass + 1)); else
+    fail=$((fail + 1)); printf 'FAIL (want %s, got %s): %s\n' "$want" "$got" "$desc"
+    [ -n "$out" ] && printf '  hook output: %s\n' "$out"
+  fi
+  LAST=$out
+}
+
+REPO=$(mktemp -d); git -C "$REPO" init -q -b main
+printf '{"lines": {"README.md": 2}, "voice": {"scope": "tree"}}\n' > "$REPO/.prose-budgets.json"
+printf 'a\nb\nc\n' > "$REPO/README.md"
+printf 'a\n' > "$REPO/CLAUDE.md"
+mkdir -p "$REPO/docs"; printf 'a seamless flow\n' > "$REPO/docs/x.md"
+printf 'print(1)\n' > "$REPO/x.py"
+printf '{"note": "a robust note"}\n' > "$REPO/data.json"
+NOCONF=$(mktemp -d); printf 'a robust line\n' > "$NOCONF/README.md"
+trap 'rm -rf "$REPO" "$NOCONF"' EXIT
+
+check context 'file over its line budget'         "$REPO/README.md"
+printf '%s' "$LAST" | grep -q 'README.md:3: lines' || { fail=$((fail + 1)); echo 'FAIL: context lacks the finding'; }
+check context 'voice word in a docs file'         "$REPO/docs/x.md"
+check silent  'clean file'                        "$REPO/CLAUDE.md"
+check silent  'json outside any json_prose target' "$REPO/data.json"
+check silent  'not markdown or json'              "$REPO/x.py"
+check silent  'no config in the repo'             "$NOCONF/README.md"
+check silent  'file does not exist'               "$REPO/missing.md"
+
+BARE=$(mktemp -d); for t in bash sh cat git dirname timeout; do p=$(command -v $t) && ln -s "$p" "$BARE/$t"; done
+out=$(jq -n --arg f "$REPO/README.md" '{tool_name:"Edit",tool_input:{file_path:$f}}' | PATH=$BARE bash "$HOOK" 2>&1)
+if [ -z "$out" ]; then pass=$((pass + 1)); else fail=$((fail + 1)); echo "FAIL: without jq the hook should be silent, got: $out"; fi
+rm -rf "$BARE"
+
+printf '%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -180,6 +180,16 @@
         ]
       },
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "h=\"$HOME/.claude/hooks/prose-budget-commit.sh\"; [ -f \"$h\" ] && bash \"$h\" || true",
+            "statusMessage": "Checking staged prose against the repo's budgets"
+          }
+        ]
+      },
+      {
         "matcher": "mcp__.*__subscribe_pr_activity",
         "hooks": [
           {
@@ -230,6 +240,15 @@
       }
     ],
     "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "h=\"$HOME/.claude/hooks/prose-budget-edit.sh\"; [ -f \"$h\" ] && bash \"$h\" || true"
+          }
+        ]
+      },
       {
         "matcher": "Bash|mcp__.*__(create_pull_request|merge_pull_request|update_pull_request|update_pull_request_branch|push_files|create_or_update_file|delete_file|create_branch|create_repository|fork_repository)",
         "hooks": [

--- a/.github/workflows/hook-tests.yml
+++ b/.github/workflows/hook-tests.yml
@@ -27,6 +27,8 @@ jobs:
           set -euo pipefail
           sudo apt-get update -q
           sudo apt-get install -y -q mawk gawk original-awk jq
+      - name: prose-budget engine tests
+        run: python3 .local/bin/prose-budget.test.py
       - name: Run every hook test under each awk
         run: |
           set -euo pipefail

--- a/.local/bin/cloud-session-setup.sh
+++ b/.local/bin/cloud-session-setup.sh
@@ -80,8 +80,11 @@ INSTALL="
 .claude/hooks/log-commit.sh
 .claude/hooks/statusline-metrics.sh
 .claude/hooks/connector-budget.sh
+.claude/hooks/prose-budget-commit.sh
+.claude/hooks/prose-budget-edit.sh
 .claude/hooks/fixtures
 .local/bin/metrics-preview.sh
+.local/bin/prose-budget
 "
 
 # --- what is wholly owned by this installer -------------------------------

--- a/.local/bin/prose-budget
+++ b/.local/bin/prose-budget
@@ -364,6 +364,14 @@ def load_config(path):
                                                  "grandfathered": []}, False)
     r["narration"] = _rule(cfg, "narration", {"targets": MD_TARGETS, "patterns": {}, "disable": [],
                                                "scope": {}, "grandfathered": []}, True)
+    if r["narration"]:
+        for name, pattern in r["narration"]["patterns"].items():
+            if not isinstance(pattern, str):
+                raise ConfigError(f"narration.patterns.{name}: expected a string")
+            try:
+                re.compile(pattern)
+            except re.error as e:
+                raise ConfigError(f"narration.patterns.{name}: invalid pattern: {e}") from e
     r["voice"] = _rule(cfg, "voice", {"scope": "diff", "targets": MD_TARGETS, "words": [], "allow": [],
                                        "count": ["rather than"]}, True)
     if r["voice"] and r["voice"]["scope"] not in ("diff", "tree"):
@@ -373,6 +381,11 @@ def load_config(path):
     if ids is not None and ids is not False and not (isinstance(ids, list) and all(
             isinstance(e, dict) and "file" in e and "pattern" in e for e in ids)):
         raise ConfigError("unique_ids: expected [{file, pattern}]")
+    for entry in ids or []:
+        try:
+            re.compile(entry["pattern"])
+        except re.error as e:
+            raise ConfigError(f"unique_ids[{entry['file']}].pattern: invalid pattern: {e}") from e
     r["unique_ids"] = ids or None
     r["land_alone"] = _rule(cfg, "land_alone", {"targets": RUNBOOK_TARGETS, "with": LAND_WITH}, True)
     return r
@@ -445,6 +458,7 @@ class Checker:
         self.only = only
         self.findings = []
         self.info = []
+        self._bad_json = set()
         self.full = mode in ("tree", "base") and only is None
         if only is not None:
             self.files = [f for f in only if os.path.isfile(os.path.join(repo.root, f))]
@@ -523,14 +537,16 @@ class Checker:
             files.append(self.config_rel)
         return files
 
-    def _prose_fields(self, f, keys):
+    def _prose_fields(self, f, keys, rule="json_prose"):
         text = self.read(f)
         if text is None:
             return []
         try:
             data = json.loads(text)
         except ValueError as e:
-            self.add("json_prose", f, f"invalid JSON: {e}")
+            if f not in self._bad_json:
+                self._bad_json.add(f)
+                self.add(rule, f, f"invalid JSON: {e}")
             return []
         if f == self.config_rel:
             keys = list(keys) + ["$comment"]
@@ -603,14 +619,14 @@ class Checker:
             return []
         if f.endswith(".json"):
             keys = self.rules["json_prose"]["keys"] if self.rules["json_prose"] else PROSE_KEYS
-            return [(None, ptr, s) for ptr, s in self._prose_fields(f, keys)]
+            return [(None, ptr, s) for ptr, s in self._prose_fields(f, keys, rule="voice")]
         return [(i, None, l) for i, l in enumerate(text.split("\n"), 1)]
 
     def check_voice(self, cfg):
         regexes = voice_regexes(VOICE_WORDS + list(cfg["words"]), VOICE_PHRASES)
         counts = {p: {} for p in cfg["count"]}
         count_rx = {p: re.compile(r"\b" + re.escape(p) + r"\b", re.I) for p in cfg["count"]}
-        if cfg["scope"] == "tree":
+        if cfg["scope"] == "tree" or self.only is not None:
             units = [(f, u) for f in self.targets(cfg["targets"]) if f != self.config_rel
                      for u in self._voice_units(f)]
         elif self.mode in ("staged", "base") and self.only is None:

--- a/.local/bin/prose-budget
+++ b/.local/bin/prose-budget
@@ -1,0 +1,770 @@
+#!/usr/bin/env python3
+# prose-budget: mechanical guards against agents bloating documentation.
+#
+# Every number and every grandfathered exception lives in the repo's config
+# (docs/budgets.json or .prose-budgets.json), so loosening a rule is a
+# visible diff in review, not a quiet edit to a test. Rules: lines, sections,
+# delta, json_prose, narration, voice, headers, unique_ids, land_alone.
+#
+# Usage: prose-budget [--config PATH] [--tree | --staged | --base REF]
+#                     [--file PATH ...] [--warn-only] [--json]
+#                     [--require-config] [--version]
+#
+# Exit 1 on any finding, 2 on a bad config or usage, 0 otherwise. A missing
+# config is a no-op (exit 0) unless --require-config. Findings go to stdout,
+# one per line as `file:line: rule: message`; counts and other information
+# go to stderr. Python 3 stdlib only; on PATH from dotfiles.
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+
+VERSION = "1.0.0"
+CONFIG_NAMES = ("docs/budgets.json", ".prose-budgets.json")
+RAISE = "Budgets live in {}; raising one is a deliberate, reviewable diff."
+
+MD_TARGETS = ["README.md", "RUNBOOK.md", "AGENTS.md", "CLAUDE.md", "docs/**/*.md", "runbooks/*.md"]
+RUNBOOK_TARGETS = ["RUNBOOK.md", "runbooks/*.md"]
+LAND_WITH = ["README.md", "CLAUDE.md", "AGENTS.md", "docs/**", "reference/**"]
+PROSE_KEYS = ["note", "$note", "notes", "about", "gap", "narrative", "settled_by", "rationale", "why", "would_settle"]
+NARRATION = {
+    "pr": r"\bPR ?#?\d+\b",
+    "issue": r"(?<![\w./-])[\w-]+(?:/[\w-]+)?#\d+\b",
+    "phase": r"\bP\d\.\d\b",
+    "session": r"\b(?:this|that|the) session\b",
+    "seeded": r"\bseeded \d{4}-",
+    "split": r"\bsplit out of\b|\bstacked on\b",
+}
+VOICE_WORDS = [
+    "delve", "leverage", "seamless", "cutting-edge", "robust", "comprehensive", "vibrant", "testament",
+    "tapestry", "pivotal", "foster", "elevate", "unlock", "game-changer", "revolutionary",
+]
+VOICE_PHRASES = {
+    "worth noting": r"\bit'?s worth noting\b",
+    "not just X but Y": r"\bnot just\b[^.;\n]{1,80}\bbut\b",
+    "whether you're X or Y": r"\bwhether you'?re\b[^.;\n]{1,80}\bor\b",
+    "sentence opener": r"(?:^|[.!?]\s+)(?:Moreover|Additionally|Certainly)\b",
+}
+CODE_EXT = {".js", ".mjs", ".cjs", ".ts", ".tsx", ".jsx", ".py"}
+COMMENT_SYNTAX = {
+    "slash": ({".js", ".mjs", ".cjs", ".ts", ".tsx", ".jsx", ".go", ".rs", ".java", ".c", ".h", ".cpp",
+               ".hpp", ".cs", ".swift", ".kt", ".scala", ".php"}, "//", ("/*", "*/")),
+    "hash": ({".py", ".sh", ".bash", ".zsh", ".rb", ".pl", ".awk", ".yml", ".yaml", ".toml", ".jq", ".mk", ""},
+             "#", None),
+    "dash": ({".sql", ".lua", ".hs"}, "--", None),
+}
+TITLE_RE = {
+    "js": re.compile(r"(?<![.\w])(?:describe|it|test)(?:\.(?:skip|todo|only|each))?\s*\(\s*(['\"`])((?:\\.|(?!\1).)*)\1"),
+    "py": re.compile(r"^\s*def (test_\w+)", re.M),
+}
+FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})")
+HEADING_RE = re.compile(r"^(#{1,6})\s+(.*?)\s*#*\s*$")
+WORD_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9'’./_-]*")
+CODE_SPAN_RE = re.compile(r"`[^`]*`")
+HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
+
+
+class ConfigError(Exception):
+    pass
+
+
+# --- text ------------------------------------------------------------------
+
+def line_count(text):
+    if not text:
+        return 0
+    return text.count("\n") + (0 if text.endswith("\n") else 1)
+
+
+def hash12(s):
+    return hashlib.sha256(s.strip().encode("utf-8")).hexdigest()[:12]
+
+
+def glob_re(pattern):
+    out, i = "", 0
+    while i < len(pattern):
+        c = pattern[i]
+        if pattern.startswith("**/", i):
+            out += "(?:.*/)?"
+            i += 3
+        elif pattern.startswith("**", i):
+            out += ".*"
+            i += 2
+        elif c == "*":
+            out += "[^/]*"
+            i += 1
+        elif c == "?":
+            out += "[^/]"
+            i += 1
+        else:
+            out += re.escape(c)
+            i += 1
+    return re.compile("^" + out + "$")
+
+
+def matches(globs, path):
+    return any(glob_re(g).match(path) for g in globs)
+
+
+def _is_table_delimiter(stripped):
+    return "|" in stripped and "-" in stripped and set(stripped) <= set("|-: ")
+
+
+def prose_lines(text):
+    """Yield (section_id, section_title, heading_line, lineno, line) per prose line.
+
+    Ported from symphony's lint_runbook_prose. Sections are keyed by ordinal
+    so two `## Backup` sections stay distinct. Fences, headings, blanks and
+    tables are free; a `#` comment inside a fence still counts (prose in a
+    costume) except a shebang; inline code spans are stripped in words().
+    """
+    section_id, title, heading_line = 0, "(preamble)", 0
+    in_fence, fence_char, fence_len, in_table = False, None, 0, False
+    pending = None
+
+    def flush():
+        nonlocal pending
+        item, pending = pending, None
+        return item
+
+    for lineno, line in enumerate(text.splitlines(), 1):
+        if in_fence:
+            s = line.strip()
+            if s and set(s) == {fence_char} and len(s) >= fence_len:
+                in_fence = False
+            elif re.match(r"^\s*#", line) and not line.lstrip().startswith("#!"):
+                item = flush()
+                if item:
+                    yield item
+                yield section_id, title, heading_line, lineno, line
+            continue
+        m = FENCE_RE.match(line)
+        if m:
+            item = flush()
+            if item:
+                yield item
+            fence_char, fence_len, in_fence, in_table = m.group(1)[0], len(m.group(1)), True, False
+            continue
+        h = HEADING_RE.match(line)
+        if h:
+            item = flush()
+            if item:
+                yield item
+            in_table = False
+            if len(h.group(1)) == 2:
+                section_id, title, heading_line = section_id + 1, h.group(2), lineno
+            continue
+        stripped = line.strip()
+        if not stripped:
+            item = flush()
+            if item:
+                yield item
+            in_table = False
+            continue
+        if _is_table_delimiter(stripped):
+            pending = None
+            in_table = True
+            continue
+        if in_table:
+            if "|" in stripped:
+                continue
+            in_table = False
+        if stripped.startswith("|"):
+            continue
+        item = flush()
+        if item:
+            yield item
+        pending = (section_id, title, heading_line, lineno, line)
+    item = flush()
+    if item:
+        yield item
+
+
+def words(line):
+    return len(WORD_RE.findall(CODE_SPAN_RE.sub(" ", line)))
+
+
+def count_prose_words(text, exempt=("Where things are",)):
+    return sum(words(line) for _, title, _, _, line in prose_lines(text) if title not in exempt)
+
+
+def section_word_counts(text, exempt=("Where things are",)):
+    """[(title, words, heading_line)] in document order, exempt sections dropped."""
+    order, counts = [], {}
+    for sid, title, hline, _, line in prose_lines(text):
+        if title in exempt:
+            continue
+        if sid not in counts:
+            counts[sid] = [title, 0, hline]
+            order.append(sid)
+        counts[sid][1] += words(line)
+    return [tuple(counts[s]) for s in order]
+
+
+def json_pointer(parts):
+    return "".join("/" + str(p).replace("~", "~0").replace("/", "~1") for p in parts)
+
+
+def prose_strings(value, keys, path=()):
+    """(pointer, text) for every string (or list of strings) under a prose key."""
+    if isinstance(value, list):
+        for i, v in enumerate(value):
+            yield from prose_strings(v, keys, path + (i,))
+    elif isinstance(value, dict):
+        for k, v in value.items():
+            p = path + (k,)
+            if k in keys:
+                if isinstance(v, str):
+                    yield json_pointer(p), v
+                elif isinstance(v, list):
+                    for i, s in enumerate(v):
+                        if isinstance(s, str):
+                            yield json_pointer(p + (i,)), s
+            if not isinstance(v, str):
+                yield from prose_strings(v, keys, p)
+
+
+def comment_syntax(path):
+    ext = os.path.splitext(path)[1]
+    for _, (exts, line_marker, block) in COMMENT_SYNTAX.items():
+        if ext in exts:
+            return line_marker, block
+    return None, None
+
+
+def header_comment(text, path):
+    """Lines of the leading comment block: consecutive line comments, or one block comment."""
+    marker, block = comment_syntax(path)
+    if marker is None:
+        return []
+    lines = text.split("\n")
+    if lines and lines[0].startswith("#!"):
+        lines = lines[1:]
+    if block and lines and lines[0].lstrip().startswith(block[0]):
+        for i, l in enumerate(lines):
+            if block[1] in l:
+                return lines[: i + 1]
+        return lines
+    out = []
+    for l in lines:
+        if not l.startswith(marker):
+            break
+        out.append(l)
+    return out
+
+
+def comment_line_count(text, path):
+    marker, block = comment_syntax(path)
+    if marker is None:
+        return 0
+    n, in_block = 0, False
+    for raw in text.split("\n"):
+        l = raw.strip()
+        if in_block:
+            n += 1
+            if block[1] in l:
+                in_block = False
+        elif l.startswith(marker) and not l.startswith("#!"):
+            n += 1
+        elif block and l.startswith(block[0]):
+            n += 1
+            if block[1] not in l:
+                in_block = True
+    return n
+
+
+def test_titles(text, path):
+    """(lineno, title) for every test title in a source file, indented or not."""
+    kind = "py" if path.endswith(".py") else "js"
+    out = []
+    for m in TITLE_RE[kind].finditer(text):
+        out.append((text.count("\n", 0, m.start()) + 1, m.group(2) if kind == "js" else m.group(1)))
+    return out
+
+
+def voice_regexes(words_, phrases):
+    out = [(w, re.compile(r"(?<![\w-])" + re.escape(w) + r"(?![\w-])", re.I)) for w in words_]
+    out += [(name, re.compile(p, re.I if name != "sentence opener" else 0)) for name, p in phrases.items()]
+    return out
+
+
+# --- config ----------------------------------------------------------------
+
+def find_config(cwd, root):
+    d = os.path.abspath(cwd)
+    while True:
+        for name in CONFIG_NAMES:
+            p = os.path.join(d, name)
+            if os.path.isfile(p):
+                return p
+        if os.path.samefile(d, root) or os.path.dirname(d) == d:
+            return None
+        d = os.path.dirname(d)
+
+
+def _rule(cfg, name, defaults, on):
+    v = cfg.get(name)
+    if v is False:
+        return None
+    if v is None:
+        return dict(defaults) if on else None
+    if not isinstance(v, dict):
+        raise ConfigError(f"{name}: expected an object")
+    for k in v:
+        if k not in defaults:
+            raise ConfigError(f"{name}.{k}: unknown key")
+    d = dict(defaults)
+    d.update(v)
+    return d
+
+
+def load_config(path):
+    try:
+        with open(path, encoding="utf-8") as f:
+            cfg = json.load(f)
+    except (OSError, ValueError) as e:
+        raise ConfigError(f"cannot read {path}: {e}")
+    if not isinstance(cfg, dict):
+        raise ConfigError("top level must be an object")
+    known = {"$comment", "preset", "lines", "sections", "delta", "json_prose", "narration", "voice",
+             "headers", "unique_ids", "land_alone"}
+    for k in cfg:
+        if k not in known:
+            raise ConfigError(f"unknown rule {k!r}")
+    if cfg.get("preset", "strict") != "strict":
+        raise ConfigError("preset: only 'strict' exists")
+    r = {}
+    lines = cfg.get("lines")
+    if lines is None or lines is False:
+        r["lines"] = None
+    elif not isinstance(lines, dict):
+        raise ConfigError("lines: expected {file: max_lines}")
+    else:
+        files = {k: v for k, v in lines.items() if k not in ("required", "must_budget", "pending")}
+        for k, v in files.items():
+            if not isinstance(v, int):
+                raise ConfigError(f"lines.{k}: expected an integer")
+        r["lines"] = {"files": files, "required": bool(lines.get("required", False)),
+                      "must_budget": list(lines.get("must_budget", [])), "pending": list(lines.get("pending", []))}
+    r["sections"] = _rule(cfg, "sections", {"targets": RUNBOOK_TARGETS, "max_words": 140,
+                                             "exempt": ["Where things are"]}, True)
+    budgeted = set(r["lines"]["files"]) if r["lines"] else set()
+    r["delta"] = _rule(cfg, "delta", {"targets": None, "max_words": 40}, True)
+    if r["delta"] and r["delta"]["targets"] is None:
+        r["delta"]["targets"] = MD_TARGETS
+        r["delta"]["exclude"] = budgeted
+    elif r["delta"]:
+        r["delta"]["exclude"] = set()
+    r["json_prose"] = _rule(cfg, "json_prose", {"targets": [], "keys": PROSE_KEYS, "max_chars": 450,
+                                                 "grandfathered": []}, False)
+    r["narration"] = _rule(cfg, "narration", {"targets": MD_TARGETS, "patterns": {}, "disable": [],
+                                               "scope": {}, "grandfathered": []}, True)
+    r["voice"] = _rule(cfg, "voice", {"scope": "diff", "targets": MD_TARGETS, "words": [], "allow": [],
+                                       "count": ["rather than"]}, True)
+    if r["voice"] and r["voice"]["scope"] not in ("diff", "tree"):
+        raise ConfigError("voice.scope: 'diff' or 'tree'")
+    r["headers"] = _rule(cfg, "headers", {"targets": [], "max_lines": 25, "grandfathered": {}}, False)
+    ids = cfg.get("unique_ids")
+    if ids is not None and ids is not False and not (isinstance(ids, list) and all(
+            isinstance(e, dict) and "file" in e and "pattern" in e for e in ids)):
+        raise ConfigError("unique_ids: expected [{file, pattern}]")
+    r["unique_ids"] = ids or None
+    r["land_alone"] = _rule(cfg, "land_alone", {"targets": RUNBOOK_TARGETS, "with": LAND_WITH}, True)
+    return r
+
+
+# --- repo access -------------------------------------------------------------
+
+class Repo:
+    def __init__(self, root):
+        self.root = root
+        self.is_git = self.git("rev-parse", "--git-dir").returncode == 0
+
+    def git(self, *args):
+        return subprocess.run(["git", *args], cwd=self.root, capture_output=True, text=True)
+
+    def all_files(self):
+        if self.is_git:
+            r = self.git("ls-files", "-co", "--exclude-standard", "-z")
+            if r.returncode == 0:
+                return sorted(p for p in r.stdout.split("\0") if p and os.path.isfile(os.path.join(self.root, p)))
+        out = []
+        for d, dirs, files in os.walk(self.root):
+            dirs[:] = [x for x in dirs if x not in (".git", "node_modules")]
+            for f in files:
+                out.append(os.path.relpath(os.path.join(d, f), self.root))
+        return sorted(out)
+
+    def read_disk(self, path):
+        try:
+            with open(os.path.join(self.root, path), encoding="utf-8", errors="replace") as f:
+                return f.read()
+        except OSError:
+            return None
+
+    def show(self, ref, path):
+        r = self.git("show", f"{ref}:{path}" if ref != ":" else f":{path}")
+        return r.stdout if r.returncode == 0 else None
+
+    def staged_paths(self):
+        r = self.git("diff", "--cached", "--no-renames", "--name-only", "--diff-filter=ACMRD")
+        return [p for p in r.stdout.splitlines() if p.strip()]
+
+    def changed_paths(self, a, b):
+        r = self.git("diff", "--no-renames", "--name-only", a, b)
+        return [p for p in r.stdout.splitlines() if p.strip()]
+
+    def added_lines(self, *diff_args):
+        """{path: [(lineno, text)]} of added lines in a unified diff."""
+        r = self.git("diff", "--no-color", "-U0", "--no-renames", *diff_args)
+        out, path, lineno = {}, None, 0
+        for line in r.stdout.split("\n"):
+            if line.startswith("+++ "):
+                path = line[6:] if line.startswith("+++ b/") else None
+            elif line.startswith("@@"):
+                m = HUNK_RE.match(line)
+                lineno = int(m.group(1)) if m else 0
+            elif path and line.startswith("+"):
+                out.setdefault(path, []).append((lineno, line[1:]))
+                lineno += 1
+            elif path and not line.startswith("-") and not line.startswith("\\"):
+                lineno += 1
+        return out
+
+
+# --- checking ------------------------------------------------------------------
+
+class Checker:
+    def __init__(self, rules, repo, config_rel, mode, base=None, only=None):
+        self.rules, self.repo, self.config_rel, self.mode, self.base = rules, repo, config_rel, mode, base
+        self.only = only
+        self.findings = []
+        self.info = []
+        self.full = mode in ("tree", "base") and only is None
+        if only is not None:
+            self.files = [f for f in only if os.path.isfile(os.path.join(repo.root, f))]
+            self.read = repo.read_disk
+        elif mode == "staged":
+            deleted = set(repo.git("diff", "--cached", "--name-only", "--diff-filter=D").stdout.split())
+            self.files = [p for p in repo.staged_paths() if p not in deleted]
+            self.read = lambda p: repo.show(":", p)
+        else:
+            self.files = repo.all_files()
+            self.read = repo.read_disk
+        if mode == "staged":
+            self.before_ref, self.after_ref = "HEAD", ":"
+            self.changed = repo.staged_paths()
+            self.diff_args = ("--cached",)
+        elif mode == "base":
+            mb = repo.git("merge-base", base, "HEAD").stdout.strip()
+            if not mb:
+                raise ConfigError(f"--base {base}: no merge base with HEAD")
+            self.before_ref, self.after_ref = mb, "HEAD"
+            self.changed = repo.changed_paths(mb, "HEAD")
+            self.diff_args = (mb, "HEAD")
+        else:
+            self.changed = []
+
+    def add(self, rule, file, message, line=None, pointer=None, hash_=None):
+        self.findings.append({"rule": rule, "file": file, "line": line, "pointer": pointer,
+                              "hash": hash_, "message": message})
+
+    def targets(self, globs):
+        return [f for f in self.files if matches(globs, f)]
+
+    def run(self):
+        r = self.rules
+        for name in ("lines", "sections", "json_prose", "narration", "voice", "headers", "unique_ids"):
+            if r[name]:
+                getattr(self, "check_" + name)(r[name])
+        if self.mode in ("staged", "base") and self.only is None:
+            if r["delta"]:
+                self.check_delta(r["delta"])
+            if r["land_alone"]:
+                self.check_land_alone(r["land_alone"])
+        self.findings.sort(key=lambda f: (f["file"], f["line"] or 0, f["pointer"] or "", f["rule"]))
+        return self.findings
+
+    def check_lines(self, cfg):
+        for file, max_ in cfg["files"].items():
+            if self.only is not None and file not in self.files:
+                continue
+            text = self.read(file) if (file in self.files or self.mode != "staged") else None
+            if text is None:
+                if cfg["required"] and self.full and file not in cfg["pending"]:
+                    self.add("lines", file, "budgeted but not on disk (rename or typo?); drop the entry "
+                             "or list it under lines.pending")
+                continue
+            n = line_count(text)
+            if n > max_:
+                self.add("lines", file, f"{n} lines, budget {max_}", line=n)
+        for f in self.targets(cfg["must_budget"]):
+            if f not in cfg["files"]:
+                self.add("lines", f, "no line budget; add one")
+
+    def check_sections(self, cfg):
+        for f in self.targets(cfg["targets"]):
+            text = self.read(f)
+            if text is None:
+                continue
+            for title, n, hline in section_word_counts(text, tuple(cfg["exempt"])):
+                if n > cfg["max_words"]:
+                    self.add("sections", f, f"section '{title}' has {n} prose words (max {cfg['max_words']})",
+                             line=hline)
+
+    def _json_targets(self, cfg):
+        files = self.targets(cfg["targets"])
+        if self.config_rel and self.config_rel in self.files and self.config_rel not in files:
+            files.append(self.config_rel)
+        return files
+
+    def _prose_fields(self, f, keys):
+        text = self.read(f)
+        if text is None:
+            return []
+        try:
+            data = json.loads(text)
+        except ValueError as e:
+            self.add("json_prose", f, f"invalid JSON: {e}")
+            return []
+        if f == self.config_rel:
+            keys = list(keys) + ["$comment"]
+        return list(prose_strings(data, keys))
+
+    def check_json_prose(self, cfg):
+        unused = list(cfg["grandfathered"])
+        still = 0
+        for f in self._json_targets(cfg):
+            for ptr, text in self._prose_fields(f, cfg["keys"]):
+                if len(text) <= cfg["max_chars"]:
+                    continue
+                id_ = f"{f}#{ptr}"
+                if id_ in unused:
+                    unused.remove(id_)
+                    still += 1
+                else:
+                    self.add("json_prose", f, f"{len(text)} chars, cap {cfg['max_chars']} "
+                             "(a note is one sentence plus the id it points at)", pointer=ptr)
+        if self.full:
+            for id_ in unused:
+                f, _, ptr = id_.partition("#")
+                self.add("json_prose", f, "grandfathered but no longer over the cap; remove the entry",
+                         pointer=ptr)
+        self.info.append(f"json_prose: {still} grandfathered field(s) still over {cfg['max_chars']} chars")
+
+    def _narration_units(self, f):
+        """(lineno, text) units to scan: raw lines, or header comment + test titles for code."""
+        text = self.read(f)
+        if text is None:
+            return []
+        if os.path.splitext(f)[1] in CODE_EXT:
+            header = header_comment(text, f)
+            start = 2 if text.startswith("#!") else 1
+            return [(start + i, l) for i, l in enumerate(header)] + test_titles(text, f)
+        return list(enumerate(text.split("\n"), 1))
+
+    def check_narration(self, cfg):
+        patterns = {k: v for k, v in NARRATION.items() if k not in cfg["disable"]}
+        patterns.update(cfg["patterns"])
+        compiled = {k: re.compile(v, re.I) for k, v in patterns.items()}
+        unused = list(cfg["grandfathered"])
+        old = 0
+        for f in self.targets(cfg["targets"]):
+            if f == self.config_rel:
+                continue
+            active = {k: v for k, v in compiled.items() if k not in cfg["scope"] or matches(cfg["scope"][k], f)}
+            for lineno, unit in self._narration_units(f):
+                h = hash12(unit)
+                for name, rx in active.items():
+                    for m in rx.finditer(unit):
+                        hit = m.group(0)
+                        g = next((e for e in unused if e.get("file") == f
+                                  and e.get("hash", h) == h and e.get("match", hit) == hit), None)
+                        if g is not None:
+                            unused.remove(g)
+                            old += 1
+                        else:
+                            self.add("narration", f, f'{name} "{hit}" (session narration belongs in the PR '
+                                     f"body or the log; grandfather hash {h})", line=lineno, hash_=h)
+        if self.full:
+            for g in unused:
+                self.add("narration", g.get("file", "?"), f"grandfathered {g.get('match', g.get('hash'))!r} "
+                         "no longer matches; remove the entry", hash_=g.get("hash"))
+        self.info.append(f"narration: {old} grandfathered hit(s)")
+
+    def _voice_units(self, f):
+        text = self.read(f)
+        if text is None:
+            return []
+        if f.endswith(".json"):
+            keys = self.rules["json_prose"]["keys"] if self.rules["json_prose"] else PROSE_KEYS
+            return [(None, ptr, s) for ptr, s in self._prose_fields(f, keys)]
+        return [(i, None, l) for i, l in enumerate(text.split("\n"), 1)]
+
+    def check_voice(self, cfg):
+        regexes = voice_regexes(VOICE_WORDS + list(cfg["words"]), VOICE_PHRASES)
+        counts = {p: {} for p in cfg["count"]}
+        count_rx = {p: re.compile(r"\b" + re.escape(p) + r"\b", re.I) for p in cfg["count"]}
+        if cfg["scope"] == "tree":
+            units = [(f, u) for f in self.targets(cfg["targets"]) if f != self.config_rel
+                     for u in self._voice_units(f)]
+        elif self.mode in ("staged", "base") and self.only is None:
+            added = self.repo.added_lines(*self.diff_args)
+            units = [(f, (n, None, l)) for f, lines in added.items() if matches(cfg["targets"], f)
+                     for n, l in lines]
+        else:
+            return
+        for f, (lineno, ptr, text) in units:
+            for a in cfg["allow"]:
+                text = text.replace(a, "")
+            for name, rx in regexes:
+                for m in rx.finditer(text):
+                    self.add("voice", f, f'"{m.group(0).strip()}" reads as a model; say it plainer',
+                             line=lineno, pointer=ptr)
+            for p, rx in count_rx.items():
+                n = len(rx.findall(text))
+                if n:
+                    counts[p][f] = counts[p].get(f, 0) + n
+        for p, per_file in counts.items():
+            self.info.append(f'voice: "{p}": ' + (", ".join(f"{f} {n}" for f, n in sorted(per_file.items()))
+                                                    or "none"))
+
+    def check_headers(self, cfg):
+        for f in self.targets(cfg["targets"]):
+            text = self.read(f)
+            if text is None:
+                continue
+            total, comments, header = line_count(text), comment_line_count(text, f), len(header_comment(text, f))
+            self.info.append(f"headers: {f}: {comments}/{total} comment lines "
+                             f"({100 * comments // max(total, 1)}%), header {header}")
+            max_ = cfg["grandfathered"].get(f, cfg["max_lines"])
+            if header > max_:
+                self.add("headers", f, f"header comment is {header} lines, cap {max_}", line=1)
+
+    def check_unique_ids(self, cfg):
+        for entry in cfg:
+            f = entry["file"]
+            if f not in self.files:
+                continue
+            text = self.read(f) or ""
+            seen = {}
+            for m in re.finditer(entry["pattern"], text):
+                id_ = m.group(1) if m.groups() else m.group(0)
+                seen[id_] = seen.get(id_, 0) + 1
+            for id_, n in seen.items():
+                if n > 1:
+                    self.add("unique_ids", f, f"{id_} defined {n} times")
+
+    def check_delta(self, cfg):
+        exempt = tuple(self.rules["sections"]["exempt"]) if self.rules["sections"] else ("Where things are",)
+        paths = [p for p in self.changed if matches(cfg["targets"], p) and p not in cfg["exclude"]]
+        added = removed = 0
+        for p in paths:
+            before = self.repo.show(self.before_ref, p)
+            after = self.repo.show(self.after_ref, p)
+            b = count_prose_words(before, exempt) if before is not None else 0
+            a = count_prose_words(after, exempt) if after is not None else 0
+            if a > b:
+                added += a - b
+            else:
+                removed += b - a
+        delta = added - removed
+        if paths:
+            self.info.append(f"delta: {delta:+d} net prose words across {len(paths)} file(s)")
+        if delta > cfg["max_words"]:
+            self.add("delta", "", f"adds {delta} net prose words to {', '.join(paths)} "
+                     f"(max {cfg['max_words']}); cut as much as you add")
+
+    def check_land_alone(self, cfg):
+        if not any(matches(cfg["targets"], p) for p in self.changed):
+            return
+        strays = sorted(p for p in self.changed if not matches(cfg["targets"], p)
+                        and not matches(cfg["with"], p) and p != self.config_rel)
+        if strays:
+            self.add("land_alone", "", "edits to " + ", ".join(p for p in self.changed if matches(cfg["targets"], p))
+                     + " land in their own change so they can be reviewed and rejected on their own; "
+                     "also changed: " + ", ".join(strays))
+
+
+# --- CLI -------------------------------------------------------------------------
+
+def format_finding(f):
+    loc = f["file"] or "(change)"
+    if f["pointer"]:
+        loc += "#" + f["pointer"]
+    if f["line"]:
+        loc += f":{f['line']}"
+    return f"{loc}: {f['rule']}: {f['message']}"
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(prog="prose-budget", add_help=True)
+    ap.add_argument("--config")
+    mode = ap.add_mutually_exclusive_group()
+    mode.add_argument("--tree", action="store_true")
+    mode.add_argument("--staged", action="store_true")
+    mode.add_argument("--base", metavar="REF")
+    ap.add_argument("--file", nargs="+", default=None)
+    ap.add_argument("--warn-only", action="store_true")
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument("--require-config", action="store_true")
+    ap.add_argument("--version", action="version", version=f"prose-budget {VERSION}")
+    try:
+        args = ap.parse_args(argv)
+    except SystemExit as e:
+        return 0 if e.code == 0 else 2
+
+    cwd = os.getcwd()
+    top = subprocess.run(["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True, cwd=cwd)
+    root = top.stdout.strip() if top.returncode == 0 else cwd
+    config = os.path.abspath(args.config) if args.config else find_config(cwd, root)
+    if config is None:
+        if args.require_config:
+            print("no prose-budget config (docs/budgets.json or .prose-budgets.json) and --require-config given")
+            return 1
+        print("no prose-budget config")
+        return 0
+    if not args.config:
+        root = os.path.dirname(config)
+        if os.path.basename(root) == "docs" and config.endswith(os.path.join("docs", "budgets.json")):
+            root = os.path.dirname(root)
+    config_rel = os.path.relpath(config, root).replace(os.sep, "/")
+    if config_rel.startswith(".."):
+        config_rel = None
+    try:
+        rules = load_config(config)
+        repo = Repo(root)
+        which = "staged" if args.staged else "base" if args.base else "tree"
+        if which != "tree" and not repo.is_git:
+            raise ConfigError(f"--{which} needs a git repository at {root}")
+        only = None
+        if args.file:
+            only = [os.path.relpath(os.path.abspath(p), root).replace(os.sep, "/") for p in args.file]
+            only = [p for p in only if not p.startswith("..")]
+        checker = Checker(rules, repo, config_rel, which, args.base, only)
+        findings = checker.run()
+    except ConfigError as e:
+        print(f"prose-budget: bad config {config}: {e}", file=sys.stderr)
+        return 2
+
+    for line in checker.info:
+        print("prose-budget: " + line, file=sys.stderr)
+    if args.json:
+        print(json.dumps(findings, indent=2))
+    else:
+        for f in findings:
+            print(format_finding(f))
+        if findings:
+            print(RAISE.format(config_rel or config))
+        else:
+            print(f"prose-budget: OK -- {len(checker.files)} file(s) checked ({which})")
+    if findings and not args.warn_only:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.local/bin/prose-budget
+++ b/.local/bin/prose-budget
@@ -57,7 +57,8 @@ COMMENT_SYNTAX = {
     "dash": ({".sql", ".lua", ".hs"}, "--", None),
 }
 TITLE_RE = {
-    "js": re.compile(r"(?<![.\w])(?:describe|it|test)(?:\.(?:skip|todo|only|each))?\s*\(\s*(['\"`])((?:\\.|(?!\1).)*)\1"),
+    "js": re.compile(r"(?<![.\w])(?:describe|it|test)(?:\.(?:skip|todo|only|each))?\s*\(\s*"
+                     r"(?:'((?:[^'\\\n]|\\.)*)'|\"((?:[^\"\\\n]|\\.)*)\"|`((?:[^`\\\n]|\\.)*)`)"),
     "py": re.compile(r"^\s*def (test_\w+)", re.M),
 }
 FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})")
@@ -281,7 +282,8 @@ def test_titles(text, path):
     kind = "py" if path.endswith(".py") else "js"
     out = []
     for m in TITLE_RE[kind].finditer(text):
-        out.append((text.count("\n", 0, m.start()) + 1, m.group(2) if kind == "js" else m.group(1)))
+        title = m.group(1) if kind == "py" else next(g for g in m.groups() if g is not None)
+        out.append((text.count("\n", 0, m.start()) + 1, title))
     return out
 
 
@@ -613,8 +615,8 @@ class Checker:
                      for u in self._voice_units(f)]
         elif self.mode in ("staged", "base") and self.only is None:
             added = self.repo.added_lines(*self.diff_args)
-            units = [(f, (n, None, l)) for f, lines in added.items() if matches(cfg["targets"], f)
-                     for n, l in lines]
+            units = [(f, (n, None, l)) for f, lines in added.items()
+                     if matches(cfg["targets"], f) and f != self.config_rel for n, l in lines]
         else:
             return
         for f, (lineno, ptr, text) in units:

--- a/.local/bin/prose-budget.test.py
+++ b/.local/bin/prose-budget.test.py
@@ -156,6 +156,10 @@ class CliTest(RepoCase):
         self.assertEqual(self.cli("--tree")[0], 2)
         self.config({"nonsense": 1})
         self.assertEqual(self.cli("--tree")[0], 2)
+        self.config({"narration": {"patterns": {"bad": "(unclosed"}}})
+        self.assertEqual(self.cli("--tree")[0], 2)
+        self.config({"unique_ids": [{"file": "README.md", "pattern": "(unclosed"}]})
+        self.assertEqual(self.cli("--tree")[0], 2)
 
     def test_version(self):
         self.assertEqual(self.cli("--version")[1].strip(), f"prose-budget {pb.VERSION}")
@@ -449,6 +453,25 @@ class VoiceTest(RepoCase):
         self.config({"$comment": "a robust comment", "voice": {"targets": ["**/*.json"]}}, path="docs/budgets.json")
         self.git("add", "docs/budgets.json")
         self.assertEqual(self.findings("--staged"), [])
+
+    def test_file_scope_is_scanned_even_under_default_diff_scope(self):
+        # The edit hook runs `--tree --file <path>`; with the default voice.scope
+        # ("diff") this used to hit the diff-only branch, see self.only is not
+        # None, and bail without scanning the file at all.
+        self.config({})
+        self.write("README.md", "a robust design\n")
+        f = self.findings("--tree", "--file", "README.md")
+        self.assertEqual([x["rule"] for x in f], ["voice"])
+
+    def test_malformed_json_reported_once_under_the_enabled_rule(self):
+        self.config({"json_prose": {"targets": ["*.json"]}, "voice": {"targets": ["*.json"]}})
+        self.write("a.json", "{oops")
+        f = self.findings("--tree")
+        self.assertEqual([(x["rule"], x["file"]) for x in f], [("json_prose", "a.json")])
+        self.config({"voice": {"scope": "tree", "targets": ["*.json"]}})
+        self.write("b.json", "{oops")
+        f = [x for x in self.findings("--tree") if x["file"] == "b.json"]
+        self.assertEqual([(x["rule"], x["file"]) for x in f], [("voice", "b.json")])
 
     def test_diff_scope_judges_only_added_lines(self):
         self.config({})

--- a/.local/bin/prose-budget.test.py
+++ b/.local/bin/prose-budget.test.py
@@ -84,6 +84,8 @@ class HelpersTest(unittest.TestCase):
     def test_test_titles_indented_and_skip_forms(self):
         src = "    test('deep title', () => {})\ntest.skip(\"skipped\", x)\nit(`tmpl`)\nfoo.test('method call')\n"
         self.assertEqual([t for _, t in pb.test_titles(src, "a.test.mjs")], ["deep title", "skipped", "tmpl"])
+        self.assertEqual([t for _, t in pb.test_titles("it('esc\\'d quote', x)", "a.ts")], ["esc\\'d quote"])
+        self.assertEqual(pb.test_titles('it("' + "\\a" * 40 + "x", "a.ts"), [], "no backtracking blowup")
         self.assertEqual([t for _, t in pb.test_titles("class T:\n    def test_x(self): pass\n", "t.py")], ["test_x"])
 
     def test_header_comment_forms(self):
@@ -439,6 +441,14 @@ class VoiceTest(RepoCase):
     def test_json_prose_strings_are_checked_in_tree_scope(self):
         self.assertEqual(self.tree('{"note": "a seamless flow", "id": "seamless-id"}', {"targets": ["*.json"]}, "a.json"),
                          ["seamless"])
+
+    def test_diff_scope_never_judges_the_config_file(self):
+        self.config({"voice": {"targets": ["**/*.json"]}}, path="docs/budgets.json")
+        self.git("add", "docs/budgets.json")
+        self.assertEqual(self.findings("--staged"), [])
+        self.config({"$comment": "a robust comment", "voice": {"targets": ["**/*.json"]}}, path="docs/budgets.json")
+        self.git("add", "docs/budgets.json")
+        self.assertEqual(self.findings("--staged"), [])
 
     def test_diff_scope_judges_only_added_lines(self):
         self.config({})

--- a/.local/bin/prose-budget.test.py
+++ b/.local/bin/prose-budget.test.py
@@ -1,0 +1,482 @@
+#!/usr/bin/env python3
+# Tests for prose-budget. Run: python3 .local/bin/prose-budget.test.py
+#
+# Every rule gets a positive and a negative case, symphony's runbook-lint
+# cases are ported one for one, and the false positives that bit the three
+# source repos each get a regression: hyphenated identifiers, a cited
+# surname on the voice list, prose hidden in a fence, tables without a
+# leading pipe, indented test titles.
+import importlib.util
+import importlib.machinery
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.dont_write_bytecode = True
+ENGINE = Path(__file__).resolve().parent / "prose-budget"
+spec = importlib.util.spec_from_loader("prose_budget", importlib.machinery.SourceFileLoader("prose_budget", str(ENGINE)))
+pb = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(pb)
+
+
+class ProseCountingTest(unittest.TestCase):
+    """Symphony's cases, verbatim."""
+
+    def test_ignores_fences_headings_tables_blanks(self):
+        text = ("# Title\n\none two three\n\n```sh\nthis whole fenced block is free of charge entirely\n```\n\n"
+                "| col | col |\n| --- | --- |\n| a | b |\n")
+        self.assertEqual(pb.count_prose_words(text), 3)
+
+    def test_shell_comments_inside_fences_count(self):
+        text = "## A\n\n```bash\n#!/bin/sh\n# four words of prose\nrun --flag  # not counted\n```\n"
+        self.assertEqual(pb.count_prose_words(text), 4)
+
+    def test_inline_code_spans_are_free(self):
+        self.assertEqual(pb.count_prose_words("## A\n\nrun `docker compose up -d` now\n"), 2)
+
+    def test_index_section_is_exempt(self):
+        self.assertEqual(pb.count_prose_words("## Where things are\n\nlink one link two link three\n"), 0)
+
+    def test_words_attributed_to_enclosing_section(self):
+        counts = [(t, n) for t, n, _ in pb.section_word_counts("## A\n\none two\n\n## B\n\nthree four five\n")]
+        self.assertEqual(counts, [("A", 2), ("B", 3)])
+
+    def test_repeated_section_titles_stay_separate(self):
+        counts = [(t, n) for t, n, _ in pb.section_word_counts("## Backup\n\none two\n\n## Backup\n\nthree four five\n")]
+        self.assertEqual(counts, [("Backup", 2), ("Backup", 3)])
+
+    def test_four_backtick_fence_survives_a_nested_triple_backtick(self):
+        self.assertEqual(pb.count_prose_words("## A\n\n````\nsome prose with ``` inside a fence\n````\n\nafter\n"), 1)
+
+    def test_table_without_leading_pipes_is_free(self):
+        text = "## A\n\nHeader | Header\n------ | ------\nvalue | value\n\nreal words here\n"
+        self.assertEqual(pb.count_prose_words(text), 3)
+
+    def test_section_heading_line_is_reported(self):
+        self.assertEqual(pb.section_word_counts("intro\n\n## A\n\nx\n")[1][2], 3)
+
+
+class HelpersTest(unittest.TestCase):
+    def test_glob_double_star(self):
+        self.assertTrue(pb.matches(["docs/**/*.md"], "docs/a.md"))
+        self.assertTrue(pb.matches(["docs/**/*.md"], "docs/adr/0001.md"))
+        self.assertFalse(pb.matches(["docs/*.md"], "docs/adr/0001.md"))
+        self.assertFalse(pb.matches(["*.md"], "docs/a.md"))
+        self.assertTrue(pb.matches(["reference/**"], "reference/x/y.txt"))
+
+    def test_line_count(self):
+        self.assertEqual(pb.line_count(""), 0)
+        self.assertEqual(pb.line_count("a\nb\n"), 2)
+        self.assertEqual(pb.line_count("a\nb"), 2)
+
+    def test_json_pointer_escapes(self):
+        self.assertEqual(pb.json_pointer(("a/b", 0, "c~d")), "/a~1b/0/c~0d")
+
+    def test_prose_strings_takes_strings_and_string_lists(self):
+        data = {"note": "x", "items": [{"why": "y", "notes": ["p", "q"], "id": "skip"}]}
+        self.assertEqual(list(pb.prose_strings(data, ["note", "why", "notes"])),
+                         [("/note", "x"), ("/items/0/why", "y"), ("/items/0/notes/0", "p"), ("/items/0/notes/1", "q")])
+
+    def test_test_titles_indented_and_skip_forms(self):
+        src = "    test('deep title', () => {})\ntest.skip(\"skipped\", x)\nit(`tmpl`)\nfoo.test('method call')\n"
+        self.assertEqual([t for _, t in pb.test_titles(src, "a.test.mjs")], ["deep title", "skipped", "tmpl"])
+        self.assertEqual([t for _, t in pb.test_titles("class T:\n    def test_x(self): pass\n", "t.py")], ["test_x"])
+
+    def test_header_comment_forms(self):
+        self.assertEqual(len(pb.header_comment("#!/bin/sh\n# a\n# b\ncode\n# c\n", "x.sh")), 2)
+        self.assertEqual(len(pb.header_comment("/* a\n b */\n// not header\n", "x.ts")), 2)
+        self.assertEqual(len(pb.header_comment("// a\n// b\n\n// c\n", "x.ts")), 2)
+        self.assertEqual(pb.header_comment("x", "x.md"), [])
+
+    def test_issue_pattern_skips_markdown_anchors(self):
+        rx = pb.re.compile(pb.NARRATION["issue"], pb.re.I)
+        self.assertIsNone(rx.search("see [Q-5](docs/requirements.md#9-open-questions)"))
+        self.assertEqual(rx.search("fixed in colregs-engine#12").group(0), "colregs-engine#12")
+        self.assertEqual(rx.search("fixed in mark-brannan/colregs#12").group(0), "mark-brannan/colregs#12")
+
+
+class RepoCase(unittest.TestCase):
+    """A throwaway git repo with a config; cli() invokes the engine CLI in it."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name).resolve()
+        self.git("init", "-q", "-b", "main")
+        self.git("config", "user.email", "t@example.com")
+        self.git("config", "user.name", "t")
+        self.git("config", "commit.gpgsign", "false")
+
+    def git(self, *args):
+        return subprocess.run(["git", *args], cwd=self.root, capture_output=True, text=True, check=True)
+
+    def write(self, path, text):
+        p = self.root / path
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(text, encoding="utf-8")
+
+    def config(self, cfg, path=".prose-budgets.json"):
+        self.write(path, json.dumps(cfg))
+
+    def commit(self, *paths, msg="c"):
+        self.git("add", "--", *paths)
+        self.git("commit", "-qm", msg)
+
+    def cli(self, *args, cwd=None):
+        r = subprocess.run([sys.executable, str(ENGINE), *args], cwd=cwd or self.root, capture_output=True, text=True)
+        return r.returncode, r.stdout, r.stderr
+
+    def findings(self, *args):
+        code, out, err = self.cli("--json", *args)
+        self.assertIn(code, (0, 1), err)
+        return json.loads(out)
+
+    def rules(self, *args):
+        return sorted(f["rule"] for f in self.findings(*args))
+
+
+class CliTest(RepoCase):
+    def test_no_config_is_a_noop(self):
+        code, out, _ = self.cli("--tree")
+        self.assertEqual((code, out.strip()), (0, "no prose-budget config"))
+
+    def test_require_config_fails_without_one(self):
+        self.assertEqual(self.cli("--tree", "--require-config")[0], 1)
+
+    def test_bad_config_exits_2(self):
+        self.write(".prose-budgets.json", "{not json")
+        self.assertEqual(self.cli("--tree")[0], 2)
+        self.config({"voice": {"scope": "sometimes"}})
+        self.assertEqual(self.cli("--tree")[0], 2)
+        self.config({"nonsense": 1})
+        self.assertEqual(self.cli("--tree")[0], 2)
+
+    def test_version(self):
+        self.assertEqual(self.cli("--version")[1].strip(), f"prose-budget {pb.VERSION}")
+
+    def test_findings_end_with_the_budget_line_and_name_the_config(self):
+        self.config({"lines": {"README.md": 1}}, path="docs/budgets.json")
+        self.write("README.md", "a\nb\nc\n")
+        code, out, _ = self.cli("--tree")
+        self.assertEqual(code, 1)
+        self.assertEqual(out.splitlines()[0], "README.md:3: lines: 3 lines, budget 1")
+        self.assertEqual(out.splitlines()[-1], pb.RAISE.format("docs/budgets.json"))
+
+    def test_warn_only_exits_zero(self):
+        self.config({"lines": {"README.md": 1}})
+        self.write("README.md", "a\nb\n")
+        self.assertEqual(self.cli("--tree", "--warn-only")[0], 0)
+
+    def test_json_shape(self):
+        self.config({"lines": {"README.md": 1}})
+        self.write("README.md", "a\nb\n")
+        f = self.findings("--tree")
+        self.assertEqual(set(f[0]), {"rule", "file", "line", "pointer", "hash", "message"})
+
+    def test_config_discovered_walking_up_and_docs_first(self):
+        self.config({"lines": {"README.md": 1}}, path="docs/budgets.json")
+        self.config({}, path=".prose-budgets.json")
+        self.write("README.md", "a\nb\n")
+        (self.root / "sub" / "dir").mkdir(parents=True)
+        self.assertEqual(self.cli("--tree", cwd=self.root / "sub" / "dir")[0], 1)
+
+    def test_tree_is_the_default_and_covers_untracked_files(self):
+        self.config({"lines": {"README.md": 1}})
+        self.write("README.md", "a\nb\n")
+        self.assertEqual(self.cli()[0], 1)
+
+    def test_file_restricts_scope_and_skips_unused_grandfather_checks(self):
+        self.config({"lines": {"README.md": 1, "OTHER.md": 1},
+                     "json_prose": {"targets": ["d.json"], "grandfathered": ["d.json#/note"]}})
+        self.write("README.md", "a\nb\n")
+        self.write("OTHER.md", "a\nb\n")
+        self.write("d.json", '{"note": "short"}')
+        f = self.findings("--tree", "--file", "README.md")
+        self.assertEqual([x["file"] for x in f], ["README.md"])
+        f = self.findings("--tree", "--file", str(self.root / "sub" / "outside.md"))
+        self.assertEqual(f, [])
+
+
+class LinesTest(RepoCase):
+    def test_over_and_under(self):
+        self.config({"lines": {"README.md": 2, "docs/a.md": 2}})
+        self.write("README.md", "a\nb\nc\n")
+        self.write("docs/a.md", "a\nb\n")
+        self.assertEqual([f["file"] for f in self.findings("--tree")], ["README.md"])
+
+    def test_missing_file_skipped_unless_required(self):
+        self.config({"lines": {"gone.md": 2}})
+        self.assertEqual(self.findings("--tree"), [])
+        self.config({"lines": {"gone.md": 2, "required": True}})
+        self.assertEqual(self.rules("--tree"), ["lines"])
+        self.config({"lines": {"gone.md": 2, "required": True, "pending": ["gone.md"]}})
+        self.assertEqual(self.findings("--tree"), [])
+
+    def test_must_budget(self):
+        self.config({"lines": {"README.md": 5, "must_budget": ["docs/**/*.md"]}})
+        self.write("README.md", "a\n")
+        self.write("docs/x.md", "a\n")
+        self.assertEqual([f["file"] for f in self.findings("--tree")], ["docs/x.md"])
+        self.config({"lines": {"README.md": 5, "docs/x.md": 5, "must_budget": ["docs/**/*.md"]}})
+        self.assertEqual(self.findings("--tree"), [])
+
+
+class SectionsTest(RepoCase):
+    def test_section_over_budget_fails(self):
+        self.config({"delta": False})
+        self.write("RUNBOOK.md", "## Big\n\n" + ("word " * 145) + "\n")
+        self.git("add", "RUNBOOK.md")
+        f = self.findings("--staged")
+        self.assertEqual([(x["rule"], x["line"]) for x in f], [("sections", 1)])
+        self.assertIn("Big", f[0]["message"])
+
+    def test_section_within_budget_passes(self):
+        self.config({})
+        self.write("RUNBOOK.md", "## Small\n\nshort enough\n")
+        self.git("add", "RUNBOOK.md")
+        self.assertEqual(self.findings("--staged"), [])
+
+    def test_prose_in_a_fence_costume_still_counts(self):
+        self.config({"sections": {"max_words": 5}})
+        self.write("RUNBOOK.md", "## A\n\n```sh\n# one two three four five six\nls\n```\n")
+        self.assertEqual(self.rules("--tree"), ["sections"])
+
+    def test_exempt_and_custom_targets(self):
+        self.config({"sections": {"targets": ["docs/*.md"], "max_words": 2, "exempt": ["Index"]}})
+        self.write("docs/a.md", "## Index\n\none two three four\n\n## Body\n\none two\n")
+        self.write("RUNBOOK.md", "## Big\n\none two three four\n")
+        self.assertEqual(self.findings("--tree"), [])
+
+
+class DeltaTest(RepoCase):
+    def test_new_file_counts_fully_as_added(self):
+        self.config({"delta": {"targets": ["RUNBOOK.md", "runbooks/*.md"]}})
+        self.write("RUNBOOK.md", "seed\n")
+        self.commit("RUNBOOK.md", ".prose-budgets.json")
+        self.write("runbooks/new.md", "## S\n\n" + ("word " * 60) + "\n")
+        self.git("add", "runbooks/new.md")
+        f = self.findings("--staged")
+        self.assertEqual([x["rule"] for x in f], ["delta"])
+        self.assertIn("adds 60 net prose words", f[0]["message"])
+
+    def test_removal_credits_against_addition(self):
+        self.config({})
+        self.write("RUNBOOK.md", "## A\n\n" + ("word " * 100) + "\n")
+        self.commit("RUNBOOK.md", ".prose-budgets.json")
+        self.write("RUNBOOK.md", "## A\n\n" + ("term " * 100) + "\n")
+        self.git("add", "RUNBOOK.md")
+        self.assertEqual(self.findings("--staged"), [])
+
+    def test_deleted_runbook_credits_its_words(self):
+        self.config({})
+        self.write("RUNBOOK.md", "## A\n")
+        self.write("runbooks/old.md", "## S\n\n" + ("word " * 100) + "\n")
+        self.commit("RUNBOOK.md", "runbooks/old.md", ".prose-budgets.json")
+        self.git("rm", "-q", "runbooks/old.md")
+        self.write("RUNBOOK.md", "## A\n\n" + ("word " * 120) + "\n")
+        self.git("add", "RUNBOOK.md")
+        self.assertEqual(self.findings("--staged"), [])
+
+    def test_pure_rename_is_net_zero(self):
+        self.config({})
+        self.write("RUNBOOK.md", "seed\n")
+        self.write("runbooks/a.md", "## S\n\n" + ("word " * 100) + "\n")
+        self.commit("RUNBOOK.md", "runbooks/a.md", ".prose-budgets.json")
+        self.git("mv", "runbooks/a.md", "runbooks/b.md")
+        self.assertEqual(self.findings("--staged"), [])
+
+    def test_preset_delta_skips_files_with_a_line_budget_and_runs_under_base(self):
+        self.config({"lines": {"README.md": 500}})
+        self.write("README.md", "seed\n")
+        self.write("docs/a.md", "seed\n")
+        self.commit("README.md", "docs/a.md", ".prose-budgets.json")
+        self.git("checkout", "-qb", "feature")
+        self.write("README.md", "## A\n\n" + ("word " * 100) + "\n")
+        self.commit("README.md")
+        self.assertEqual(self.findings("--base", "main"), [])
+        self.write("docs/a.md", "## A\n\n" + ("word " * 100) + "\n")
+        self.commit("docs/a.md")
+        self.assertEqual(self.rules("--base", "main"), ["delta"])
+        self.assertEqual(self.findings("--tree"), [], "delta never runs on the tree")
+
+
+class LandAloneTest(RepoCase):
+    def stage(self, *paths):
+        for p in paths:
+            self.write(p, "x\n")
+        self.git("add", "--", *paths)
+
+    def test_code_alongside_runbook_fails(self):
+        self.config({})
+        self.stage("RUNBOOK.md", "scripts/foo.py")
+        f = [x for x in self.findings("--staged") if x["rule"] == "land_alone"]
+        self.assertEqual(len(f), 1)
+        self.assertIn("scripts/foo.py", f[0]["message"])
+
+    def test_allowlisted_neighbours_pass(self):
+        self.config({"land_alone": {"with": ["README.md", "CLAUDE.md", "reference/**"]}})
+        self.stage("RUNBOOK.md", "README.md", "CLAUDE.md", "reference/x.md", "runbooks/y.md")
+        self.assertNotIn("land_alone", self.rules("--staged"))
+
+    def test_no_runbook_staged_is_not_our_business(self):
+        self.config({})
+        self.stage("scripts/foo.py", "ansible/x.yml")
+        self.assertEqual(self.findings("--staged"), [])
+
+
+class JsonProseTest(RepoCase):
+    def test_over_cap_and_grandfather_consumed(self):
+        long = "x" * 20
+        self.config({"json_prose": {"targets": ["data/*.json"], "max_chars": 10,
+                                    "grandfathered": ["data/a.json#/items/0/note"]}})
+        self.write("data/a.json", json.dumps({"items": [{"note": long}, {"why": long, "id": long}]}))
+        f = self.findings("--tree")
+        self.assertEqual([(x["file"], x["pointer"]) for x in f], [("data/a.json", "/items/1/why")])
+        _, _, err = self.cli("--tree")
+        self.assertIn("1 grandfathered field(s) still over 10 chars", err)
+
+    def test_unused_grandfather_is_a_finding_only_on_a_full_scan(self):
+        self.config({"json_prose": {"targets": ["data/*.json"], "max_chars": 10, "grandfathered": ["data/a.json#/note"]}})
+        self.write("data/a.json", '{"note": "short"}')
+        self.assertEqual(self.rules("--tree"), ["json_prose"])
+        self.git("add", "data/a.json")
+        self.assertEqual(self.findings("--staged"), [])
+
+    def test_config_comment_is_subject_to_the_cap(self):
+        self.config({"$comment": "y" * 30, "json_prose": {"max_chars": 10}})
+        f = self.findings("--tree")
+        self.assertEqual([(x["file"], x["pointer"]) for x in f], [(".prose-budgets.json", "/$comment")])
+
+    def test_invalid_json_is_a_finding(self):
+        self.config({"json_prose": {"targets": ["data/*.json"]}})
+        self.write("data/a.json", "{oops")
+        self.assertEqual(self.rules("--tree"), ["json_prose"])
+
+
+class NarrationTest(RepoCase):
+    def hits(self, text, cfg=None, name="README.md"):
+        self.config({"narration": cfg or {}})
+        self.write(name, text)
+        return [f["message"].split('"')[1] for f in self.findings("--tree") if f["rule"] == "narration"]
+
+    def test_builtins(self):
+        self.assertEqual(self.hits("done in PR #12\n"), ["PR #12"])
+        self.assertEqual(self.hits("see colregs#4\n"), ["colregs#4"])
+        self.assertEqual(self.hits("during P2.1\n"), ["P2.1"])
+        self.assertEqual(self.hits("earlier in this session\n"), ["this session"])
+        self.assertEqual(self.hits("seeded 2026-01-01\n"), ["seeded 2026-"])
+        self.assertEqual(self.hits("split out of the big one\n"), ["split out of"])
+        self.assertEqual(self.hits("clean prose\n"), [])
+
+    def test_disable_scope_and_extra_patterns(self):
+        self.assertEqual(self.hits("PR #12\n", {"disable": ["pr"]}), [])
+        self.assertEqual(self.hits("PR #12\n", {"scope": {"pr": ["docs/**"]}}), [])
+        self.assertEqual(self.hits("PR #12\n", {"scope": {"pr": ["docs/**"]}, "targets": ["docs/*.md"]}, "docs/a.md"),
+                         ["PR #12"])
+        os.remove(self.root / "docs" / "a.md")
+        self.assertEqual(self.hits("TODO later\n", {"patterns": {"todo": r"\bTODO\b"}}), ["TODO"])
+
+    def test_grandfather_by_hash_and_by_match_and_unused(self):
+        line = "done in PR #12 and PR #13"
+        h = pb.hash12(line)
+        self.assertEqual(self.hits(line + "\n", {"grandfathered": [{"file": "README.md", "hash": h}]}), ["PR #13"])
+        self.assertEqual(self.hits(line + "\n", {"grandfathered": [{"file": "README.md", "match": "PR #12"},
+                                                                    {"file": "README.md", "match": "PR #13"}]}), [])
+        f = self.findings("--tree")
+        self.config({"narration": {"grandfathered": [{"file": "README.md", "match": "PR #99"}]}})
+        self.write("README.md", "clean\n")
+        self.assertEqual(self.rules("--tree"), ["narration"])
+
+    def test_grandfather_hash_is_printed_for_the_fix(self):
+        self.config({})
+        self.write("README.md", "  done in PR #12  \n")
+        f = self.findings("--tree")
+        self.assertEqual(f[0]["hash"], pb.hash12("done in PR #12"))
+        self.assertIn(f[0]["hash"], f[0]["message"])
+
+    def test_code_files_scan_titles_and_header_only(self):
+        src = "// header mentions PR #1\nconst x = 'PR #2 in code is fine'\n    test('indented PR #3', () => {})\n"
+        self.assertEqual(self.hits(src, {"targets": ["test/*.mjs"]}, "test/a.test.mjs"), ["PR #1", "PR #3"])
+
+    def test_config_file_itself_is_not_scanned(self):
+        self.config({"narration": {"targets": ["*.json"], "grandfathered": [{"file": "x.json", "match": "PR #1"}]}})
+        self.write("x.json", '{"a": "PR #1"}')
+        self.assertEqual(self.findings("--tree"), [])
+
+
+class VoiceTest(RepoCase):
+    def tree(self, text, cfg=None, name="README.md"):
+        c = {"scope": "tree"}
+        c.update(cfg or {})
+        self.config({"voice": c})
+        self.write(name, text)
+        return [f["message"].split('"')[1] for f in self.findings("--tree") if f["rule"] == "voice"]
+
+    def test_words_and_phrases(self):
+        self.assertEqual(self.tree("a robust design\n"), ["robust"])
+        self.assertEqual(self.tree("It's worth noting that\n"), ["It's worth noting"])
+        self.assertEqual(self.tree("not just fast but correct\n"), ["not just fast but"])
+        self.assertEqual(self.tree("whether you're new or old\n"), ["whether you're new or"])
+        self.assertEqual(self.tree("Done. Moreover, more.\n"), [". Moreover"])
+        self.assertEqual(self.tree("a plain sentence\n"), [])
+        self.assertEqual(self.tree("we extrapolate\n", {"words": ["extrapolate"]}), ["extrapolate"])
+
+    def test_hyphenated_identifier_is_not_prose(self):
+        self.assertEqual(self.tree("see no-robust-policy-in-model and `foster-care`\n"), [])
+
+    def test_allow_lets_a_citation_through(self):
+        self.assertEqual(self.tree("per Foster/Gleirscher 2020\n"), ["Foster"])
+        self.assertEqual(self.tree("per Foster/Gleirscher 2020\n", {"allow": ["Foster/Gleirscher"]}), [])
+
+    def test_count_is_reported_never_failed(self):
+        self.assertEqual(self.tree("this rather than that\n"), [])
+        self.assertIn('"rather than": README.md 1', self.cli("--tree")[2])
+
+    def test_json_prose_strings_are_checked_in_tree_scope(self):
+        self.assertEqual(self.tree('{"note": "a seamless flow", "id": "seamless-id"}', {"targets": ["*.json"]}, "a.json"),
+                         ["seamless"])
+
+    def test_diff_scope_judges_only_added_lines(self):
+        self.config({})
+        self.write("README.md", "a robust line Mark wrote\nkeep\n")
+        self.commit("README.md", ".prose-budgets.json")
+        self.assertEqual(self.findings("--tree"), [], "diff scope never judges the tree")
+        self.write("README.md", "a robust line Mark wrote\nkeep\nnew and comprehensive\n")
+        self.git("add", "README.md")
+        f = [x for x in self.findings("--staged") if x["rule"] == "voice"]
+        self.assertEqual([(x["line"], x["message"].split('"')[1]) for x in f], [(3, "comprehensive")])
+        self.git("commit", "-qm", "x")
+        self.git("checkout", "-qb", "feature")
+        self.write("README.md", "a robust line Mark wrote\nkeep\nnew and comprehensive\nleverage it\n")
+        self.commit("README.md")
+        f = [x for x in self.findings("--base", "main") if x["rule"] == "voice"]
+        self.assertEqual([x["message"].split('"')[1] for x in f], ["leverage"])
+
+
+class HeadersTest(RepoCase):
+    def test_cap_grandfather_and_shebang(self):
+        self.config({"headers": {"targets": ["src/*.ts", "bin/*"], "max_lines": 2, "grandfathered": {"src/old.ts": 3}}})
+        self.write("src/a.ts", "// 1\n// 2\n// 3\nx\n")
+        self.write("src/ok.ts", "/* 1\n 2 */\n// 3\nx\n")
+        self.write("src/old.ts", "// 1\n// 2\n// 3\nx\n")
+        self.write("bin/tool", "#!/bin/sh\n# 1\n# 2\necho\n")
+        self.assertEqual([f["file"] for f in self.findings("--tree")], ["src/a.ts"])
+        self.assertIn("src/a.ts: 3/4 comment lines (75%), header 3", self.cli("--tree")[2])
+
+
+class UniqueIdsTest(RepoCase):
+    def test_duplicate_id(self):
+        self.config({"unique_ids": [{"file": "docs/r.md", "pattern": r"\*\*(Q-\d+|REQ-[A-Z]+-\d+)\*\*"}]})
+        self.write("docs/r.md", "**Q-1** a\n**REQ-X-1** b\n**Q-1** again\n")
+        f = self.findings("--tree")
+        self.assertEqual([(x["rule"], x["message"]) for x in f], [("unique_ids", "Q-1 defined 2 times")])
+        self.write("docs/r.md", "**Q-1** a\n**Q-2** b\n")
+        self.assertEqual(self.findings("--tree"), [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,8 @@ happen to be tracked here, but they are not *about* this repo. This file is.
 - `.local/bin/dotfiles-add-secret.sh` — the one command for adding a sops secret.
 - `.local/bin/cloud-session-setup.sh` — seeds a subset of this repo into `$HOME`
   on an ephemeral cloud VM.
+- `.local/bin/prose-budget` — the documentation-bloat guard every repo with a
+  `docs/budgets.json` runs; `prose-budget.test.py` beside it is its suite.
 - `.claude/cloud-setup.sh` — writes `deniedMcpServers` at user scope.
 - `.claude/hooks/` — session-continuity and metrics hooks.
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -34,6 +34,7 @@ and the scars behind them — see [README.md § Conventions](README.md).
 **Claude Code — a real machine**
 - [Wire the hooks on a real machine](#wire-the-hooks-on-a-real-machine)
 - [Change what the metrics readouts show](#change-what-the-metrics-readouts-show)
+- [Check a repo's prose budgets](#check-a-repos-prose-budgets)
 
 **GitHub repository**
 - [Set the auth token for the PR review workflows](#set-the-auth-token-for-the-pr-review-workflows)
@@ -380,6 +381,28 @@ Widths worth knowing: the block's header pads to 30 columns, and the desktop
 UI prefixes **each line** with `PostToolUse:<tool> says:` — 50 characters on
 its own for a long MCP tool name — then wraps around 75. `--fields` shows which
 field is eating the budget when a line wraps.
+
+## Check a repo's prose budgets
+
+`prose-budget` reads `docs/budgets.json` (or `.prose-budgets.json`), walking
+up from the current directory; a repo with neither is skipped. The commit
+hook runs `--staged` and denies the commit on findings; CI runs `--base`.
+
+```bash
+prose-budget --tree                     # every tree rule, whole repo
+prose-budget --staged                   # what the commit hook sees
+prose-budget --base origin/main         # what CI sees for this branch
+prose-budget --tree --file docs/x.md    # one file, as the edit hook does
+```
+
+Exit 0 is clean, 1 lists findings as `file:line: rule: message`, 2 is a bad
+config. Every finding ends with the config path; edit that file, never the
+engine, to raise a budget or grandfather a hit (the `narration` message
+prints the hash to grandfather).
+
+```bash
+prose-budget --tree; echo "exit $?"     # 0, and one "OK" line
+```
 
 ## Set the auth token for the PR review workflows
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -386,7 +386,10 @@ field is eating the budget when a line wraps.
 
 `prose-budget` reads `docs/budgets.json` (or `.prose-budgets.json`), walking
 up from the current directory; a repo with neither is skipped. The commit
-hook runs `--staged` and denies the commit on findings; CI runs `--base`.
+hook runs `--staged` and denies the commit on findings. `--base` is not yet
+wired into this repository's CI — `hook-tests.yml` only runs the engine's own
+test suite — so a finding that a local commit lets through (`--file`,
+`--only`, an uncommitted skip) has no CI backstop today.
 
 ```bash
 prose-budget --tree                     # every tree rule, whole repo


### PR DESCRIPTION
One engine, `.local/bin/prose-budget`, replaces the three per-repo copies of the prose guardrails (colregs `test/docs.test.mjs`, colregs-engine `test/docs.test.ts`, symphony `scripts/lint_runbook_prose.py`). Each repo keeps only a config, `docs/budgets.json` or `.prose-budgets.json`; every threshold and grandfathered exception lives there, so loosening a rule is a reviewable diff.

## Design

- Python 3 stdlib, one file, on PATH from dotfiles and seeded to cloud sessions.
- Modes: `--tree` (default), `--staged` (the commit hook), `--base REF` (CI). Change rules (`delta`, `land_alone`, `voice` in its default `diff` scope) only run under the last two.
- `preset: "strict"` is implied: `sections`, `delta`, `narration`, `voice` (diff scope) and `land_alone` are on with default targets; `lines`, `json_prose`, `headers`, `unique_ids` are on only when keyed. `"rule": false` turns one off.
- Grandfather entries are consumed once per hit and an unused one is a finding, so lists only shrink. The config's own `$comment`/`why` is under the `json_prose` cap.
- Two hooks: `prose-budget-commit.sh` (PreToolUse Bash, denies a `git commit` on findings, detection via `lib-shell-words.awk`) and `prose-budget-edit.sh` (PostToolUse Edit|Write|MultiEdit, findings as context, never blocks). Both fail open without jq, the engine or a config.
- Deviations from the spec, each forced by a fidelity run: `narration.scope: {name: [globs]}` restricts a pattern to some files (engine only ever applied `phase` to `.ts` headers; colregs applied `pr`/`issue`/`phase` outside `docs/`); `lines.pending` ports colregs' `lines_not_yet_created`; the `issue` builtin skips markdown anchors like `requirements.md#9-open-questions`; code files in `narration` targets are scanned by header comment plus test titles, not whole; the config file is never itself scanned for narration or voice.

## Fidelity

With the configs below, `prose-budget --tree`:

- colregs `claude/doc-budgets` (5a3d1fe): 0 findings, 95 files; 46 json_prose and 4 narration grandfathered hits, matching what `node --test test/docs.test.mjs` prints on the same tree (46 / 4).
- colregs-engine `origin/main` (0abee37): 0 findings, 67 files; 2 json_prose and 6 narration grandfathered hits, matching its config's 2 pointer entries and 6 phase ids.

Symphony's eight prose-counting cases, its section, delta and land-alone cases are ported into `prose-budget.test.py` (59 tests) alongside the false-positive scars: hyphenated identifiers, `Foster/Gleirscher` via `allow`, prose in a fence costume, tables without a leading pipe, indented and `test.skip` titles.

<details><summary>colregs docs/budgets.json (translated)</summary>

```json
{
  "$comment": "Prose budgets enforced by prose-budget (dotfiles .local/bin). Raising a number or adding an exception is a deliberate, reviewable diff.",
  "lines": {
    "README.md": 360,
    "AGENTS.md": 120,
    "CLAUDE.md": 10,
    "docs/requirements.md": 1500,
    "docs/identifiers.md": 450,
    "docs/part-b-invariants.md": 950,
    "required": true,
    "pending": [
      "docs/part-b-invariants.md"
    ]
  },
  "json_prose": {
    "targets": [
      "data/*.json",
      "fixtures/*.json"
    ],
    "keys": [
      "note",
      "gap",
      "narrative",
      "settled_by",
      "rationale",
      "why"
    ],
    "max_chars": 450,
    "grandfathered": [
      "data/applicability.json#/effects/note",
      "data/applicability.json#/known_omissions/9/why",
      "data/applicability.json#/known_omissions/10/why",
      "data/applicability.json#/known_omissions/11/why",
      "data/applicability.json#/entries/43/note",
      "data/applicability.json#/entries/44/note",
      "data/applicability.json#/entries/45/note",
      "data/applicability.json#/entries/47/note",
      "data/applicability.json#/entries/50/note",
      "data/applicability.json#/entries/51/note",
      "data/applicability.json#/entries/52/note",
      "data/applicability.json#/entries/53/note",
      "data/applicability.json#/entries/55/note",
      "data/applicability.json#/entries/56/note",
      "data/applicability.json#/entries/60/note",
      "data/applicability.json#/entries/61/note",
      "data/applicability.json#/entries/62/note",
      "data/applicability.json#/entries/63/note",
      "data/applicability.json#/entries/64/note",
      "data/applicability.json#/entries/64/gap",
      "data/applicability.json#/entries/65/note",
      "data/applicability.json#/entries/65/gap",
      "data/applicability.json#/entries/66/note",
      "data/applicability.json#/entries/67/note",
      "data/applicability.json#/entries/68/note",
      "data/applicability.json#/entries/68/gap",
      "data/applicability.json#/entries/69/note",
      "data/facts.json#/derived/note",
      "data/facts.json#/derived/fact:rule18_class/note",
      "data/facts.json#/derived/fact:rule18_class/decode/1/note",
      "data/facts.json#/derived/fact:rule18_class/decode/2/note",
      "data/facts.json#/situation/kinematics/kin:wind_side/note",
      "data/facts.json#/situation/geometry/directional/geo:rel_bearing_deg/note",
      "data/facts.json#/situation/geometry/consistency/note",
      "data/facts.json#/situation/history/hist:was_overtaking/note",
      "data/facts.json#/situation/constants/note",
      "fixtures/situation-fixtures.json#/case_status/note",
      "fixtures/situation-fixtures.json#/cases/0/narrative",
      "fixtures/situation-fixtures.json#/cases/1/narrative",
      "fixtures/situation-fixtures.json#/cases/2/narrative",
      "fixtures/situation-fixtures.json#/cases/45/narrative",
      "fixtures/situation-fixtures.json#/cases/62/narrative",
      "fixtures/situation-fixtures.json#/cases/75/narrative",
      "fixtures/situation-fixtures.json#/cases/76/narrative",
      "fixtures/situation-fixtures.json#/cases/77/narrative",
      "fixtures/situation-fixtures.json#/cases/78/narrative"
    ]
  },
  "narration": {
    "targets": [
      "README.md",
      "AGENTS.md",
      "CLAUDE.md",
      "data/*.json",
      "fixtures/*.json",
      "test/*.mjs",
      "docs/**/*.md"
    ],
    "scope": {
      "pr": [
        "README.md",
        "AGENTS.md",
        "CLAUDE.md",
        "data/*.json",
        "fixtures/*.json",
        "test/*.mjs"
      ],
      "issue": [
        "README.md",
        "AGENTS.md",
        "CLAUDE.md",
        "data/*.json",
        "fixtures/*.json",
        "test/*.mjs"
      ],
      "phase": [
        "README.md",
        "AGENTS.md",
        "CLAUDE.md",
        "data/*.json",
        "fixtures/*.json",
        "test/*.mjs"
      ],
      "split": [
        "README.md",
        "AGENTS.md",
        "CLAUDE.md",
        "data/*.json",
        "fixtures/*.json",
        "test/*.mjs"
      ]
    },
    "grandfathered": [
      {
        "file": "data/applicability.json",
        "hash": "447b3984d57b",
        "match": "PR #24"
      },
      {
        "file": "data/applicability.json",
        "hash": "5ff9d39319b8",
        "match": "PR #24"
      },
      {
        "file": "docs/conventions.md",
        "hash": "d1f1ed997431",
        "match": "the session"
      },
      {
        "file": "docs/requirements.md",
        "hash": "cdbdaf145c0a",
        "match": "seeded 2026-"
      }
    ]
  },
  "voice": {
    "scope": "tree",
    "targets": [
      "README.md",
      "AGENTS.md",
      "CLAUDE.md",
      "docs/**/*.md",
      "data/*.json",
      "fixtures/*.json"
    ]
  },
  "unique_ids": [
    {
      "file": "docs/requirements.md",
      "pattern": "\\*\\*(Q-\\d+|REQ-[A-Z]+-\\d+)\\*\\*"
    }
  ]
}
```
</details>

<details><summary>colregs-engine docs/budgets.json (translated)</summary>

```json
{
  "lines": {
    "README.md": 180,
    "AGENTS.md": 29,
    "docs/engine-notes.md": 110,
    "docs/formal-methods-glossary.md": 190,
    "docs/formal-methods-reading-list.md": 70,
    "docs/normative-language.md": 130,
    "research/conformance/README.md": 197,
    "research/z3/README.md": 89,
    "required": true,
    "must_budget": [
      "README.md",
      "AGENTS.md",
      "docs/**/*.md",
      "research/conformance/README.md",
      "research/z3/README.md"
    ]
  },
  "json_prose": {
    "targets": [
      "research/**/*.json",
      "docs/**/*.json"
    ],
    "keys": [
      "note",
      "$note",
      "notes",
      "about",
      "narrative",
      "rationale",
      "why",
      "would_settle"
    ],
    "max_chars": 300,
    "grandfathered": [
      "research/z3/expectations.json#/about",
      "research/z3/expectations.json#/queries/CONFLICT~126b-id+30a/would_settle"
    ]
  },
  "narration": {
    "targets": [
      "README.md",
      "AGENTS.md",
      "docs/**/*.md",
      "research/**/README.md",
      "research/**/*.json",
      "docs/**/*.json",
      "test/**/*.test.ts",
      "research/**/*.ts"
    ],
    "grandfathered": [
      {
        "file": "research/z3/encode.ts",
        "match": "P2.1"
      },
      {
        "file": "research/z3/encode.ts",
        "match": "P1.3"
      },
      {
        "file": "research/z3/encode.ts",
        "match": "P3.1"
      },
      {
        "file": "research/z3/queries.ts",
        "match": "P1.3"
      },
      {
        "file": "research/z3/run.ts",
        "match": "P2.1"
      },
      {
        "file": "research/z3/run.ts",
        "match": "P3.1"
      }
    ],
    "disable": [
      "issue"
    ],
    "scope": {
      "phase": [
        "research/**/*.ts"
      ]
    }
  },
  "voice": {
    "scope": "tree",
    "targets": [
      "README.md",
      "AGENTS.md",
      "docs/**/*.md",
      "research/**/README.md",
      "research/**/*.json",
      "docs/**/*.json"
    ],
    "allow": [
      "Foster/Gleirscher",
      "Foster, Gleirscher"
    ]
  },
  "headers": {
    "targets": [
      "research/**/*.ts",
      "src/**/*.ts"
    ],
    "max_lines": 25,
    "grandfathered": {
      "research/z3/encode.ts": 48,
      "research/z3/run.ts": 27
    }
  }
}
```
</details>

Not in this PR: the reusable `prose-budget.yml` workflow in `mark-brannan/.github` and the consumer migrations; those are the next two cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added prose-budget checks for documentation size, structure, wording, JSON content, and change hygiene.
  - Added automatic checks after editing supported Markdown and JSON files.
  - Added staged-content checks before commits, with findings shown and commits blocked when violations are detected.
  - Missing configuration or unavailable tooling allows work to continue without interruption.

- **Documentation**
  - Added guidance for running prose-budget checks, interpreting results, and updating configured budgets.

- **Tests**
  - Added comprehensive automated coverage for budget rules, hooks, configuration handling, and fail-open behavior.
  - Integrated these checks into continuous integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->