### PR TITLE
hooks: catch PR merge/mergify work, close card-check gap

### DIFF
--- a/.claude/hooks/pr-ownership-context.sh
+++ b/.claude/hooks/pr-ownership-context.sh
@@ -16,6 +16,11 @@
 #
 # Fires once per session, on the first matching call:
 #   - Bash: `gh pr ...`, or `gh api ...` naming pulls / graphql / reviewThreads
+#   - Bash: `mergify stack push/checkout/sync`, `mergify queue ...`, or
+#     `mergify merge ...` -- the mergify CLI plugin creates and merges PRs
+#     without ever calling gh, so a session working a PR only through it used
+#     to leave the record empty and the Stop gate silently found nothing.
+#     2026-09-08.
 #   - MCP:  any GitHub tool whose name mentions a pull request or a review
 # The section is read live from code.md, so there is one source of truth and
 # nothing here to keep in sync. If the file or the heading is missing, say so
@@ -41,7 +46,7 @@ case "$tool" in
   Bash)
     cmd=$(printf '%s' "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null) || exit 0
     printf '%s' "$cmd" | grep -Eq \
-      '(^|[^A-Za-z0-9_./-])gh[[:space:]]+(pr([[:space:]]|$)|api[[:space:]].*(pulls|graphql|reviewThreads))' \
+      '(^|[^A-Za-z0-9_./-])gh[[:space:]]+(pr([[:space:]]|$)|api[[:space:]].*(pulls|graphql|reviewThreads))|(^|[^A-Za-z0-9_./-])mergify[[:space:]]+(stack[[:space:]]+(push|checkout|sync)([[:space:]]|$)|(queue|merge)([[:space:]]|$))' \
       || exit 0
     ;;
   mcp__*github*__*)
@@ -61,14 +66,20 @@ if [ -n "$sid" ]; then
   record="${TMPDIR:-/tmp}/claude-pr-threads.$tag"
   case "$tool" in
     Bash)
-      repo=$(printf '%s' "$cmd" | grep -Eo -- '(^|[[:space:]])(-R|--repo)[[:space:]=]+[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+' | head -1 | sed 's/.*[[:space:]=]//')
-      num=$(printf '%s' "$cmd" | grep -Eo 'gh[[:space:]]+pr[[:space:]]+[a-z-]+[[:space:]]+[0-9]+' | head -1 | grep -Eo '[0-9]+$')
-      [ -z "$num" ] && num=$(printf '%s' "$cmd" | grep -Eo 'pulls/[0-9]+' | head -1 | grep -Eo '[0-9]+$')
-      [ -z "$num" ] && num=$(printf '%s' "$cmd" | grep -Eo 'pull/[0-9]+' | head -1 | grep -Eo '[0-9]+$')
-      [ -z "$repo" ] && repo=$(printf '%s' "$cmd" | grep -Eo '(repos|github\.com)/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pulls?/' | head -1 | sed 's#^[^/]*/##; s#/pulls\?/$##; s#/pull/$##')
       cwd=$(printf '%s' "$payload" | jq -r '.cwd // empty' 2>/dev/null)
