### PR TITLE
claude: make model+difficulty mandatory on every hand-off prompt

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -128,6 +128,9 @@ Hooks handle the mechanics unprompted.
 - **End with a prompt, not a status bullet or observation.** Work remaining
   → hand-off prompt; only-I-can-do → card by link. Nothing else in a closing
   message; `/wrapup` has the spec.
+- **Every hand-off prompt names a recommended model and difficulty (effort)
+  setting.** Not optional, not only under `/wrapup` — any prompt meant to be
+  pasted into a new session. A hand-off without both is unfinished.
 
 **A finding that reads like a real security or credential exposure never
 goes into a public repo's tracked files** — board, log, doc, commit

--- a/.claude/skills/wrapup/SKILL.md
+++ b/.claude/skills/wrapup/SKILL.md
@@ -56,7 +56,9 @@ the next one. It must:
 - be **ready to paste** — no "as discussed", no context the reader has to
   supply;
 - name the **branch, PR, file, card, etc.** it acts on;
-- name a **recommended model and difficulty (effort) setting**;
+- name a **recommended model and difficulty (effort) setting** — both,
+  every time, e.g. `Model: opus · Effort: high`. A hand-off prompt missing
+  either is not finished;
 - be written so somebody who was not in this session can act on it.
 
 Put it in the narrative log as well as the chat. The log survives; the chat


### PR DESCRIPTION
The requirement was moved into the wrapup skill in f83adf4, so it only
loaded when /wrapup was invoked. The resident 'End with a prompt' rule
still produced hand-offs outside that path, without the model/effort
line. Restore one resident line and harden the skill wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)