-      if [ -n "$repo" ] && [ -n "$num" ]; then printf 'repo\t%s\t%s\n' "$repo" "$num" >> "$record" 2>/dev/null || :
-      elif [ -n "$cwd" ]; then printf 'cwd\t%s\n' "$cwd" >> "$record" 2>/dev/null || :
+      if printf '%s' "$cmd" | grep -Eq '(^|[^A-Za-z0-9_./-])mergify[[:space:]]'; then
+        # mergify never names owner/repo/number on the command line -- it
+        # infers the PR from the current branch, so cwd is the only handle.
+        [ -n "$cwd" ] && printf 'cwd\t%s\n' "$cwd" >> "$record" 2>/dev/null
+      else
+        repo=$(printf '%s' "$cmd" | grep -Eo -- '(^|[[:space:]])(-R|--repo)[[:space:]=]+[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+' | head -1 | sed 's/.*[[:space:]=]//')
+        num=$(printf '%s' "$cmd" | grep -Eo 'gh[[:space:]]+pr[[:space:]]+[a-z-]+[[:space:]]+[0-9]+' | head -1 | grep -Eo '[0-9]+$')
+        [ -z "$num" ] && num=$(printf '%s' "$cmd" | grep -Eo 'pulls/[0-9]+' | head -1 | grep -Eo '[0-9]+$')
+        [ -z "$num" ] && num=$(printf '%s' "$cmd" | grep -Eo 'pull/[0-9]+' | head -1 | grep -Eo '[0-9]+$')
+        [ -z "$repo" ] && repo=$(printf '%s' "$cmd" | grep -Eo '(repos|github\.com)/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pulls?/' | head -1 | sed 's#^[^/]*/##; s#/pulls\?/$##; s#/pull/$##')
+        if [ -n "$repo" ] && [ -n "$num" ]; then printf 'repo\t%s\t%s\n' "$repo" "$num" >> "$record" 2>/dev/null || :
+        elif [ -n "$cwd" ]; then printf 'cwd\t%s\n' "$cwd" >> "$record" 2>/dev/null || :
+        fi
       fi
       ;;
     *)

--- a/.claude/hooks/pr-ownership-context.sh
+++ b/.claude/hooks/pr-ownership-context.sh
@@ -45,8 +45,12 @@ tool=$(printf '%s' "$payload" | jq -r '.tool_name // empty' 2>/dev/null) || exit
 case "$tool" in
   Bash)
     cmd=$(printf '%s' "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null) || exit 0
+    # The mergify half is restricted to a real command position (start of
+    # string, or after a separator: ; & | ( or a backtick) so "echo mergify
+    # merge" or "true # mergify merge" -- mergify named but not run -- don't
+    # falsely record a cwd and trip the Stop gate on an unrelated PR.
     printf '%s' "$cmd" | grep -Eq \
-      '(^|[^A-Za-z0-9_./-])gh[[:space:]]+(pr([[:space:]]|$)|api[[:space:]].*(pulls|graphql|reviewThreads))|(^|[^A-Za-z0-9_./-])mergify[[:space:]]+(stack[[:space:]]+(push|checkout|sync)([[:space:]]|$)|(queue|merge)([[:space:]]|$))' \
+      '(^|[^A-Za-z0-9_./-])gh[[:space:]]+(pr([[:space:]]|$)|api[[:space:]].*(pulls|graphql|reviewThreads))|(^|[;&|(`])[[:space:]]*mergify[[:space:]]+(stack[[:space:]]+(push|checkout|sync)([[:space:]]|$)|(queue|merge)([[:space:]]|$))' \
       || exit 0
     ;;
   mcp__*github*__*)
@@ -67,10 +71,12 @@ if [ -n "$sid" ]; then
   case "$tool" in
     Bash)
       cwd=$(printf '%s' "$payload" | jq -r '.cwd // empty' 2>/dev/null)
-      if printf '%s' "$cmd" | grep -Eq '(^|[^A-Za-z0-9_./-])mergify[[:space:]]'; then
+      if printf '%s' "$cmd" | grep -Eq '(^|[;&|(`])[[:space:]]*mergify[[:space:]]'; then
         # mergify never names owner/repo/number on the command line -- it
         # infers the PR from the current branch, so cwd is the only handle.
-        [ -n "$cwd" ] && printf 'cwd\t%s\n' "$cwd" >> "$record" 2>/dev/null
+        # Best-effort like the record writes below: a full disk or a race on
+        # the tmp file must not fail the mergify command that triggered this.
+        [ -n "$cwd" ] && { printf 'cwd\t%s\n' "$cwd" >> "$record" 2>/dev/null || :; }
       else
         repo=$(printf '%s' "$cmd" | grep -Eo -- '(^|[[:space:]])(-R|--repo)[[:space:]=]+[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+' | head -1 | sed 's/.*[[:space:]=]//')
         num=$(printf '%s' "$cmd" | grep -Eo 'gh[[:space:]]+pr[[:space:]]+[a-z-]+[[:space:]]+[0-9]+' | head -1 | grep -Eo '[0-9]+$')

--- a/.claude/hooks/pr-ownership-context.test.sh
+++ b/.claude/hooks/pr-ownership-context.test.sh
@@ -86,6 +86,11 @@ check inject 'gh api pulls'     "$(bash_input s3 'gh api repos/o/r/pulls/4/comme
 check inject 'gh pr after &&'   "$(bash_input s4 'git push && gh pr checks --watch')"
 check inject 'MCP pull_request_read'  "$(mcp_input s5 mcp__plugin_github_github__pull_request_read)"
 check inject 'MCP review tool'        "$(mcp_input s6 mcp__github__create_pending_pull_request_review)"
+check inject 'mergify stack push'     "$(bash_input s5a 'mergify stack push')"
+check inject 'mergify stack checkout' "$(bash_input s5b 'mergify stack checkout NAME')"
+check inject 'mergify stack sync'     "$(bash_input s5c 'mergify stack sync')"
+check inject 'mergify queue add'      "$(bash_input s5d 'mergify queue add')"
+check inject 'mergify merge'          "$(bash_input s5e 'mergify merge 12')"
 
 # --- stays silent ------------------------------------------------------------
 check silent 'gh issue'              "$(bash_input s7 'gh issue view 3')"
@@ -96,6 +101,16 @@ check silent 'MCP non-PR github'     "$(mcp_input s7 mcp__github__search_reposit
 check silent 'MCP other server'      "$(mcp_input s7 mcp__Trello__pull_request_read)"
 check silent 'other tool'            "$(jq -n '{session_id:"s7",tool_name:"Read",tool_input:{file_path:"gh pr"}}')"
 check silent 'empty payload'         ''
+check silent 'mergify config command' "$(bash_input s7 'mergify config validate')"
+check silent 'mergify events command' "$(bash_input s7 'mergify events list')"
+check silent 'word containing mergify' "$(bash_input s7 'echo unmergifyable')"
+
+# --- mergify records cwd, not repo/number (it never names them) -----------
+bash_input_cwd() { jq -n --arg s "$1" --arg c "$2" --arg w "$3" '{session_id:$s,tool_name:"Bash",tool_input:{command:$c},cwd:$w}'; }
+check inject 'mergify stack push (cwd)' "$(bash_input_cwd s5f 'mergify stack push' /repo/checkout)"
+RECORD="$TMPDIR/claude-pr-threads.s5f"
+if [ -f "$RECORD" ] && grep -qx "cwd	/repo/checkout" "$RECORD"; then pass=$((pass + 1))
+else fail=$((fail + 1)); printf 'FAIL: mergify call did not record cwd (record: %s)\n' "$(cat "$RECORD" 2>/dev/null || echo MISSING)"; fi
 
 # --- once per session ----------------------------------------------------------
 check inject 'first PR call in s8'   "$(bash_input s8 'gh pr view')"

--- a/.claude/hooks/pr-ownership-context.test.sh
+++ b/.claude/hooks/pr-ownership-context.test.sh
@@ -104,6 +104,10 @@ check silent 'empty payload'         ''
 check silent 'mergify config command' "$(bash_input s7 'mergify config validate')"
 check silent 'mergify events command' "$(bash_input s7 'mergify events list')"
 check silent 'word containing mergify' "$(bash_input s7 'echo unmergifyable')"
+check silent 'mergify named, not run (echo)'    "$(bash_input s7 'echo mergify merge')"
+check silent 'mergify named, not run (comment)' "$(bash_input s7 'true # mergify merge')"
+check inject 'mergify after &&'   "$(bash_input s7b 'git push && mergify stack push')"
+check inject 'mergify after pipe' "$(bash_input s7c 'echo x | mergify queue add')"
 
 # --- mergify records cwd, not repo/number (it never names them) -----------
 bash_input_cwd() { jq -n --arg s "$1" --arg c "$2" --arg w "$3" '{session_id:$s,tool_name:"Bash",tool_input:{command:$c},cwd:$w}'; }

--- a/.claude/skills/wrapup/SKILL.md
+++ b/.claude/skills/wrapup/SKILL.md
@@ -46,6 +46,18 @@ decisions to the board before the session ends. Anything only Mark can do
 personally is a card, referenced by link and by a short name; either the
 link or the short name must be distinctive enough for a future session to
 find it.
+
+**Before surfacing any card that asks Mark to decide on or act on a PR
+(merge it, review it, close it), check its live state first** —
+`gh pr view <PR> --json state,mergedAt,mergeCommit` (or the equivalent for
+the board's existing PR cards, not just ones from this session). If it's
+already merged or closed, don't hand it to him as a decision: mark it done
+and note how, or drop it if it was already reflected on the board. This
+applies to every open PR card being carried forward, not only ones this
+session touched — a PR can merge after the session that filed the card
+ended. A card that asks him to decide something already decided outside
+the chat is wasted attention.
+
 Board selection and card format: `/card-write`.
 
 ## 4. Hand-off prompt

--- a/.claude/skills/wrapup/SKILL.md
+++ b/.claude/skills/wrapup/SKILL.md
@@ -52,7 +52,12 @@ find it.
 `gh pr view <PR> --json state,mergedAt,mergeCommit` (or the equivalent for
 the board's existing PR cards, not just ones from this session). If it's
 already merged or closed, don't hand it to him as a decision: mark it done
-and note how, or drop it if it was already reflected on the board. This
+and note how, or drop it if it was already reflected on the board. If the
+check itself fails — `gh` errors, isn't authenticated, or the reply carries
+no `state` — that's not the same as "still open": leave the card pending
+and say its live state couldn't be verified, the same failure-closed stance
+`pr-threads-gate.sh` already takes. Only mark done or drop after a state
+check actually succeeds. This
 applies to every open PR card being carried forward, not only ones this
 session touched — a PR can merge after the session that filed the card
 ended. A card that asks him to decide something already decided outside


### PR DESCRIPTION
## What

- `wrapup` skill: before surfacing a card asking Mark to decide on or act on a PR, check the PR's live state (`gh pr view --json state,mergedAt,mergeCommit`) first. Several recent wrap-ups handed him a "make a call on merging this" card for a PR that was already merged by the time the session ended — GitHub's own state should settle that before it becomes a decision for him.
- `pr-ownership-context.sh` / `pr-threads-gate.sh`: the review-threads-must-be-resolved gate only re-checks PRs that `pr-ownership-context.sh` recorded, and that hook's Bash trigger only matched `gh pr ...` / `gh api ...pulls|graphql`. The `mergify` CLI plugin (mergify-stack, mergify-merge-queue skills) creates and merges PRs without ever calling `gh`, so a session working a PR only through it left the record empty — the Stop gate then found nothing to check, indistinguishable from a PR with no open threads.

## Why

Confirmed by reading the mergify-stack skill: `mergify stack push/checkout/sync` and `mergify queue`/`mergify merge` create and merge PRs entirely through the `mergify` binary. None of that matches the existing `gh`-only regex, so the ownership-context hook never fired and the thread-resolution gate had an empty record to check against.

## Fix

Widen the Bash trigger in `pr-ownership-context.sh` to also match `mergify stack push|checkout|sync` and `mergify queue|merge`. `mergify` never names owner/repo/number on the command line (it infers the PR from the current branch), so these always record a `cwd` line — the existing `gh pr view`-based cwd resolution in `pr-threads-gate.sh` picks the PR up from there, same as it already does for bare `gh pr` calls without `--repo`.

## Testing

`bash .claude/hooks/pr-ownership-context.test.sh` — 41/41 pass, including new cases for each mergify subcommand (fires on stack push/checkout/sync and queue/merge, stays silent on `mergify config`/`mergify events`, and verifies the recorded line is `cwd\t<path>` rather than a repo/number pair).

No `cloud-session-setup.sh` change needed — this only broadens matching inside an already-installed hook, no new hook added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - PR ownership context now recognizes Mergify stack, queue, and merge commands.
  - Mergify activity records the working directory when repository and PR details are unavailable.

- **Bug Fixes**
  - Wrap-up workflows now verify each PR’s current state before presenting pending actions.
  - Merged or closed PRs are marked complete or removed from pending decisions.

- **Tests**
  - Added coverage for supported Mergify commands, unrelated commands, matching substrings, and working-directory handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->