### PR TITLE
feat(board): one home per fact — live worklist, kanban lint, public-issue guard

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -127,7 +127,9 @@ Hooks handle the mechanics unprompted.
 ## Open loops
 
 - **Write the issue or card when the loop is found, never at wrap-up** — by
-  then the evidence is compacted away. Routing and format: `/card-write`.
+  then the evidence is compacted away — and only if you would pull it
+  yourself. "Verify X later" is not a loop: verify it now or drop it.
+  Routing and format: `/card-write`.
 - **One home per fact.** GitHub owns work state; the board holds only agent
   loops with no GitHub home; a sweep is `worklist`, never an edit.
 - **A unilateral call** — deleting someone's work, cutting scope, reversing

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -135,9 +135,9 @@ Hooks handle the mechanics unprompted.
   afterward doesn't substitute.
 - A loop not worth a card is not worth telling me about.
 - **End with a prompt, not a status bullet or observation.** Work remaining
-  → hand-off prompt; only-I-can-do → the PR or issue, by link; a card only
-  when the loop has no GitHub home. Nothing else in a closing message;
-  `/wrapup` has the spec.
+  → hand-off prompt; a question → a `## Needs ruling` card, and the default
+  is to work around it: decide, record the assumption where the work lands,
+  carry on. Nothing else in a closing message; `/wrapup` has the spec.
 - **Every hand-off prompt names a recommended model and difficulty (effort)
   setting.** Not optional, not only under `/wrapup` — any prompt meant to be
   pasted into a new session. A hand-off without both is unfinished.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -118,7 +118,7 @@ Hooks handle the mechanics unprompted.
 - **Capture ≠ activation.** Off-goal but real → card at discovery; trivial
   → drop; important and urgent → suggest a parallel session or subagent.
   Never a new workstream mid-session.
-- **New sessions open by pulling from a board.** WIP limit ~2–3.
+- **New sessions open from `worklist`.** WIP limit ~2–3.
 - **Ask early or not at all.** Front-load questions; inline only when the
   answer blocks the task; card the rest for batch review at wrap-up. Work
   unblocked and around obstacles; the one exception is a one-way door — an
@@ -126,15 +126,18 @@ Hooks handle the mechanics unprompted.
 
 ## Open loops
 
-- **Write the card when the loop is found, never at wrap-up** — by then the
-  evidence is compacted away. Board and format: `/card-write`.
+- **Write the issue or card when the loop is found, never at wrap-up** — by
+  then the evidence is compacted away. Routing and format: `/card-write`.
+- **One home per fact.** GitHub owns work state; the board holds only agent
+  loops with no GitHub home; a sweep is `worklist`, never an edit.
 - **A unilateral call** — deleting someone's work, cutting scope, reversing
   a prior decision — **gets a card the moment it's made.** A PR comment
   afterward doesn't substitute.
 - A loop not worth a card is not worth telling me about.
 - **End with a prompt, not a status bullet or observation.** Work remaining
-  → hand-off prompt; only-I-can-do → card by link. Nothing else in a closing
-  message; `/wrapup` has the spec.
+  → hand-off prompt; only-I-can-do → the PR or issue, by link; a card only
+  when the loop has no GitHub home. Nothing else in a closing message;
+  `/wrapup` has the spec.
 - **Every hand-off prompt names a recommended model and difficulty (effort)
   setting.** Not optional, not only under `/wrapup` — any prompt meant to be
   pasted into a new session. A hand-off without both is unfinished.

--- a/.claude/hooks/kanban-gate.sh
+++ b/.claude/hooks/kanban-gate.sh
@@ -56,6 +56,6 @@ case $rc in
   1) block "kanban-gate: this turn cannot end yet. The uncommitted changes to $SR/$board break the board contract -- line number in the working copy, rule, and where that fact lives instead:
 $out
 
-Fix or delete each line named, then end the turn again; this gate fires once per turn. The board holds only agent rabbit-trails under ## Claude's; /card-write has the routing table for everything else. stop-continuity.sh will not commit the board while this lint fails." ;;
+Fix or delete each line named, then end the turn again; this gate fires once per turn. The board holds a question only the user can settle under ## Needs ruling, and agent rabbit-trails under ## Claude's; /card-write has the routing table for everything else. stop-continuity.sh will not commit the board while this lint fails." ;;
   *) block "kanban-gate: $SR/$board has uncommitted changes that could not be linted ($out). This gate fails closed: make the board lintable, or revert it (git -C $SR checkout -- $board), then end the turn again." ;;
 esac

--- a/.claude/hooks/kanban-gate.sh
+++ b/.claude/hooks/kanban-gate.sh
@@ -25,14 +25,7 @@ HERE=$(cd "$(dirname "$0")" && pwd)
 # shellcheck source=lib-state.sh
 . "$HERE/lib-state.sh"
 
-json_str() {
-  if command -v jq >/dev/null 2>&1; then
-    printf '%s' "$1" | jq -Rs .
-  else
-    printf '"%s"\n' "$(printf '%s' "$1" | tr '\t' ' ' | sed 's/\\/\\\\/g; s/"/\\"/g' | awk '{ if (NR > 1) printf "\\n"; printf "%s", $0 }')"
-  fi
-}
-block() { printf '{"decision":"block","reason":%s}\n' "$(json_str "$1")"; exit 0; }
+# json_str() and block() come from lib-state.sh, sourced above.
 
 payload=$(cat) || exit 0
 if command -v jq >/dev/null 2>&1; then

--- a/.claude/hooks/kanban-gate.sh
+++ b/.claude/hooks/kanban-gate.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+# Blocks the end of a turn while the state repo's kanban.md carries an
+# uncommitted change that breaks the board contract.
+#
+# Why: kanban-lint.sh already runs on every Edit/Write of a board, but a
+# board can also change through a Bash heredoc, a sed, or a script, and
+# stop-continuity.sh commits and pushes the state repo at every Stop. A bad
+# card written at 23:59 is in git history by 00:00 with nobody having read
+# it. So, in the pr-threads-gate.sh pattern, the turn is not allowed to end
+# until the added lines pass the lint -- the same lint, --diff mode, so only
+# what this session wrote is judged and history on the board is left alone.
+#
+# Blocks at most once per turn: the harness sets stop_hook_active on the
+# retry, and a second block would only loop.
+#
+# GATE: no state repo here means nothing to gate (exit 0 -- a cloud session
+# without the private clone is reported at SessionStart, not here). But a
+# dirty board that cannot be linted -- kanban-lint.sh missing, awk gone,
+# the lint itself failing -- blocks and says so. A gate that goes quiet
+# when it cannot look is indistinguishable from one that looked and found
+# nothing.
+set -u
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=lib-state.sh
+. "$HERE/lib-state.sh"
+
+json_str() {
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$1" | jq -Rs .
+  else
+    printf '"%s"\n' "$(printf '%s' "$1" | tr '\t' ' ' | sed 's/\\/\\\\/g; s/"/\\"/g' | awk '{ if (NR > 1) printf "\\n"; printf "%s", $0 }')"
+  fi
+}
+block() { printf '{"decision":"block","reason":%s}\n' "$(json_str "$1")"; exit 0; }
+
+payload=$(cat) || exit 0
+if command -v jq >/dev/null 2>&1; then
+  active=$(printf '%s' "$payload" | jq -r '.stop_hook_active // false' 2>/dev/null)
+else
+  active=false
+  printf '%s' "$payload" | grep -q '"stop_hook_active"[[:space:]]*:[[:space:]]*true' && active=true
+fi
+[ "$active" = true ] && exit 0
+
+SR=$(state_repo) || exit 0
+board=state/global/kanban.md
+[ -n "$(git -C "$SR" status --porcelain -- "$board" 2>/dev/null)" ] || exit 0
+
+LINT="$HERE/kanban-lint.sh"
+[ -f "$LINT" ] || block "kanban-gate: $SR/$board has uncommitted changes and kanban-lint.sh is missing from $HERE, so they could not be linted. This gate fails closed: restore the hook, or revert the board (git -C $SR checkout -- $board), then end the turn again."
+
+out=$(sh "$LINT" --diff "$SR" "$board" 2>&1); rc=$?
+case $rc in
+  0) exit 0 ;;
+  1) block "kanban-gate: this turn cannot end yet. The uncommitted changes to $SR/$board break the board contract -- line number in the working copy, rule, and where that fact lives instead:
+$out
+
+Fix or delete each line named, then end the turn again; this gate fires once per turn. The board holds only agent rabbit-trails under ## Claude's; /card-write has the routing table for everything else. stop-continuity.sh will not commit the board while this lint fails." ;;
+  *) block "kanban-gate: $SR/$board has uncommitted changes that could not be linted ($out). This gate fails closed: make the board lintable, or revert it (git -C $SR checkout -- $board), then end the turn again." ;;
+esac

--- a/.claude/hooks/kanban-gate.test.sh
+++ b/.claude/hooks/kanban-gate.test.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Tests for kanban-gate.sh. Run: bash .claude/hooks/kanban-gate.test.sh
+# Set AWK_PATH to a directory whose `awk` is another implementation to run
+# the same cases under it; CI does this for each.
+#
+# What matters: silent on the retry (stop_hook_active), silent with no state
+# repo, silent when the board is committed or its added lines are clean;
+# blocks with the lint's lines when they are not; and blocks -- never goes
+# quiet -- when a dirty board cannot be linted.
+set -uo pipefail
+[ -n "${AWK_PATH:-}" ] && PATH="$AWK_PATH:$PATH"
+
+HOOKS="$(cd "$(dirname "$0")" && pwd)"
+GATE="$HOOKS/kanban-gate.sh"
+pass=0; fail=0
+SCRATCH=$(mktemp -d); trap 'rm -rf "$SCRATCH"' EXIT
+export HOME="$SCRATCH/home"; mkdir -p "$HOME"
+export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1
+
+gitq() { git -C "$1" -c user.name=t -c user.email=t@example.invalid -c commit.gpgsign=false "${@:2}" >/dev/null 2>&1; }
+SR="$SCRATCH/claude_prompts_scratch"; mkdir -p "$SR/state/global"; gitq "$SR" init -q
+BOARD="$SR/state/global/kanban.md"
+cat > "$BOARD" <<'EOF'
+# Open loops
+
+## Solace's
+- [x] **Merge [o/r#29](https://github.com/o/r/pull/29)** — CI green
+
+## Claude's
+- [ ] **Old card** — history ([log](log/old.md))
+EOF
+gitq "$SR" add -- state/global/kanban.md; gitq "$SR" commit -q -m board
+export CLAUDE_STATE_REPO="$SR"
+
+stop_input() { jq -n --argjson a "${1:-false}" '{session_id:"s1",stop_hook_active:$a,cwd:"/x",transcript_path:"/x/t.jsonl"}'; }
+# check <block|silent> <desc> <json> [gate path]
+check() {
+  local want=$1 desc=$2 json=$3 gate=${4:-$GATE} got
+  LAST=$(printf '%s' "$json" | sh "$gate" 2>&1)
+  if [ -z "$LAST" ]; then got=silent
+  elif [ "$(printf '%s' "$LAST" | jq -r '.decision' 2>/dev/null)" = block ]; then got=block
+  else got=invalid; fi
+  if [ "$got" = "$want" ]; then pass=$((pass+1)); else fail=$((fail+1)); printf 'FAIL (want %s, got %s): %s\n  %s\n' "$want" "$got" "$desc" "$LAST"; fi
+}
+reason()    { if printf '%s' "$LAST" | jq -r '.reason' | grep -Eq -- "$2"; then pass=$((pass+1)); else fail=$((fail+1)); printf 'FAIL (reason lacks /%s/): %s\n  %s\n' "$2" "$1" "$LAST"; fi; }
+no_reason() { if printf '%s' "$LAST" | jq -r '.reason' | grep -Eq -- "$2"; then fail=$((fail+1)); printf 'FAIL (reason has /%s/): %s\n' "$2" "$1"; else pass=$((pass+1)); fi; }
+
+# --- nothing to gate -----------------------------------------------------------
+check silent 'committed board, clean tree'   "$(stop_input)"
+check silent 'empty payload'                 ''
+CLAUDE_STATE_REPO="$SCRATCH/nowhere" check silent 'no state repo' "$(stop_input)"
+
+# --- dirty board ---------------------------------------------------------------
+printf -- '- [ ] **New card** — awaiting review ([o/r#50](https://github.com/o/r/pull/50))\n- [x] ticked ([log](log/x.md))\n' >> "$BOARD"
+check silent 'retry with stop_hook_active'  "$(stop_input true)"
+check block  'bad added lines block'         "$(stop_input)"
+reason 'names the board'                     'state/global/kanban.md'
+reason 'carries L5 with its line'            '^8: L5 state word "awaiting"'
+reason 'carries L1 with its line'            '^9: L1 '
+no_reason 'history in HEAD is not relitigated' '^4: '
+reason 'says fix or delete'                  'Fix or delete each line'
+reason 'says it fires once'                  'once per turn'
+
+gitq "$SR" checkout -- state/global/kanban.md
+printf -- '- [ ] **Fine card** — a plain agent loop ([log](log/fine.md))\n' >> "$BOARD"
+check silent 'clean added lines pass'        "$(stop_input)"
+
+# A board never committed (fresh state repo) is linted whole.
+SR2="$SCRATCH/sr2"; mkdir -p "$SR2/state/global"; gitq "$SR2" init -q
+: > "$SR2/README.md"; gitq "$SR2" add -- README.md; gitq "$SR2" commit -q -m init
+printf '## Claude'"'"'s\n- [x] ticked ([log](log/x.md))\n- [ ] fine ([log](log/y.md))\n' > "$SR2/state/global/kanban.md"
+CLAUDE_STATE_REPO="$SR2" check block 'untracked board is linted whole' "$(stop_input)"
+reason 'the ticked line counts'              '^2: L1 '
+gitq "$SR" checkout -- state/global/kanban.md
+check silent 'restored -> clean'             "$(stop_input)"
+
+# --- cannot lint is loud -----------------------------------------------------
+printf -- '- [ ] **Another** ([log](log/a.md))\n' >> "$BOARD"
+ALT="$SCRATCH/hooks"; mkdir -p "$ALT"; cp "$GATE" "$HOOKS/lib-state.sh" "$ALT/"
+check block 'kanban-lint.sh missing -> block' "$(stop_input)" "$ALT/kanban-gate.sh"
+reason 'says the board could not be linted'  'could not be linted'
+reason 'fails closed'                        'fails closed'
+gitq "$SR" checkout -- state/global/kanban.md
+check silent 'lint missing but board clean -> silent' "$(stop_input)" "$ALT/kanban-gate.sh"
+
+# No jq: stop_hook_active is still honoured, a dirty board still blocks with valid JSON.
+printf -- '- [x] ticked ([log](log/x.md))\n' >> "$BOARD"
+mkdir -p "$SCRATCH/nojq"; for b in sh awk sed grep sort head tr cat dirname basename printf git; do p=$(command -v $b) && ln -s "$p" "$SCRATCH/nojq/$b"; done
+LAST=$(stop_input true | PATH="$SCRATCH/nojq" /bin/sh "$GATE" 2>&1)
+if [ -z "$LAST" ]; then pass=$((pass+1)); else fail=$((fail+1)); echo "FAIL: no jq + stop_hook_active should be silent: $LAST"; fi
+LAST=$(stop_input | PATH="$SCRATCH/nojq" /bin/sh "$GATE" 2>&1)
+if [ "$(printf '%s' "$LAST" | jq -r .decision 2>/dev/null)" = block ]; then pass=$((pass+1)); else fail=$((fail+1)); echo "FAIL: no jq + dirty board should block: $LAST"; fi
+reason 'no jq: the lint line survives the escaper' '^8: L1 '
+gitq "$SR" checkout -- state/global/kanban.md
+
+printf '%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/.claude/hooks/kanban-lint.sh
+++ b/.claude/hooks/kanban-lint.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 # Lints a kanban.md board (or an epic file's Status lines) against the board
-# contract: the board is the agent's private pull queue, one section, cards
-# that carry a link and no state.
+# contract: the board is the agent's pull queue in two sections -- ## Needs
+# ruling for a question only the user can settle, ## Claude's for agent
+# rabbit-trails -- with cards that carry a link and no state.
 #
 # Why: measured on 2026-09-08, the global board held 128 cards, 28 of them
 # ticked and never deleted, 63 restating the state of a PR or issue that
@@ -16,12 +17,14 @@
 # Rules, each printed by id so the reason can be looked up:
 #   L1  a "- [x]" line                  -- delete, never tick
 #   L2  a bullet above the first "## "  -- cards live under a heading
-#   L3  a heading other than ## Claude's, when it is not already in HEAD
+#   L3  a heading other than ## Needs ruling or ## Claude's, when it is
+#       not already in HEAD
 #   L4  a card whose action verb is the user's (review, merge, land, bump,
 #       close, approve, ship, ratify, rule on, decide, confirm, answer,
 #       watch) AND that links a /pull/N or /issues/N -- the user's turn is
 #       derived from the PR, never written down. Verb-keyed on purpose: a
-#       card citing a merged PR as provenance is fine.
+#       card citing a merged PR as provenance is fine. Not applied under
+#       ## Needs ruling, where "decide X on PR N" is exactly the card's job.
 #   L5  a state word (merged, awaiting, not merged, CI green, open as) --
 #       only on ADDED lines (--diff) or Status lines (--epic); bare "green"
 #       and "red" are not matched ("Red Sea", "green light");
@@ -68,6 +71,8 @@ run_lint() {
       n = split(ENVIRON["KL_HEADS"], a, "\n")
       for (i = 1; i <= n; i++) if (a[i] != "") heads[a[i]] = 1
       claudes = "## Claude\047s"
+      ruling = "## Needs ruling"
+      cursec = ""
       nv = split("review merge land bump close approve ship ratify rule_on decide confirm answer watch", verbs, " ")
       for (i = 1; i <= nv; i++) gsub(/_/, " ", verbs[i])
       ns = split("not merged|ci green|open as|merged|awaiting", states, "|")
@@ -115,8 +120,8 @@ run_lint() {
           verb = verb_at(t2)
         }
       }
-      if (verb != "" && text ~ /github\.com\/[^ )]*\/(pull|issues)\/[0-9]/)
-        report(cstart, "L4", "\"" verb "\" + a PR/issue link is the user\047s turn, which worklist derives from the PR/issue itself -- a question is an issue labelled needs-ruling, an action only the user can do is an issue assigned to the user; delete the card")
+      if (verb != "" && cursec != ruling && text ~ /github\.com\/[^ )]*\/(pull|issues)\/[0-9]/)
+        report(cstart, "L4", "\"" verb "\" + a PR/issue link is the user\047s turn, which worklist derives from the PR/issue itself -- the default is to work around it -- decide, record the assumption where the work lands, and carry on; only a one-way door earns a card, under " ruling ". Otherwise delete the card")
     }
     function flush() {
       if (cstart && touched && mode != "epic") check_card()
@@ -125,11 +130,12 @@ run_lint() {
     /^## / {
       flush(); h = trim($0); seenhead = 1
       if (mode == "epic") { instatus = (h == "## Status"); next }
-      if (added(NR) && h != claudes && l3 == "enforce" && !(h in heads))
-        report(NR, "L3", "new heading \"" h "\" -- the board has one section, " claudes "; a loop only the user can close is an issue assigned to the user (public repo when it passes the private-terms check, else claude_prompts_scratch); deferred work is an issue on milestone 1.0")
+      if (added(NR) && h != claudes && h != ruling && l3 == "enforce" && !(h in heads))
+        report(NR, "L3", "new heading \"" h "\" -- the board has two sections, " ruling " and " claudes "; real work with an owner and a next action is an issue (public repo when it passes the private-terms check, else claude_prompts_scratch); deferred work is an issue on milestone 1.0")
+      cursec = h
       next
     }
-    /^#/ { flush(); next }
+    /^#/ { flush(); cursec = ""; next }
     mode == "epic" && !instatus { next }
     /^[ \t]*$/ { flush(); next }
     /^(- |[0-9]+\. )/ {
@@ -229,7 +235,7 @@ hook_mode() {
     1) block "kanban-lint: $fp breaks the board contract. Each line below is a line number in the file, the rule it broke, and where that fact lives instead:
 $out
 
-Fix or delete each line named, then carry on. The board holds only agent rabbit-trails under ## Claude's; /card-write has the routing table for everything else." ;;
+Fix or delete each line named, then carry on. The board holds a question only the user can settle under ## Needs ruling, and agent rabbit-trails under ## Claude's; /card-write has the routing table for everything else." ;;
     *) block "kanban-lint: $fp could not be linted ($out). This check fails closed: make the file lintable (or revert the edit) before carrying on." ;;
   esac
 }

--- a/.claude/hooks/kanban-lint.sh
+++ b/.claude/hooks/kanban-lint.sh
@@ -18,7 +18,8 @@
 #   L1  a "- [x]" line                  -- delete, never tick
 #   L2  a bullet above the first "## "  -- cards live under a heading
 #   L3  a heading other than ## Needs ruling or ## Claude's, when it is
-#       not already in HEAD
+#       not already in HEAD -- including a "### " group heading anywhere
+#       but inside ## Needs ruling, where the groups live
 #   L4  a card whose action verb is the user's (review, merge, land, bump,
 #       close, approve, ship, ratify, rule on, decide, confirm, answer,
 #       watch) AND that links a /pull/N or /issues/N -- the user's turn is
@@ -30,6 +31,9 @@
 #       and "red" are not matched ("Red Sea", "green light");
 #       history already on the board is not relitigated
 #   L6  a card with no link at all (http, or a relative log/ link)
+#   L7  a card under ## Needs ruling with no "### <project>" group heading
+#       above it -- rulings are grouped by the project that owns them, so
+#       a session in one repo can see its own without reading the rest
 #
 # Modes:
 #   --file <path>             whole file; L3 only for headings absent from
@@ -72,7 +76,7 @@ run_lint() {
       for (i = 1; i <= n; i++) if (a[i] != "") heads[a[i]] = 1
       claudes = "## Claude\047s"
       ruling = "## Needs ruling"
-      cursec = ""
+      cursec = ""; curgroup = ""
       nv = split("review merge land bump close approve ship ratify rule_on decide confirm answer watch", verbs, " ")
       for (i = 1; i <= nv; i++) gsub(/_/, " ", verbs[i])
       ns = split("not merged|ci green|open as|merged|awaiting", states, "|")
@@ -132,10 +136,19 @@ run_lint() {
       if (mode == "epic") { instatus = (h == "## Status"); next }
       if (added(NR) && h != claudes && h != ruling && l3 == "enforce" && !(h in heads))
         report(NR, "L3", "new heading \"" h "\" -- the board has two sections, " ruling " and " claudes "; real work with an owner and a next action is an issue (public repo when it passes the private-terms check, else claude_prompts_scratch); deferred work is an issue on milestone 1.0")
-      cursec = h
+      cursec = h; curgroup = ""
       next
     }
-    /^#/ { flush(); cursec = ""; next }
+    /^### / {
+      flush(); h = trim($0)
+      if (mode == "epic") next
+      if (cursec == ruling) { curgroup = h; next }
+      if (added(NR) && l3 == "enforce" && !(h in heads))
+        report(NR, "L3", "group heading \"" h "\" outside " ruling " -- \"### \" headings group ruling cards by project and are allowed nowhere else; " claudes " is one flat list")
+      curgroup = ""
+      next
+    }
+    /^#/ { flush(); cursec = ""; curgroup = ""; next }
     mode == "epic" && !instatus { next }
     /^[ \t]*$/ { flush(); next }
     /^(- |[0-9]+\. )/ {
@@ -144,6 +157,7 @@ run_lint() {
         if (mode != "epic") {
           if ($0 ~ /^- \[[xX]\]/) report(NR, "L1", "ticked card -- delete the line; done work lives in git log and log/, never on the board")
           if (!seenhead) report(NR, "L2", "bullet above the first \"## \" heading -- move it under " claudes)
+          if (cursec == ruling && curgroup == "") report(NR, "L7", "ruling card with no \"### <project>\" group above it -- put it under the group named for the project-<name> topic that owns it, or \"### global\" when none does; create the group if it is missing")
         }
         if (mode != "file") l5(NR, $0)
       }
@@ -163,7 +177,7 @@ run_lint() {
 # Headings in the committed copy of <file>, one per line; empty when the
 # file is not in HEAD. Caller has checked we are inside a work tree.
 head_headings() {
-  git -C "$(dirname "$1")" show "HEAD:./$(basename "$1")" 2>/dev/null | grep '^## ' | sed 's/[[:space:]]*$//'
+  git -C "$(dirname "$1")" show "HEAD:./$(basename "$1")" 2>/dev/null | grep -E '^###? ' | sed 's/[[:space:]]*$//'
 }
 
 lint_file() {
@@ -235,7 +249,7 @@ hook_mode() {
     1) block "kanban-lint: $fp breaks the board contract. Each line below is a line number in the file, the rule it broke, and where that fact lives instead:
 $out
 
-Fix or delete each line named, then carry on. The board holds a question only the user can settle under ## Needs ruling, and agent rabbit-trails under ## Claude's; /card-write has the routing table for everything else." ;;
+Fix or delete each line named, then carry on. The board holds a question only the user can settle under ## Needs ruling -- grouped by project under \"### <name>\" headings, \"### global\" when no project owns it -- and agent rabbit-trails under ## Claude's, one flat list; /card-write has the routing table for everything else." ;;
     *) block "kanban-lint: $fp could not be linted ($out). This check fails closed: make the file lintable (or revert the edit) before carrying on." ;;
   esac
 }

--- a/.claude/hooks/kanban-lint.sh
+++ b/.claude/hooks/kanban-lint.sh
@@ -1,0 +1,243 @@
+#!/bin/sh
+# Lints a kanban.md board (or an epic file's Status lines) against the board
+# contract: the board is the agent's private pull queue, one section, cards
+# that carry a link and no state.
+#
+# Why: measured on 2026-09-08, the global board held 128 cards, 28 of them
+# ticked and never deleted, 63 restating the state of a PR or issue that
+# GitHub already knew, and every session in every repo paid to read the
+# first screen of it. The card contract had said "delete when done" and
+# "state lives in the PR" for weeks, in CLAUDE.md and in /card-write, and
+# the board still grew. Prose rules already failed here once
+# (pr-threads-gate.sh header); this is the same move -- the rule leaves the
+# model's memory and becomes a check that runs at edit time, at Stop and
+# before the state repo commits.
+#
+# Rules, each printed by id so the reason can be looked up:
+#   L1  a "- [x]" line                  -- delete, never tick
+#   L2  a bullet above the first "## "  -- cards live under a heading
+#   L3  a heading other than ## Claude's, when it is not already in HEAD
+#   L4  a card whose action verb is the user's (review, merge, land, bump,
+#       close, approve, ship, ratify, rule on, decide, confirm, answer,
+#       watch) AND that links a /pull/N or /issues/N -- the user's turn is
+#       derived from the PR, never written down. Verb-keyed on purpose: a
+#       card citing a merged PR as provenance is fine.
+#   L5  a state word (merged, awaiting, not merged, CI green, open as) --
+#       only on ADDED lines (--diff) or Status lines (--epic); bare "green"
+#       and "red" are not matched ("Red Sea", "green light");
+#       history already on the board is not relitigated
+#   L6  a card with no link at all (http, or a relative log/ link)
+#
+# Modes:
+#   --file <path>             whole file; L3 only for headings absent from
+#                             HEAD, so a legacy "## Solace's" still in HEAD
+#                             passes until the migration commit removes it
+#   --diff <repo> <relpath>   only lines added in the uncommitted diff
+#                             (git diff HEAD, plus an untracked file whole)
+#   --epic <path>             L5 on the lines under "## Status"
+#   (no args)                 PostToolUse hook: reads the tool JSON, lints
+#                             tool_input.file_path when it is a kanban.md
+#                             (--diff against HEAD when inside a git repo, else --file) or under
+#                             state/global/epics/ (--epic),
+#                             blocks with the violations; silent otherwise
+#
+# Exit: 0 clean, 1 violations ("<line>: <rule> <message>" per line on
+# stdout), 2 cannot lint. A card spans its indented continuation lines;
+# they are folded before matching, the way session-start-continuity.sh
+# folds them for display.
+set -u
+
+usage() {
+  printf 'usage: kanban-lint.sh --file <path> | --diff <repo-dir> <relpath> | --epic <path>\n' >&2
+  printf '       no arguments: PostToolUse hook, JSON on stdin\n' >&2
+  exit 2
+}
+
+command -v awk >/dev/null 2>&1 || { echo "kanban-lint: awk is missing, cannot lint" >&2; exit 2; }
+
+# run_lint <mode> <file> <added: all | "n n n"> <l3: enforce|skip> <headings in HEAD>
+# Prints violations sorted by line. Returns 0 clean, 1 violations, 2 awk failed.
+run_lint() {
+  out=$(KL_MODE=$1 KL_ADDED=$3 KL_L3=$4 KL_HEADS=$5 awk '
+    BEGIN {
+      mode = ENVIRON["KL_MODE"]
+      allad = (ENVIRON["KL_ADDED"] == "all")
+      n = split(ENVIRON["KL_ADDED"], a, " ")
+      for (i = 1; i <= n; i++) if (a[i] != "") ad[a[i] + 0] = 1
+      l3 = ENVIRON["KL_L3"]
+      n = split(ENVIRON["KL_HEADS"], a, "\n")
+      for (i = 1; i <= n; i++) if (a[i] != "") heads[a[i]] = 1
+      claudes = "## Claude\047s"
+      nv = split("review merge land bump close approve ship ratify rule_on decide confirm answer watch", verbs, " ")
+      for (i = 1; i <= nv; i++) gsub(/_/, " ", verbs[i])
+      ns = split("not merged|ci green|open as|merged|awaiting", states, "|")
+      instatus = (mode != "epic")
+      seenhead = 0; cstart = 0; ctext = ""; touched = 0
+    }
+    function added(n) { return allad || (n in ad) }
+    function report(n, id, msg) { printf "%d: %s %s\n", n, id, msg }
+    function trim(s) { sub(/^[ \t]+/, "", s); sub(/[ \t]+$/, "", s); return s }
+    function l5(n, line,   bag, i, tail) {
+      bag = " " tolower(line) " "
+      gsub(/[^a-z0-9]+/, " ", bag)
+      tail = (mode == "epic") ? " (Status line = date -- slug -- decision pointer/links)" : ""
+      for (i = 1; i <= ns; i++)
+        if (index(bag, " " states[i] " ")) {
+          report(n, "L5", "state word \"" states[i] "\" -- work state lives in the PR/issue; carry the link, not the adjective" tail)
+          return
+        }
+    }
+    # The verb a card opens with, or "". Leading "**" is skipped so a short
+    # name that is itself the action ("**Review and merge [x](...)**") counts.
+    function verb_at(s,   t, i, v, rest) {
+      t = tolower(s); sub(/^[ \t*]+/, "", t)
+      for (i = 1; i <= nv; i++) {
+        v = verbs[i]
+        if (substr(t, 1, length(v)) == v) {
+          rest = substr(t, length(v) + 1, 1)
+          if (rest == "" || rest !~ /[a-z]/) return v
+        }
+      }
+      return ""
+    }
+    function check_card(   text, t2, p, verb) {
+      text = ctext
+      sub(/^[ \t]*(- \[[ xX]\] |- |[0-9]+\. )/, "", text)
+      if (text !~ /https?:\/\// && text !~ /\]\((\.\.\/)*log\//)
+        report(cstart, "L6", "card has no link -- a card carries an http link or a relative log/ link; a loop with no home gets a log entry first")
+      verb = verb_at(text)
+      if (verb == "" && substr(text, 1, 2) == "**") {
+        t2 = substr(text, 3); p = index(t2, "**")
+        if (p) {
+          t2 = substr(t2, p + 2)
+          # the separator after the short name: " -- ", " - ", ": " or an em dash
+          sub(/^[ \t]*(--|-|:|[^ -~]+)[ \t]*/, "", t2)
+          verb = verb_at(t2)
+        }
+      }
+      if (verb != "" && text ~ /github\.com\/[^ )]*\/(pull|issues)\/[0-9]/)
+        report(cstart, "L4", "\"" verb "\" + a PR/issue link is the user\047s turn, which worklist derives from the PR/issue itself -- a question is an issue labelled needs-ruling, an action only the user can do is an issue assigned to the user; delete the card")
+    }
+    function flush() {
+      if (cstart && touched && mode != "epic") check_card()
+      cstart = 0; ctext = ""; touched = 0
+    }
+    /^## / {
+      flush(); h = trim($0); seenhead = 1
+      if (mode == "epic") { instatus = (h == "## Status"); next }
+      if (added(NR) && h != claudes && l3 == "enforce" && !(h in heads))
+        report(NR, "L3", "new heading \"" h "\" -- the board has one section, " claudes "; a loop only the user can close is an issue assigned to the user (public repo when it passes the private-terms check, else claude_prompts_scratch); deferred work is an issue on milestone 1.0")
+      next
+    }
+    /^#/ { flush(); next }
+    mode == "epic" && !instatus { next }
+    /^[ \t]*$/ { flush(); next }
+    /^(- |[0-9]+\. )/ {
+      flush(); cstart = NR; ctext = $0; touched = added(NR)
+      if (added(NR)) {
+        if (mode != "epic") {
+          if ($0 ~ /^- \[[xX]\]/) report(NR, "L1", "ticked card -- delete the line; done work lives in git log and log/, never on the board")
+          if (!seenhead) report(NR, "L2", "bullet above the first \"## \" heading -- move it under " claudes)
+        }
+        if (mode != "file") l5(NR, $0)
+      }
+      next
+    }
+    {
+      if (cstart) { ctext = ctext " " trim($0); if (added(NR)) touched = 1 }
+      if (added(NR) && mode != "file") l5(NR, $0)
+    }
+    END { flush() }
+  ' "$2") || return 2
+  [ -n "$out" ] || return 0
+  printf '%s\n' "$out" | sort -n
+  return 1
+}
+
+# Headings in the committed copy of <file>, one per line; empty when the
+# file is not in HEAD. Caller has checked we are inside a work tree.
+head_headings() {
+  git -C "$(dirname "$1")" show "HEAD:./$(basename "$1")" 2>/dev/null | grep '^## ' | sed 's/[[:space:]]*$//'
+}
+
+lint_file() {
+  [ -f "$1" ] || { printf 'kanban-lint: %s: no such file\n' "$1" >&2; return 2; }
+  if git -C "$(dirname "$1")" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    run_lint file "$1" all enforce "$(head_headings "$1")"
+  else
+    run_lint file "$1" all skip ""
+  fi
+}
+
+lint_epic() {
+  [ -f "$1" ] || { printf 'kanban-lint: %s: no such file\n' "$1" >&2; return 2; }
+  run_lint epic "$1" all skip ""
+}
+
+lint_diff() {
+  repo=$1; rel=$2
+  git -C "$repo" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+    || { printf 'kanban-lint: %s: not a git work tree\n' "$repo" >&2; return 2; }
+  [ -f "$repo/$rel" ] || return 0          # deleted or never there: nothing was added
+  if git -C "$repo" cat-file -e "HEAD:$rel" 2>/dev/null; then
+    added=$(git -C "$repo" diff --no-ext-diff --no-color -U0 HEAD -- "$rel" 2>/dev/null | awk '
+      /^@@/ { s = $3; sub(/^\+/, "", s); n = split(s, p, ",")
+              cnt = (n > 1) ? p[2] : 1
+              for (i = 0; i < cnt; i++) printf "%d ", p[1] + i }') || return 2
+    [ -n "$added" ] || return 0
+    run_lint diff "$repo/$rel" "$added" enforce "$(head_headings "$repo/$rel")"
+  else
+    run_lint diff "$repo/$rel" all enforce ""
+  fi
+}
+
+json_str() {
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$1" | jq -Rs .
+  else
+    printf '"%s"\n' "$(printf '%s' "$1" | tr '\t' ' ' | sed 's/\\/\\\\/g; s/"/\\"/g' | awk '{ if (NR > 1) printf "\\n"; printf "%s", $0 }')"
+  fi
+}
+
+block() { printf '{"decision":"block","reason":%s}\n' "$(json_str "$1")"; exit 0; }
+
+hook_mode() {
+  payload=$(cat) || exit 0
+  if command -v jq >/dev/null 2>&1; then
+    fp=$(printf '%s' "$payload" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+  else
+    fp=$(printf '%s' "$payload" | sed -n 's/.*"file_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+  fi
+  case "$fp" in
+    */state/global/epics/*.md) mode="epic" ;;
+    kanban.md|*/kanban.md)     mode="file" ;;
+    *) exit 0 ;;
+  esac
+  [ -f "$fp" ] || exit 0
+  # Inside a git repo a board is linted by its DIFF, the same view the Stop
+  # gate takes: the live board carries years of lines written before these
+  # rules existed, and whole-file linting would block every edit to it --
+  # including the edit that deletes a legacy card -- until a migration lands.
+  if [ "$mode" = file ] && root=$(git -C "$(dirname "$fp")" rev-parse --show-toplevel 2>/dev/null); then
+    rel=$(printf '%s' "$fp" | sed "s|^$root/||")
+    out=$(lint_diff "$root" "$rel" 2>&1); rc=$?
+  else
+    out=$(lint_"$mode" "$fp" 2>&1); rc=$?
+  fi
+  case $rc in
+    0) exit 0 ;;
+    1) block "kanban-lint: $fp breaks the board contract. Each line below is a line number in the file, the rule it broke, and where that fact lives instead:
+$out
+
+Fix or delete each line named, then carry on. The board holds only agent rabbit-trails under ## Claude's; /card-write has the routing table for everything else." ;;
+    *) block "kanban-lint: $fp could not be linted ($out). This check fails closed: make the file lintable (or revert the edit) before carrying on." ;;
+  esac
+}
+
+case "${1:-}" in
+  --file) [ $# -eq 2 ] || usage; lint_file "$2" ;;
+  --diff) [ $# -eq 3 ] || usage; lint_diff "$2" "$3" ;;
+  --epic) [ $# -eq 2 ] || usage; lint_epic "$2" ;;
+  "")     hook_mode ;;
+  *)      usage ;;
+esac

--- a/.claude/hooks/kanban-lint.test.sh
+++ b/.claude/hooks/kanban-lint.test.sh
@@ -131,10 +131,33 @@ commit_board "$NR" kanban.md
 cat >> "$NR/kanban.md" <<'EOF'
 
 ## Needs ruling
+### colregs
 - [ ] **Board sections** — decide whether cards or issues own a question ([o/r#90](https://github.com/o/r/pull/90))
 EOF
 run 0 'an added ## Needs ruling heading passes L3' --diff "$NR" kanban.md
-run 0 'a decide + PR link card under ## Needs ruling passes L4' --file "$NR/kanban.md"
+run 0 'a grouped decide + PR link card under ## Needs ruling passes L4 and L7' --file "$NR/kanban.md"
+gitq "$NR" checkout -- kanban.md
+
+# L7: a ruling card needs a "### <project>" group above it.
+cat >> "$NR/kanban.md" <<'EOF'
+
+## Needs ruling
+- [ ] **Ungrouped** — decide the pin ([o/r#91](https://github.com/o/r/pull/91))
+EOF
+run 1 'an ungrouped ruling card fails L7' --diff "$NR" kanban.md
+has 'L7 names the line'        '^7: L7 ruling card with no'
+has 'L7 names the global group' '### global'
+lacks 'L7 alone, no L3 on the group-less section' 'L3'
+gitq "$NR" checkout -- kanban.md
+
+# "### " groups belong only under ## Needs ruling.
+cat >> "$NR/kanban.md" <<'EOF'
+### dotfiles
+- [ ] **Grouped under the wrong section** — chase the awk ([log](log/awk.md))
+EOF
+run 1 'a ### group under ## Claude'"'"'s fails L3' --diff "$NR" kanban.md
+has 'L3 names the group heading' '^5: L3 group heading "### dotfiles"'
+lacks 'no L7 outside the ruling section' 'L7'
 gitq "$NR" checkout -- kanban.md
 
 # The same card under ## Claude's is still the user's turn written down.

--- a/.claude/hooks/kanban-lint.test.sh
+++ b/.claude/hooks/kanban-lint.test.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+# Tests for kanban-lint.sh. Run: bash .claude/hooks/kanban-lint.test.sh
+# Set AWK_PATH to a directory whose `awk` is another implementation (mawk,
+# original-awk) to run the same cases under it; CI does this for each.
+#
+# What matters: every rule fires by id on the right line and stays quiet on
+# the lookalikes (a merged PR cited as provenance, "closed" vs "close",
+# "unmerged" vs "merged"); a card's indented continuation lines count as the
+# card; --file tolerates legacy headings already in HEAD; --diff judges only
+# the lines this checkout added; the hook mode blocks with the same lines.
+set -uo pipefail
+[ -n "${AWK_PATH:-}" ] && PATH="$AWK_PATH:$PATH"
+
+LINT="$(cd "$(dirname "$0")" && pwd)/kanban-lint.sh"
+pass=0; fail=0
+SCRATCH=$(mktemp -d); trap 'rm -rf "$SCRATCH"' EXIT
+export HOME="$SCRATCH/home"; mkdir -p "$HOME"
+export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1
+
+# run <want rc> <desc> <args...>  -- LAST holds stdout+stderr
+run() {
+  local want=$1 desc=$2; shift 2
+  LAST=$(sh "$LINT" "$@" 2>&1); local rc=$?
+  if [ "$rc" = "$want" ]; then pass=$((pass+1)); else fail=$((fail+1)); printf 'FAIL (want rc %s, got %s): %s\n  %s\n' "$want" "$rc" "$desc" "$LAST"; fi
+}
+has()   { if printf '%s\n' "$LAST" | grep -Eq -- "$2"; then pass=$((pass+1)); else fail=$((fail+1)); printf 'FAIL (output lacks /%s/): %s\n  %s\n' "$2" "$1" "$LAST"; fi; }
+lacks() { if printf '%s\n' "$LAST" | grep -Eq -- "$2"; then fail=$((fail+1)); printf 'FAIL (output has /%s/): %s\n  %s\n' "$2" "$1" "$LAST"; else pass=$((pass+1)); fi; }
+eq()    { if [ "$2" = "$3" ]; then pass=$((pass+1)); else fail=$((fail+1)); printf 'FAIL: %s\n  want [%s]\n  got  [%s]\n' "$1" "$2" "$3"; fi; }
+
+gitq() { git -C "$1" -c user.name=t -c user.email=t@example.invalid -c commit.gpgsign=false "${@:2}" >/dev/null 2>&1; }
+mkrepo() { mkdir -p "$1"; gitq "$1" init -q; }
+commit_board() { gitq "$1" add -- "$2"; gitq "$1" commit -q -m "board"; }
+
+# --- --file: a clean board is silent ------------------------------------------
+cat > "$SCRATCH/clean.md" <<'EOF'
+# Open loops — global
+
+Prose in the preamble is not a card.
+
+## Claude's
+- [ ] **Teach colregs-mcp the `overridden` field** — once the engine returns it
+      ([o/r#40](https://github.com/o/r/pull/40))
+- [ ] **D: bump engine to 0.2.2** — lockfile bump ([pr](https://github.com/o/r/pull/50))
+- [ ] Ruled 2026-09-08, kept ([o/r#1](https://github.com/o/r/pull/1)) — the red sidelight text
+- [ ] **Add the check** — done, landed as [o/r#59](https://github.com/o/r/pull/59), merged 2026-09-08
+- [ ] **Reviewer notes** — write them up ([log](log/2026-09-08-notes.md))
+- [ ] Closed 2026-09-08: the check exists ([log](../log/x.md)) — carry the finding
+- [ ] **Watch list** — the reading list ([list](https://example.invalid/list))
+- [ ] Merge conflicts in the harness: rework the encoder ([log](log/x.md))
+EOF
+run 0 'clean board, --file' --file "$SCRATCH/clean.md"
+eq 'clean board prints nothing' '' "$LAST"
+
+# --- every rule, by id and line ----------------------------------------------
+cat > "$SCRATCH/bad.md" <<'EOF'
+# Open loops
+
+- [ ] **Stray** — above the heading ([log](log/x.md))
+
+## Claude's
+- [ ] **Review and merge [o/r#44](https://github.com/o/r/pull/44)** — the publish workflow
+- [x] **Add the check** — done ([o/r#59](https://github.com/o/r/pull/59))
+- [ ] **Rule on [o/r#32](https://github.com/o/r/issues/32)** — does 26(a) reach a vessel aground
+- [ ] **Foo** — merge the fix once it passes
+      ([pr](https://github.com/o/r/pull/7))
+- [ ] Card with no link at all
+- [ ] **Bar** — needs a link
+      but only says so over two lines
+- [ ] REVIEW the ADR ([o/r#9](https://github.com/o/r/issues/9))
+- [ ] **Baz**: answer the question on [o/r#3](https://github.com/o/r/issues/3)
+- [ ] **Qux** -- decide the shape ([o/r#5](https://github.com/o/r/pull/5))
+- [ ] **Watch the release** ([run](https://github.com/o/r/actions/runs/1))
+- [ ] **Answer** — the ADR text, no PR ([log](log/adr.md))
+EOF
+run 1 'bad board, --file' --file "$SCRATCH/bad.md"
+has 'L2 on the stray bullet'            '^3: L2 '
+has 'L4 review in the short name'       '^6: L4 "review"'
+has 'L1 on the ticked line'             '^7: L1 '
+has 'L4 two-word verb "rule on"'        '^8: L4 "rule on"'
+has 'L4 verb after the em-dash separator, link on the continuation line' '^9: L4 "merge"'
+has 'L6 on the linkless card'           '^11: L6 '
+has 'L6 spans continuation lines'       '^12: L6 '
+has 'L4 case-insensitive'               '^14: L4 "review"'
+has 'L4 after a colon separator'        '^15: L4 "answer"'
+has 'L4 after a -- separator'           '^16: L4 "decide"'
+lacks 'watch + actions link is not a PR/issue' '^17: L4'
+lacks 'answer with only a log link'     '^18: '
+lacks 'no L5 in --file mode'            ' L5 '
+eq 'violations sorted by line' "$(printf '%s\n' "$LAST" | cut -d: -f1)" "$(printf '%s\n' "$LAST" | cut -d: -f1 | sort -n)"
+eq 'format is <line>: <rule> <message>' "$(printf '%s\n' "$LAST" | grep -cvE '^[0-9]+: L[1-6] .+')" 0
+
+# --- L3 and the transition: legacy headings already in HEAD pass --------------
+R="$SCRATCH/legacy"; mkrepo "$R"
+cat > "$R/kanban.md" <<'EOF'
+# Open loops
+
+## Solace's
+- [ ] **Run the review session** — the memos ([log](log/memos.md))
+
+## Deferred — pre-1.0
+- [ ] Later thing ([log](log/later.md))
+
+## Claude's
+- [ ] **Fix the awk** — drops the first bullet ([log](log/awk.md))
+EOF
+commit_board "$R" kanban.md
+run 0 'legacy headings in HEAD pass --file' --file "$R/kanban.md"
+cat >> "$R/kanban.md" <<'EOF'
+
+## Yours
+- [ ] Another section ([log](log/x.md))
+EOF
+run 1 'a heading not in HEAD fails --file' --file "$R/kanban.md"
+has 'L3 names the heading' '^12: L3 new heading "## Yours"'
+lacks 'the legacy heading still passes' 'Solace'
+cp "$R/kanban.md" "$SCRATCH/norepo-kanban.md"
+run 0 'outside a repo, --file skips L3' --file "$SCRATCH/norepo-kanban.md"
+: > "$R/untracked.md"; printf '## Solace'"'"'s\n- [ ] x ([log](log/x.md))\n' > "$R/untracked.md"
+run 1 'a file not in HEAD: every non-Claude heading is new' --file "$R/untracked.md"
+has 'L3 on the untracked file' '^1: L3 '
+
+# --- --diff: only added lines are judged -------------------------------------
+D="$SCRATCH/diff"; mkrepo "$D"; mkdir -p "$D/state/global"
+cat > "$D/state/global/kanban.md" <<'EOF'
+# Open loops
+
+## Solace's
+- [x] **Merge [o/r#29](https://github.com/o/r/pull/29)** — CI green, awaiting you
+- [ ] **Rule on [o/r#32](https://github.com/o/r/issues/32)** — the aground question
+
+## Claude's
+- [ ] **Old card** — merged history stays ([log](log/old.md))
+EOF
+commit_board "$D" state/global/kanban.md
+run 0 'no diff -> clean' --diff "$D" state/global/kanban.md
+eq 'no diff prints nothing' '' "$LAST"
+
+cat >> "$D/state/global/kanban.md" <<'EOF'
+- [ ] **New card** — awaiting Solace's review ([o/r#50](https://github.com/o/r/pull/50))
+- [ ] **Bump engine** — CI green now ([o/r#51](https://github.com/o/r/pull/51))
+- [ ] **Unmerged credit** — a fine card ([log](log/fine.md))
+- [ ] **Two-line state** — the fix
+      landed and is not merged yet ([log](log/two.md))
+EOF
+run 1 'added lines with state words' --diff "$D" state/global/kanban.md
+has 'L5 awaiting on the added line'      '^9: L5 state word "awaiting"'
+has 'L4 bump + PR link'                  '^10: L4 "bump"'
+has 'L5 CI green'                        '^10: L5 state word "ci green"'
+has 'L5 on the continuation line itself' '^13: L5 state word "not merged"'
+lacks 'unmerged/credit are not whole words' '^11: '
+lacks 'history above is not linted'      '^[4-8]: '
+eq 'exactly four violations' 4 "$(printf '%s\n' "$LAST" | wc -l | tr -d ' ')"
+
+gitq "$D" checkout -- state/global/kanban.md
+cat >> "$D/state/global/kanban.md" <<'EOF'
+
+## Deferred
+- [ ] Later ([log](log/later.md))
+EOF
+run 1 'a new heading in the diff' --diff "$D" state/global/kanban.md
+has 'L3 on the added heading' '^10: L3 new heading "## Deferred"'
+gitq "$D" checkout -- state/global/kanban.md
+
+# Moving an existing heading is not a new heading.
+printf '# Open loops\n\n## Claude'"'"'s\n- [ ] **Old card** — merged history stays ([log](log/old.md))\n\n## Solace'"'"'s\n- [ ] **Moved card** — the aground question ([log](log/aground.md))\n' > "$D/state/global/kanban.md"
+run 0 'reordering headings already in HEAD passes' --diff "$D" state/global/kanban.md
+gitq "$D" checkout -- state/global/kanban.md
+
+# A prose line above the first heading that is added, and a stray bullet.
+sed -i '2i - [ ] stray bullet ([log](log/s.md))' "$D/state/global/kanban.md"
+run 1 'added bullet above the first heading' --diff "$D" state/global/kanban.md
+has 'L2 in diff mode' '^2: L2 '
+gitq "$D" checkout -- state/global/kanban.md
+
+# Untracked board: everything is added.
+printf '## Claude'"'"'s\n- [x] ticked ([log](log/x.md))\n- [ ] fine ([log](log/y.md))\n' > "$D/state/global/new.md"
+run 1 'untracked file: whole file is added' --diff "$D" state/global/new.md
+has 'L1 on the untracked board' '^2: L1 '
+rm -f "$D/state/global/kanban.md"
+run 0 'deleted board: nothing added' --diff "$D" state/global/kanban.md
+gitq "$D" checkout -- state/global/kanban.md
+run 2 'not a repo' --diff "$SCRATCH/home" x.md
+
+# --- --epic: state words on Status lines only ------------------------------------
+cat > "$SCRATCH/epic.md" <<'EOF'
+# Epic
+
+The 2026-09-05 incident is closed and merged. Not a Status line.
+
+## Status
+
+- 2026-09-04 — epic opened ([#1](https://github.com/o/r/issues/1))
+- 2026-09-06 — **P2.1 built** and open as [#21](https://github.com/o/r/pull/21), awaiting review
+- 2026-09-06 — **#21 fixed and green again**, verified by re-running
+  the harness; CI green
+- 2026-09-07 — ruled, see [#26](https://github.com/o/r/pull/26)
+
+## Sessions
+
+- [ ] **P1.5 Triage** — merged evidence packs; awaiting Solace
+EOF
+run 1 'epic Status lines' --epic "$SCRATCH/epic.md"
+has 'L5 open as (first phrase wins)'     '^8: L5 state word "open as"'
+lacks 'bare green is not a state word'   '^9: '
+has 'L5 on the wrapped Status line'      '^10: L5 state word "ci green"'
+has 'epic tail names the Status shape'   'Status line = date -- slug'
+lacks 'prose outside Status is not linted' '^3: '
+lacks 'Sessions section is not linted'   '^1[5-9]: '
+lacks 'no card rules in epic mode'       ' L[1346] '
+eq 'two epic violations' 2 "$(printf '%s\n' "$LAST" | wc -l | tr -d ' ')"
+printf '## Status\n\n- 2026-09-08 — slug — [#3](https://github.com/o/r/pull/3)\n' > "$SCRATCH/epic-ok.md"
+run 0 'clean Status lines' --epic "$SCRATCH/epic-ok.md"
+
+# --- cannot lint ---------------------------------------------------------------
+run 2 'missing file' --file "$SCRATCH/nope.md"
+run 2 'missing epic' --epic "$SCRATCH/nope.md"
+run 2 'bad flag' --wat x
+run 2 'missing operand' --diff "$D"
+
+# --- hook mode ---------------------------------------------------------------
+hook() { printf '%s' "$1" | sh "$LINT" 2>&1; }
+edit_json() { jq -n --arg f "$1" '{tool_name:"Edit",tool_input:{file_path:$f,old_string:"a",new_string:"b"},tool_response:{}}'; }
+LAST=$(hook "$(edit_json "$SCRATCH/bad.md")")
+eq 'other files are ignored' '' "$LAST"
+LAST=$(hook "$(edit_json "$SCRATCH/clean.md")")
+eq 'a clean board is silent (basename kanban.md, but clean.md is not one)' '' "$LAST"
+mkdir -p "$SCRATCH/proj"; cp "$SCRATCH/clean.md" "$SCRATCH/proj/kanban.md"
+LAST=$(hook "$(edit_json "$SCRATCH/proj/kanban.md")")
+eq 'clean kanban.md is silent' '' "$LAST"
+cp "$SCRATCH/bad.md" "$SCRATCH/proj/kanban.md"
+LAST=$(hook "$(edit_json "$SCRATCH/proj/kanban.md")")
+eq 'bad kanban.md blocks' block "$(printf '%s' "$LAST" | jq -r .decision 2>/dev/null)"
+reason=$(printf '%s' "$LAST" | jq -r .reason)
+LAST=$reason
+has 'reason names the file'             "$SCRATCH/proj/kanban.md"
+has 'reason carries line and rule'      '^7: L1 '
+has 'reason carries the routing row'    'needs-ruling'
+has 'reason points at card-write'       '/card-write'
+mkdir -p "$SCRATCH/sr/state/global/epics"; cp "$SCRATCH/epic.md" "$SCRATCH/sr/state/global/epics/e.md"
+LAST=$(hook "$(jq -n --arg f "$SCRATCH/sr/state/global/epics/e.md" '{tool_name:"Write",tool_input:{file_path:$f,content:"x"}}')")
+eq 'epic path routes to --epic' block "$(printf '%s' "$LAST" | jq -r .decision 2>/dev/null)"
+LAST=$(printf '%s' "$LAST" | jq -r .reason)
+has 'epic reason is L5 only' '^8: L5 '
+lacks 'epic reason has no card rules' ' L[1346] '
+LAST=$(hook "$(edit_json "$SCRATCH/proj/missing/kanban.md")")
+eq 'a path that does not exist is silent' '' "$LAST"
+LAST=$(hook '')
+eq 'empty payload is silent' '' "$LAST"
+
+# Without jq the hook still finds the path and still blocks, with valid JSON.
+mkdir -p "$SCRATCH/nojq"; for b in sh awk sed grep sort head tr cat dirname basename printf git; do p=$(command -v $b) && ln -s "$p" "$SCRATCH/nojq/$b"; done
+LAST=$(printf '%s' "$(edit_json "$SCRATCH/proj/kanban.md")" | PATH="$SCRATCH/nojq" /bin/sh "$LINT" 2>&1)
+eq 'no jq: still blocks' block "$(printf '%s' "$LAST" | jq -r .decision 2>/dev/null)"
+eq 'no jq: reason survives the hand-rolled escaper' 1 "$(printf '%s' "$LAST" | jq -r .reason | grep -c '^7: L1 ')"
+
+printf '%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/.claude/hooks/kanban-lint.test.sh
+++ b/.claude/hooks/kanban-lint.test.sh
@@ -119,6 +119,44 @@ run 0 'outside a repo, --file skips L3' --file "$SCRATCH/norepo-kanban.md"
 run 1 'a file not in HEAD: every non-Claude heading is new' --file "$R/untracked.md"
 has 'L3 on the untracked file' '^1: L3 '
 
+# --- ## Needs ruling: the second allowed section ------------------------------
+NR="$SCRATCH/ruling"; mkrepo "$NR"
+cat > "$NR/kanban.md" <<'EOF'
+# Open loops
+
+## Claude's
+- [ ] **Fix the awk** — drops the first bullet ([log](log/awk.md))
+EOF
+commit_board "$NR" kanban.md
+cat >> "$NR/kanban.md" <<'EOF'
+
+## Needs ruling
+- [ ] **Board sections** — decide whether cards or issues own a question ([o/r#90](https://github.com/o/r/pull/90))
+EOF
+run 0 'an added ## Needs ruling heading passes L3' --diff "$NR" kanban.md
+run 0 'a decide + PR link card under ## Needs ruling passes L4' --file "$NR/kanban.md"
+gitq "$NR" checkout -- kanban.md
+
+# The same card under ## Claude's is still the user's turn written down.
+cat >> "$NR/kanban.md" <<'EOF'
+- [ ] **Board sections** — decide whether cards or issues own a question ([o/r#90](https://github.com/o/r/pull/90))
+EOF
+run 1 'the same card under ## Claude'"'"'s still fails L4' --diff "$NR" kanban.md
+has 'L4 names the verb'            '^5: L4 "decide"'
+has 'L4 points at the ruling section' '## Needs ruling'
+gitq "$NR" checkout -- kanban.md
+
+# A third heading is still refused.
+cat >> "$NR/kanban.md" <<'EOF'
+
+## Solace's
+- [ ] Another section ([log](log/x.md))
+EOF
+run 1 'a ## Solace'"'"'s heading added still fails L3' --diff "$NR" kanban.md
+has 'L3 names the heading'      '^6: L3 new heading "## Solace'"'"'s"'
+has 'L3 names both sections'    '## Needs ruling'
+gitq "$NR" checkout -- kanban.md
+
 # --- --diff: only added lines are judged -------------------------------------
 D="$SCRATCH/diff"; mkrepo "$D"; mkdir -p "$D/state/global"
 cat > "$D/state/global/kanban.md" <<'EOF'
@@ -234,7 +272,7 @@ reason=$(printf '%s' "$LAST" | jq -r .reason)
 LAST=$reason
 has 'reason names the file'             "$SCRATCH/proj/kanban.md"
 has 'reason carries line and rule'      '^7: L1 '
-has 'reason carries the routing row'    'needs-ruling'
+has 'reason carries the routing row'    '## Needs ruling'
 has 'reason points at card-write'       '/card-write'
 mkdir -p "$SCRATCH/sr/state/global/epics"; cp "$SCRATCH/epic.md" "$SCRATCH/sr/state/global/epics/e.md"
 LAST=$(hook "$(jq -n --arg f "$SCRATCH/sr/state/global/epics/e.md" '{tool_name:"Write",tool_input:{file_path:$f,content:"x"}}')")

--- a/.claude/hooks/lib-state.sh
+++ b/.claude/hooks/lib-state.sh
@@ -43,7 +43,19 @@ state_dir() {
 # True when state_dir is inside the git repo, i.e. worth committing.
 state_is_repo() { state_repo >/dev/null 2>&1; }
 
-json_str() { jq -Rn --rawfile f /dev/stdin '$f'; }
+# One JSON-string escaper for the hooks that source this. It takes its text as
+# an argument, and falls back to sed/awk where jq is absent -- a hook that
+# cannot emit its reason is a hook that fails open. Do not add a second
+# json_str with a different signature: kanban-gate.sh once sourced this file
+# and then shadowed it, and the two disagreed about stdin vs "$1".
+json_str() {
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$1" | jq -Rs .
+  else
+    printf '"%s"\n' "$(printf '%s' "$1" | tr '\t' ' ' | sed 's/\\/\\\\/g; s/"/\\"/g' | awk '{ if (NR > 1) printf "\\n"; printf "%s", $0 }')"
+  fi
+}
+block() { printf '{"decision":"block","reason":%s}\n' "$(json_str "$1")"; exit 0; }
 
 # The set of tool calls that change git state, in one place.
 #

--- a/.claude/hooks/public-issue-guard.sh
+++ b/.claude/hooks/public-issue-guard.sh
@@ -207,6 +207,7 @@ done < "$META"
 denylist="$(state_dir)/private-terms.txt"
 [ -r "$denylist" ] || deny "the private-terms denylist is unreadable ($denylist), so text bound for a public repo cannot be checked. Is the state repo checked out? On a real machine: clone mark-brannan/claude_prompts_scratch to one of the paths lib-state.sh searches, or set CLAUDE_STATE_REPO. In a cloud session: mcp__Claude_Code_Remote__add_repo (owner mark-brannan, repo claude_prompts_scratch, access push), clone it to /workspace/claude_prompts_scratch, retry. To post without the check, target the private repo itself: --repo $PRIVATE_REPO."
 sed -e 's/\r$//' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e '/^#/d' -e '/^$/d' "$denylist" > "$WORK/terms"
+[ -s "$WORK/terms" ] || deny "the private-terms denylist ($denylist) is readable but has no terms in it -- only comments and blank lines, or nothing at all. An empty list matches nothing, so every post would pass unchecked, which is indistinguishable from a check that ran. Populate it (one term per line, # for comments) and retry. To post without the check, target the private repo itself: --repo $PRIVATE_REPO."
 
 # Bodies the hook cannot read are a hole, not a pass. awk emits OPAQUE only
 # when no heredoc feeds the value, so a heredoc elsewhere does not excuse it.

--- a/.claude/hooks/public-issue-guard.sh
+++ b/.claude/hooks/public-issue-guard.sh
@@ -1,0 +1,235 @@
+#!/bin/sh
+# Denies posting text that names a private term to a public GitHub repo.
+#
+# Why: the state repo is private and the code repos are public, and the rule
+# that boat names, hostnames, service URLs and account identifiers stay in the
+# private one has lived in CLAUDE.md as prose. Prose has already failed here
+# (pr-threads-gate.sh header). Once a term is in a public issue or PR comment
+# it is in GitHub's history and every mirror of it; the undo is a support
+# ticket, not an edit. So the check moves from the model's memory to the
+# moment the text leaves the machine.
+#
+# Fires on PreToolUse for
+#   - Bash: `gh issue|pr create|comment|edit|review|close|reopen|merge`, and
+#     `gh api` writing to repos/*/*/issues|pulls or a graphql mutation that
+#     comments or opens an issue/PR;
+#   - MCP: the GitHub tools that create or edit an issue, PR, comment or
+#     review (matched on the tool name's tail).
+# Nothing else: a body posted from `python -c`, `curl`, or a script file is
+# not inspected. The scope is Bash `gh` and the GitHub MCP tools.
+# The text judged is the whole command after quote removal (so a term
+# spelled `ho\stname` or split across quotes still reads whole), every
+# heredoc body, the file named by --body-file/-F/--input/-F key=@file, and
+# for MCP every string in tool_input. It is grepped case-insensitively, as
+# fixed substrings, against state/global/private-terms.txt in the state repo;
+# comment and blank lines in that file are ignored. The reason names the
+# term(s) that hit and nothing around them.
+#
+# The target repo is --repo/-R, GH_REPO=, the `gh api` path, or MCP
+# owner/repo; failing those, the origin of the payload's cwd -- unless the
+# command also runs `cd`, in which case it is unknown. Unknown is scanned.
+# Only mark-brannan/claude_prompts_scratch is allowed unscanned.
+#
+# GATE, fails closed: no jq, no awk, no library, unreadable payload, a body
+# the hook cannot see (--body-file it cannot read, `-F -` with no heredoc,
+# a body built from `$(...)` or `$VAR` that no heredoc feeds -- a heredoc
+# elsewhere in the command does not vouch for it), or a missing denylist while
+# the target is not the private repo -> deny, with the fix in the reason.
+set -uf
+
+HERE=$(dirname "$0")
+LIB="$HERE/lib-shell-words.awk"
+PRIVATE_REPO="mark-brannan/claude_prompts_scratch"
+
+deny() {
+  if command -v jq >/dev/null 2>&1; then
+    jq -cn --arg r "public-issue-guard: $1" '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}'
+  else
+    printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"public-issue-guard: jq missing, cannot inspect the text about to be posted"}}\n'
+  fi
+  exit 0
+}
+
+command -v jq  >/dev/null 2>&1 || deny 'jq missing, cannot inspect the text about to be posted'
+command -v awk >/dev/null 2>&1 || deny 'awk missing, cannot inspect the text about to be posted'
+[ -r "$LIB" ] || deny "$LIB missing, cannot inspect the command"
+[ -r "$HERE/lib-state.sh" ] || deny "$HERE/lib-state.sh missing, cannot locate the denylist"
+# shellcheck source=lib-state.sh
+. "$HERE/lib-state.sh"
+
+payload=$(cat) || deny 'unreadable hook payload'
+tool=$(printf '%s' "$payload" | jq -r '.tool_name // empty' 2>/dev/null) || deny 'unreadable hook payload'
+[ -n "$tool" ] || exit 0
+cwd=$(printf '%s' "$payload" | jq -r '.cwd // empty' 2>/dev/null)
+[ -n "$cwd" ] || cwd=$PWD
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/public-issue-guard.XXXXXX") || deny 'cannot create a scratch directory'
+trap 'rm -rf "$WORK"' EXIT
+TEXT="$WORK/text"      # everything that will be posted, one candidate per line
+META="$WORK/meta"      # R repo | F file | STDIN | OPAQUE | HEREDOC | CD
+: > "$TEXT"; : > "$META"
+
+# owner/name in lower case from any of the spellings gh and git accept.
+norm_repo() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]' \
+    | sed -e 's#^[a-z]*://[^/]*/##' -e 's#^[^@/]*@[^:]*:##' -e 's#^github\.com/##' -e 's#\.git$##' -e 's#/*$##'
+}
+
+case "$tool" in
+  Bash)
+    cmd=$(printf '%s' "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null) || deny 'unreadable hook payload'
+    [ -n "$cmd" ] || exit 0
+    printf '%s\n' "$cmd" | awk "$(cat "$LIB")"'
+      function wv(i) { return (k[i] == "q") ? q[i] : w[i] }
+      function flat(t) { gsub(/\n/, " ", t); return t }
+      function file(p) { if (p == "-") print "STDIN"; else print "F\t" flat(p) }
+      # Opaque = built at run time. Allowed only when the heredoc feeding it is
+      # on the value itself: `$(cat <<EOF ...)` inline, or `$VAR` whose
+      # assignment carries `<<`. The heredoc body is in TEXT and gets scanned.
+      function fed(v,   name) {
+        name = v; sub(/^\$\{?/, "", name); sub(/[^A-Za-z0-9_].*$/, "", name)
+        return name != "" && orig ~ ("(^|[;&|[:space:]])" name "=[\"\047]?\\$\\([^)]*<<")
+      }
+      function val(v) {
+        if (v ~ /\$\(/ || v ~ /`/) { if (v !~ /<</) print "OPAQUE\t" flat(v) }
+        else if (v ~ /^\$[A-Za-z_{]/) { if (!fed(v)) print "OPAQUE\t" flat(v) }
+      }
+      function field(v) { sub(/^[^=]*=/, "", v); if (v ~ /^@/) file(substr(v, 2)); else val(v) }
+      { buf = buf $0 "\n" }
+      END {
+        orig = buf
+        stripped = strip_heredocs(buf)
+        if (stripped != buf) print "HEREDOC"
+        buf = stripped
+        ntexts = texts_of(buf, texts, nested)
+        for (x = 1; x <= ntexts; x++) {
+          n = scan(texts[x], w, k, q)
+          for (i = 1; i <= n; i++) {
+            if (k[i] == ";") continue
+            if (k[i] == "w" && w[i] ~ /^(cd|pushd)$/) print "CD"
+            print "T\t" flat(wv(i))
+          }
+          a0 = 1
+          for (i = 1; i <= n + 1; i++) {
+            if (i <= n && k[i] != ";") continue
+            if (a0 < i) segment(a0, i - 1, nested[x])
+            a0 = i + 1
+          }
+        }
+      }
+      function segment(lo, hi, nested,   g, i, t, v, repo, sub_, act) {
+        g = cmd_index(w, k, lo, hi, "(^|/)gh$", nested, "")
+        if (!g || g + 1 > hi) return
+        repo = ""
+        for (i = lo; i < g; i++) if (k[i] == "w" && w[i] ~ /^GH_REPO=/) repo = substr(w[i], 9)
+        sub_ = w[g + 1]
+        if (sub_ == "api") { api(g, hi, repo); return }
+        if ((sub_ != "issue" && sub_ != "pr") || g + 2 > hi) return
+        act = w[g + 2]
+        if (act !~ /^(create|comment|edit|review|close|reopen|merge)$/) return
+        for (i = g + 3; i <= hi; i++) {
+          t = w[i]
+          if (t == "--repo" || t == "-R") { if (i < hi) repo = wv(++i) }
+          else if (t ~ /^--repo=/) repo = substr(t, 8)
+          else if (t ~ /^-R./) repo = substr(t, 3)
+          else if (t == "--body-file" || t == "-F") { if (i < hi) file(wv(++i)) }
+          else if (t ~ /^--body-file=/) file(substr(t, 13))
+          else if (t ~ /^-F./) file(substr(t, 3))
+          else if (t ~ /^(--body|--title|--comment|--subject|-b|-t|-c)$/) { if (i < hi) val(wv(++i)) }
+          else if (t ~ /^--(body|title|comment|subject)=/) { v = t; sub(/^[^=]*=/, "", v); val(v) }
+          else if (t ~ /^-[btc]./) val(substr(t, 3))
+        }
+        print "R\t" (repo == "" ? "-" : flat(repo))
+      }
+      function api(g, hi, repo,   i, t, v, path, method, fields, p, parts, hit) {
+        path = ""; method = ""; fields = 0
+        for (i = g + 2; i <= hi; i++) {
+          t = w[i]
+          if (t == "-X" || t == "--method") { if (i < hi) method = toupper(w[++i]) }
+          else if (t ~ /^--method=/) method = toupper(substr(t, 10))
+          else if (t ~ /^-X./) method = toupper(substr(t, 3))
+          else if (t ~ /^(-f|-F|--field|--raw-field)$/) { fields = 1; if (i < hi) field(wv(++i)) }
+          else if (t ~ /^-[fF]./) { fields = 1; field(substr(t, 3)) }
+          else if (t ~ /^--(field|raw-field)=/) { fields = 1; v = t; sub(/^[^=]*=/, "", v); field(v) }
+          else if (t == "--input") { fields = 1; if (i < hi) file(wv(++i)) }
+          else if (t ~ /^--input=/) { fields = 1; file(substr(t, 9)) }
+          else if (t ~ /^(-H|--header|-q|--jq|-t|--template|-p|--preview|--hostname|--cache)$/) i++
+          else if (t ~ /^-/) continue
+          else if (path == "") path = t
+        }
+        p = path; sub(/^https?:\/\/[^\/]+\//, "", p); sub(/^\/+/, "", p)
+        if (p ~ /^repos\/[^\/]+\/[^\/]+\/(issues|pulls)(\/|$)/) {
+          if (method == "GET" || method == "HEAD" || (method == "" && !fields)) return
+          split(p, parts, "/")
+          print "R\t" parts[2] "/" parts[3]
+        } else if (p == "graphql") {
+          hit = 0
+          for (i = g; i <= hi; i++)
+            if (wv(i) ~ /(addComment|createIssue|updateIssue|createPullRequest|updatePullRequest|addPullRequestReview|submitPullRequestReview|addDiscussionComment)/) hit = 1
+          if (hit) print "R\t" (repo == "" ? "-" : flat(repo))
+        }
+      }' > "$META" || deny 'awk failed, cannot inspect the command'
+    # The tokeniser can lose a segment behind an odd construct; the raw string
+    # is the backstop, so a gh write it names is scanned with the repo unknown.
+    if ! grep -q '^R	' "$META" && printf '%s' "$cmd" | grep -Eq '(^|[^A-Za-z0-9_./-])gh[[:space:]]+(issue|pr)[[:space:]]+(create|comment|edit|review|close|reopen|merge)([[:space:]]|$)'; then
+      printf 'R\t-\n' >> "$META"
+    fi
+    grep -q '^R	' "$META" || exit 0
+    { printf '%s\n' "$cmd"; sed -n 's/^T	//p' "$META"; } >> "$TEXT"
+    ;;
+  mcp__*__create_issue|mcp__*__update_issue|mcp__*__issue_write|mcp__*__add_issue_comment| \
+  mcp__*__create_pull_request|mcp__*__update_pull_request| \
+  mcp__*__add_pull_request_review_comment|mcp__*__create_pull_request_review| \
+  mcp__*__pull_request_review_write|mcp__*__add_comment_to_pending_review| \
+  mcp__*__create_and_submit_pull_request_review|mcp__*__submit_pending_pull_request_review)
+    repo=$(printf '%s' "$payload" | jq -r 'if (.tool_input.owner? // "") != "" and (.tool_input.repo? // "") != "" then "\(.tool_input.owner)/\(.tool_input.repo)" else "-" end' 2>/dev/null)
+    printf 'R\t%s\n' "${repo:--}" >> "$META"
+    printf '%s' "$payload" | jq -r '[.tool_input | .. | strings] | join("\n")' 2>/dev/null >> "$TEXT" || deny 'unreadable hook payload'
+    ;;
+  *) exit 0 ;;
+esac
+
+# Every target must be the private repo for the text to go unscanned; one
+# unknown or public target among several means the scan runs.
+all_private=1
+# shellcheck disable=SC2094  # META is only read here
+while IFS="$(printf '\t')" read -r kind repo; do
+  [ "$kind" = R ] || continue
+  if [ "$repo" = "-" ]; then
+    if grep -q '^CD$' "$META"; then repo=""
+    else repo=$(git -C "$cwd" remote get-url origin 2>/dev/null) || repo=""
+    fi
+  fi
+  [ "$(norm_repo "$repo")" = "$PRIVATE_REPO" ] || all_private=0
+done < "$META"
+[ "$all_private" = 1 ] && exit 0
+
+denylist="$(state_dir)/private-terms.txt"
+[ -r "$denylist" ] || deny "the private-terms denylist is unreadable ($denylist), so text bound for a public repo cannot be checked. Is the state repo checked out? On a real machine: clone mark-brannan/claude_prompts_scratch to one of the paths lib-state.sh searches, or set CLAUDE_STATE_REPO. In a cloud session: mcp__Claude_Code_Remote__add_repo (owner mark-brannan, repo claude_prompts_scratch, access push), clone it to /workspace/claude_prompts_scratch, retry. To post without the check, target the private repo itself: --repo $PRIVATE_REPO."
+sed -e 's/\r$//' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e '/^#/d' -e '/^$/d' "$denylist" > "$WORK/terms"
+
+# Bodies the hook cannot read are a hole, not a pass. awk emits OPAQUE only
+# when no heredoc feeds the value, so a heredoc elsewhere does not excuse it.
+opaque=$(sed -n 's/^OPAQUE	//p' "$META" | head -1)
+[ -n "$opaque" ] && deny "the body or title is built at run time ($opaque) and no heredoc in this command feeds it, so its text cannot be checked before it is posted. Write it literally, in a heredoc in the same command, or in a file and pass --body-file <path>."
+if ! grep -q '^HEREDOC$' "$META"; then
+  grep -q '^STDIN$' "$META" && deny "the body comes from stdin (-F - / --input -) and there is no heredoc in the command, so it cannot be checked. Put the text in a heredoc in the same command, or in a file and pass --body-file <path>."
+fi
+sed -n 's/^F	//p' "$META" | while IFS= read -r f; do
+  case "$f" in
+    '~'/*) f="$HOME${f#\~}" ;;
+    /*) ;;
+    *) f="$cwd/$f" ;;
+  esac
+  [ -r "$f" ] || { printf '%s\n' "$f" > "$WORK/badfile"; continue; }
+  cat "$f" >> "$TEXT"; printf '\n' >> "$TEXT"
+done
+[ -f "$WORK/badfile" ] && deny "--body-file $(cat "$WORK/badfile") cannot be read, so the text about to be posted cannot be checked. Create the file first, in the same command or an earlier one, then retry."
+
+grep -q -i -F -f "$WORK/terms" "$TEXT" || exit 0
+
+hits=""
+while IFS= read -r term; do
+  grep -q -i -F -e "$term" -- "$TEXT" && hits="$hits, $term"
+done < "$WORK/terms"
+deny "the text about to be posted to a public repo contains private term(s) from the denylist: ${hits#, }. Private detail does not go on public GitHub, ever -- it stays in GitHub's history. Either open the issue on the private state repo instead (--repo $PRIVATE_REPO) and link it from here, or rewrite the body without the term. Do not paraphrase it into something recognisable."

--- a/.claude/hooks/public-issue-guard.test.sh
+++ b/.claude/hooks/public-issue-guard.test.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Tests for public-issue-guard.sh. Run: bash .claude/hooks/public-issue-guard.test.sh
+# Set AWK_PATH to a directory whose `awk` is another implementation to run
+# the same cases under it (CI does mawk, gawk, original-awk).
+#
+# What matters: a private term is caught wherever the body travels -- a
+# flag value, a file, a heredoc, an MCP field, a different case -- the
+# private repo is never scanned, reads are never touched, and the gate is
+# loud when it cannot see the text or the denylist.
+# shellcheck disable=SC2016  # the commands under test contain $(...) and $VAR on purpose
+set -uo pipefail
+
+HOOK="$(cd "$(dirname "$0")" && pwd)/public-issue-guard.sh"
+[ -n "${AWK_PATH:-}" ] && PATH="$AWK_PATH:$PATH"
+pass=0; fail=0
+SCRATCH=$(mktemp -d); trap 'rm -rf "$SCRATCH"' EXIT
+export HOME="$SCRATCH/home"; mkdir -p "$HOME"
+export TMPDIR="$SCRATCH/tmp"; mkdir -p "$TMPDIR"
+
+# A fake state repo with a denylist. The terms here are invented: the real
+# list is private and only ever read by path.
+STATE="$SCRATCH/state"
+mkdir -p "$STATE/.git" "$STATE/state/global"
+cat > "$STATE/state/global/private-terms.txt" <<'EOF'
+# private terms -- lines starting with # are comments
+
+Wanderlust
+gateway.home.example
+  acct-4471
+EOF
+export CLAUDE_STATE_REPO="$STATE"
+PRIVATE=mark-brannan/claude_prompts_scratch
+
+# Two checkouts to resolve a cwd through: one whose origin is the private
+# repo, one whose origin is public.
+mkrepo() { mkdir -p "$1"; git -C "$1" init -q; git -C "$1" remote add origin "$2"; }
+mkrepo "$SCRATCH/private" "git@github.com:$PRIVATE.git"
+mkrepo "$SCRATCH/public" "https://github.com/mark-brannan/colregs.git"
+mkdir -p "$SCRATCH/nogit"
+
+LAST=""
+# check <deny|allow> <desc> <json>
+check() {
+  local want=$1 desc=$2 json=$3 out got
+  out=$(printf '%s' "$json" | sh "$HOOK" 2>&1)
+  if printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then got=deny
+  elif [ -z "$out" ]; then got=allow
+  else got=invalid; fi
+  if [ "$got" = "$want" ]; then pass=$((pass + 1)); else
+    fail=$((fail + 1)); printf 'FAIL (want %s, got %s): %s\n' "$want" "$got" "$desc"
+    [ -n "$out" ] && printf '  hook output: %s\n' "$out"
+  fi
+  LAST=$out
+}
+reason() { if printf '%s' "$LAST" | jq -r '.hookSpecificOutput.permissionDecisionReason' | grep -Fq -- "$2"; then pass=$((pass + 1)); else fail=$((fail + 1)); printf 'FAIL (reason lacks [%s]): %s\n  %s\n' "$2" "$1" "$LAST"; fi; }
+no_reason() { if printf '%s' "$LAST" | jq -r '.hookSpecificOutput.permissionDecisionReason' | grep -Fq -- "$2"; then fail=$((fail + 1)); printf 'FAIL (reason has [%s]): %s\n  %s\n' "$2" "$1" "$LAST"; else pass=$((pass + 1)); fi; }
+
+# bash_in <cwd> <command>
+bash_in() { jq -n --arg d "$1" --arg c "$2" '{tool_name:"Bash",cwd:$d,tool_input:{command:$c}}'; }
+# mcp_in <tool> <tool_input json>
+mcp_in() { jq -n --arg t "$1" --argjson i "$2" '{tool_name:$t,cwd:"/x",tool_input:$i}'; }
+PUB="$SCRATCH/public"
+
+# --- a term in the body, wherever it travels -----------------------------------
+check deny 'term in --body'          "$(bash_in "$PUB" 'gh issue create --title "Log rotation" --body "seen on Wanderlust last night"')"
+reason 'names the term'              'Wanderlust'
+no_reason 'never the surrounding text' 'last night'
+reason 'points at the private repo'  "--repo $PRIVATE"
+reason 'or rewrite'                  'rewrite the body'
+check deny 'term in --title'         "$(bash_in "$PUB" 'gh issue create -t "Wanderlust: AIS drops" -b "details below"')"
+check deny 'term in -b glued'        "$(bash_in "$PUB" 'gh pr comment 12 -b"tested on Wanderlust"')"
+check deny 'term in --body= form'    "$(bash_in "$PUB" 'gh issue edit 3 --body="host is gateway.home.example"')"
+check deny 'term in pr review body'  "$(bash_in "$PUB" 'gh pr review 9 --approve --body "ok from acct-4471"')"
+check deny 'term in issue close -c'  "$(bash_in "$PUB" 'gh issue close 3 -c "moved to Wanderlust log"')"
+check deny 'term in pr merge -b'     "$(bash_in "$PUB" 'gh pr merge 5 --squash -b "tested on wanderlust"')"
+check deny 'term after &&'           "$(bash_in "$PUB" 'git push && gh pr create --title x --body "cf Wanderlust"')"
+check deny 'term escaped mid-word'   "$(bash_in "$PUB" 'gh issue create -t x -b Wander\lust')"
+check deny 'term split across quotes' "$(bash_in "$PUB" "gh issue create -t x -b 'Wander'\"lust\"")"
+check deny 'term in sh -c'           "$(bash_in "$PUB" "sh -c 'gh issue create -t x -b \"on Wanderlust\"'")"
+check deny 'term in a heredoc'       "$(bash_in "$PUB" 'gh issue create -t x -F - <<'"'"'EOF'"'"'
+Steps:
+1. ssh to gateway.home.example
+EOF')"
+check deny 'term in a heredoc via variable' "$(bash_in "$PUB" 'body=$(cat <<EOF
+crew of Wanderlust
+EOF
+)
+gh issue create -t x -b "$body"')"
+
+printf 'reproduced aboard Wanderlust\n' > "$SCRATCH/body.md"
+printf 'nothing private here\n' > "$SCRATCH/clean.md"
+check deny 'term in --body-file'     "$(bash_in "$PUB" "gh issue create -t x --body-file $SCRATCH/body.md")"
+check deny 'term in -F, relative path' "$(bash_in "$SCRATCH" 'gh pr create -t x -F body.md')"
+check deny 'term in --body-file=~ path' "$(cp "$SCRATCH/body.md" "$HOME/b.md"; bash_in "$PUB" 'gh issue comment 4 --body-file=~/b.md')"
+check allow 'clean --body-file'      "$(bash_in "$PUB" "gh issue create -t x -F $SCRATCH/clean.md")"
+
+# --- case-insensitive, fixed strings ------------------------------------------
+check deny 'upper-case body, lower-case list' "$(bash_in "$PUB" 'gh issue create -t x -b "ACCT-4471 again"')"
+check deny 'mixed case'              "$(bash_in "$PUB" 'gh issue create -t x -b "WANDERLUST"')"
+check allow 'dot is literal, not any char' "$(bash_in "$PUB" 'gh issue create -t x -b "gatewayXhomeXexample"')"
+
+# --- MCP ------------------------------------------------------------------------
+check deny 'MCP create_issue body'   "$(mcp_in mcp__github__create_issue '{"owner":"mark-brannan","repo":"colregs","title":"x","body":"seen on Wanderlust"}')"
+check deny 'MCP add_issue_comment'   "$(mcp_in mcp__github__add_issue_comment '{"owner":"o","repo":"r","issue_number":3,"body":"ping gateway.home.example"}')"
+check deny 'MCP issue_write title'   "$(mcp_in mcp__github__issue_write '{"method":"create","owner":"o","repo":"r","title":"Wanderlust AIS"}')"
+check deny 'MCP review comment nested' "$(mcp_in mcp__github__create_pull_request_review '{"owner":"o","repo":"r","pullNumber":1,"event":"COMMENT","comments":[{"path":"a.ts","body":"acct-4471"}]}')"
+check allow 'MCP clean body'         "$(mcp_in mcp__github__create_issue '{"owner":"o","repo":"r","title":"x","body":"see mark-brannan/colregs#12"}')"
+check allow 'MCP private repo'       "$(mcp_in mcp__github__create_issue "{\"owner\":\"mark-brannan\",\"repo\":\"claude_prompts_scratch\",\"title\":\"x\",\"body\":\"Wanderlust\"}")"
+check allow 'MCP read tool ignored'  "$(mcp_in mcp__github__get_issue '{"owner":"o","repo":"r","issue_number":3}')"
+
+# --- gh api -------------------------------------------------------------------------
+check deny 'api POST issues -f body' "$(bash_in "$PUB" 'gh api repos/o/r/issues -f title=x -f body="aboard Wanderlust"')"
+check deny 'api -X PATCH'            "$(bash_in "$PUB" 'gh api -X PATCH repos/o/r/issues/3 -f body=gateway.home.example')"
+check deny 'api pulls review'        "$(bash_in "$PUB" 'gh api repos/o/r/pulls/3/reviews -f event=COMMENT -f body="acct-4471"')"
+check deny 'api graphql addComment'  "$(bash_in "$PUB" "gh api graphql -f query='mutation { addComment(input:{subjectId:\"I_1\", body:\"from Wanderlust\"}) { clientMutationId } }'")"
+check deny 'api -F body=@file'       "$(bash_in "$PUB" "gh api repos/o/r/issues/3/comments -F body=@$SCRATCH/body.md")"
+check allow 'api GET issues'         "$(bash_in "$PUB" 'gh api repos/o/r/issues --jq ".[].title"')"
+check allow 'api graphql read'       "$(bash_in "$PUB" "gh api graphql -f query='{ repository(owner:\"o\",name:\"r\"){ issue(number:3){ title } } }'")"
+check allow 'api private repo path'  "$(bash_in "$PUB" "gh api repos/$PRIVATE/issues -f title=x -f body=Wanderlust")"
+
+# --- the private repo is never scanned ------------------------------------------
+check allow '--repo private'         "$(bash_in "$PUB" "gh issue create --repo $PRIVATE -t x -b 'aboard Wanderlust'")"
+check allow '-R private, mixed case' "$(bash_in "$PUB" "gh issue create -R Mark-Brannan/Claude_Prompts_Scratch -t x -b Wanderlust")"
+check allow '--repo= URL form'       "$(bash_in "$PUB" "gh issue comment 3 --repo=https://github.com/$PRIVATE -b Wanderlust")"
+check allow 'GH_REPO= private'       "$(bash_in "$PUB" "GH_REPO=$PRIVATE gh issue create -t x -b Wanderlust")"
+check allow 'cwd origin is private'  "$(bash_in "$SCRATCH/private" 'gh issue create -t x -b "aboard Wanderlust"')"
+check deny 'cwd private but cd elsewhere' "$(bash_in "$SCRATCH/private" "cd $PUB && gh issue create -t x -b Wanderlust")"
+check deny 'cwd public'              "$(bash_in "$PUB" 'gh issue create -t x -b Wanderlust')"
+check deny 'cwd not a repo'          "$(bash_in "$SCRATCH/nogit" 'gh issue create -t x -b Wanderlust')"
+check deny 'one private, one public target' "$(bash_in "$PUB" "gh issue create --repo $PRIVATE -t x -b Wanderlust && gh issue comment 3 --repo o/r -b Wanderlust")"
+
+# --- reads and clean bodies pass ------------------------------------------------
+check allow 'gh issue list'          "$(bash_in "$PUB" 'gh issue list --label ready')"
+check allow 'gh pr view'             "$(bash_in "$PUB" 'gh pr view 12 --comments')"
+check allow 'gh pr checks'           "$(bash_in "$PUB" 'gh pr checks 12 --watch')"
+check allow 'clean body, public names and URLs' "$(bash_in "$PUB" 'gh issue create -t "Ruling: Q-14" -b "Argument in mark-brannan/colregs requirements.md; see https://github.com/mark-brannan/colregs-engine/pull/25 and claude_prompts_scratch#3"')"
+check allow 'no scannable text'      "$(bash_in "$PUB" 'gh pr merge 12 --squash --delete-branch')"
+check allow 'echo mentioning a gh write' "$(bash_in "$PUB" 'echo "gh issue create --body hi"')"
+check allow 'unrelated command'      "$(bash_in "$PUB" 'ls -la')"
+check allow 'empty command'          "$(jq -n '{tool_name:"Bash",tool_input:{}}')"
+check allow 'other tool'             "$(jq -n '{tool_name:"Read",tool_input:{file_path:"/x"}}')"
+
+# --- the gate is loud when it cannot see ------------------------------------------
+check deny '-F - with no heredoc'    "$(bash_in "$PUB" 'cat notes.md | gh issue create -t x -F -')"
+reason 'says stdin'                  'stdin'
+check allow '-F - with a clean heredoc' "$(bash_in "$PUB" 'gh issue create -t x -F - <<EOF
+all public
+EOF')"
+check deny 'body from $(...)'        "$(bash_in "$PUB" 'gh issue create -t x -b "$(cat notes.md)"')"
+reason 'says it is built at run time' 'run time'
+check deny 'body from $VAR, no heredoc' "$(bash_in "$PUB" 'gh pr comment 3 --body "$body"')"
+check allow '$VAR body fed by a clean heredoc' "$(bash_in "$PUB" 'b=$(cat <<EOF
+public text
+EOF
+); gh pr comment 3 --body "$b"')"
+check deny 'opaque $(...) beside an unrelated heredoc' "$(bash_in "$PUB" 'cat <<EOF
+hello
+EOF
+gh issue create -t x --body "$(cat notes.md)"')"
+reason 'says no heredoc feeds it'  'no heredoc in this command feeds it'
+check deny '$VAR from a file, heredoc elsewhere' "$(bash_in "$PUB" 'body=$(cat notes.md); cat <<EOF
+hi
+EOF
+gh pr comment 3 --body "$body"')"
+check deny 'missing --body-file'     "$(bash_in "$PUB" "gh issue create -t x -F $SCRATCH/absent.md")"
+reason 'names the file'              'absent.md'
+check allow 'missing --body-file, private repo' "$(bash_in "$PUB" "gh issue create --repo $PRIVATE -t x -F $SCRATCH/absent.md")"
+
+# denylist missing: a state repo with no private-terms.txt, and no repo at all
+EMPTY="$SCRATCH/empty"; mkdir -p "$EMPTY/.git" "$EMPTY/state/global"
+out=$(bash_in "$PUB" 'gh issue create -t x -b "all public"' | CLAUDE_STATE_REPO=$EMPTY sh "$HOOK" 2>&1); LAST=$out
+if printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then pass=$((pass + 1)); else fail=$((fail + 1)); echo "FAIL: denylist missing should deny: $out"; fi
+reason 'says the denylist is unreadable' 'denylist is unreadable'
+reason 'asks about the state repo'   'state repo checked out'
+reason 'offers the private repo'     "--repo $PRIVATE"
+out=$(bash_in "$PUB" 'gh issue create -t x -b "all public"' | CLAUDE_STATE_REPO='' sh "$HOOK" 2>&1)
+if printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then pass=$((pass + 1)); else fail=$((fail + 1)); echo "FAIL: no state repo anywhere should deny: $out"; fi
+out=$(bash_in "$PUB" "gh issue create --repo $PRIVATE -t x -b Wanderlust" | CLAUDE_STATE_REPO=$EMPTY sh "$HOOK" 2>&1)
+if [ -z "$out" ]; then pass=$((pass + 1)); else fail=$((fail + 1)); echo "FAIL: private repo needs no denylist: $out"; fi
+out=$(bash_in "$PUB" 'gh issue list' | CLAUDE_STATE_REPO=$EMPTY sh "$HOOK" 2>&1)
+if [ -z "$out" ]; then pass=$((pass + 1)); else fail=$((fail + 1)); echo "FAIL: a read needs no denylist: $out"; fi
+
+# comment and blank lines in the denylist are not terms
+check allow 'comment line is not a term' "$(bash_in "$PUB" 'gh issue create -t x -b "private terms -- lines starting"')"
+
+# no awk: deny, do not crash quiet
+mkdir -p "$SCRATCH/noawk"; for b in jq cat dirname mktemp rm sed grep tr git head; do ln -s "$(command -v $b)" "$SCRATCH/noawk/$b"; done
+out=$(bash_in "$PUB" 'gh issue create -t x -b hi' | PATH="$SCRATCH/noawk" /bin/sh "$HOOK" 2>&1); LAST=$out
+if printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then pass=$((pass + 1)); else fail=$((fail + 1)); echo "FAIL: awk absent should deny: $out"; fi
+reason 'names awk as missing'        'awk missing'
+
+printf '%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/.claude/hooks/public-issue-guard.test.sh
+++ b/.claude/hooks/public-issue-guard.test.sh
@@ -180,6 +180,16 @@ if [ -z "$out" ]; then pass=$((pass + 1)); else fail=$((fail + 1)); echo "FAIL: 
 out=$(bash_in "$PUB" 'gh issue list' | CLAUDE_STATE_REPO=$EMPTY sh "$HOOK" 2>&1)
 if [ -z "$out" ]; then pass=$((pass + 1)); else fail=$((fail + 1)); echo "FAIL: a read needs no denylist: $out"; fi
 
+# denylist present but empty: a readable file with no terms matches nothing,
+# which would let every post through looking exactly like a check that ran.
+BLANK="$SCRATCH/blank"; mkdir -p "$BLANK/.git" "$BLANK/state/global"
+printf '# comments only\n\n   \n' > "$BLANK/state/global/private-terms.txt"
+out=$(bash_in "$PUB" 'gh issue create -t x -b "all public"' | CLAUDE_STATE_REPO=$BLANK sh "$HOOK" 2>&1); LAST=$out
+if printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then pass=$((pass + 1)); else fail=$((fail + 1)); echo "FAIL: empty denylist should deny: $out"; fi
+reason 'says the denylist has no terms' 'no terms in it'
+out=$(bash_in "$PUB" "gh issue create --repo $PRIVATE -t x -b Wanderlust" | CLAUDE_STATE_REPO=$BLANK sh "$HOOK" 2>&1)
+if [ -z "$out" ]; then pass=$((pass + 1)); else fail=$((fail + 1)); echo "FAIL: private repo needs no denylist terms: $out"; fi
+
 # comment and blank lines in the denylist are not terms
 check allow 'comment line is not a term' "$(bash_in "$PUB" 'gh issue create -t x -b "private terms -- lines starting"')"
 

--- a/.claude/hooks/session-start-continuity.sh
+++ b/.claude/hooks/session-start-continuity.sh
@@ -11,6 +11,15 @@
 # work, what the last sessions left behind, and how much deciding the user has
 # already been asked to do this week.
 #
+# The board is not read here. It used to be: the first 16 bullets of
+# kanban.md, half of them ticked, ~4 KB into every session, and a bullet
+# above the first heading never printed at all. `worklist --brief` owns that
+# view now -- live PR and issue state plus the `## Claude's` cards, <= 3 KB by
+# its contract, served from cache so it is fast. This hook only caps the wait
+# at 6 s (a hung gh call must never hold session start) and clips the output
+# at 4 KB, so a broken worklist cannot become a 40 KB tax. Missing worklist
+# is reported, not worked around; the old dump is not a fallback.
+#
 # Never clones. A private clone needs credentials a hook cannot count on and
 # would stall session start on the network; absence is reported with the fix
 # instead of silently papered over.
@@ -76,6 +85,43 @@ fi
 
 SD="$SR/state/global"
 
+# Runs worklist --brief under a wall-clock cap. Background + sleep + kill
+# rather than timeout(1): macOS has no timeout, and one code path is one to
+# test. Both children get their stdio pointed away from this hook's pipe --
+# a child still holding it would keep jq reading until the child died.
+board_view() {
+  wl="$HOME/.local/bin/worklist"
+  if [ ! -x "$wl" ]; then
+    echo "worklist not installed -- live board view unavailable; this is not a clean state (run dotsync / cloud-session-setup.sh)"
+    return 0
+  fi
+  out=$(mktemp "${TMPDIR:-/tmp}/worklist-brief.XXXXXX") || return 0
+  "$wl" --brief >"$out" 2>/dev/null </dev/null &
+  wl_pid=$!
+  ( sleep 6; kill "$wl_pid" 2>/dev/null ) >/dev/null 2>&1 </dev/null &
+  wd_pid=$!
+  wait "$wl_pid" 2>/dev/null
+  rc=$?
+  kill "$wd_pid" 2>/dev/null
+  if [ "$rc" -gt 128 ]; then
+    echo "worklist --brief did not return in 6 s -- board view unavailable this session; run \`worklist --brief\` yourself"
+  elif [ "$rc" -ne 0 ]; then
+    echo "worklist --brief exited $rc -- board view unavailable this session; run \`worklist --brief\` yourself"
+  fi
+  head -c 4096 "$out"
+  rm -f "$out"
+}
+
+# A card written above the first "## " heading belongs to no section, so the
+# lint, worklist and every reader skip it. One line, so someone moves it.
+board_lint_warning() {
+  [ -f "$SD/kanban.md" ] || return 0
+  if awk '/^## / { exit } /^- \[/ { found = 1; exit } END { exit !found }' "$SD/kanban.md"; then
+    echo
+    echo "WARNING: kanban.md has a card above its first \`## \` heading -- no section, invisible to every reader. Move it under \`## Claude's\`."
+  fi
+}
+
 # Freshen the board, but never block session start on it.
 timeout 25 git -C "$SR" pull --rebase --autostash -q >/dev/null 2>&1 || true
 
@@ -86,25 +132,9 @@ timeout 25 git -C "$SR" pull --rebase --autostash -q >/dev/null 2>&1 || true
   echo "State repo: \`$SR\` (board, checkpoints and metrics live here; the Stop"
   echo "hook commits and pushes to it automatically -- no need to be asked)."
 
-  if [ -f "$SD/kanban.md" ]; then
-    echo
-    echo "### Open board items (\`state/global/kanban.md\`)"
-    echo
-    # Bullets under the first "## Backlog"-style heading onward, each folded
-    # back onto one line -- board items wrap over several lines, and printing
-    # only the first one turns "delete these three branches" into "delete".
-    awk '
-      /^## / { print ""; print "**" substr($0, 4) "**"; print "";
-               inb = 1; buf = ""; next }
-      !inb   { next }
-      /^(- |[0-9]+\. )/ { if (buf != "") { print buf; if (++n >= 16) exit }
-                          buf = $0; next }
-      /^[ \t]*$/       { if (buf != "") { print buf; buf = ""
-                                          if (++n >= 16) exit } next }
-                        { if (buf != "") buf = buf " " $0 }
-      END               { if (buf != "" && n < 16) print buf }
-    ' "$SD/kanban.md" | sed 's/[[:space:]][[:space:]]*/ /g' | cut -c1-260
-  fi
+  echo
+  board_view
+  board_lint_warning
 
   if [ -d "$SD/log/auto" ]; then
     recent=$(ls -t "$SD/log/auto"/*.md 2>/dev/null | head -3)

--- a/.claude/hooks/session-start-continuity.sh
+++ b/.claude/hooks/session-start-continuity.sh
@@ -14,7 +14,8 @@
 # The board is not read here. It used to be: the first 16 bullets of
 # kanban.md, half of them ticked, ~4 KB into every session, and a bullet
 # above the first heading never printed at all. `worklist --brief` owns that
-# view now -- live PR and issue state plus the `## Claude's` cards, <= 3 KB by
+# view now -- live PR and issue state plus the `## Needs ruling` and
+# `## Claude's` cards, <= 3 KB by
 # its contract, served from cache so it is fast. This hook only caps the wait
 # at 6 s (a hung gh call must never hold session start) and clips the output
 # at 4 KB, so a broken worklist cannot become a 40 KB tax. Missing worklist
@@ -118,7 +119,7 @@ board_lint_warning() {
   [ -f "$SD/kanban.md" ] || return 0
   if awk '/^## / { exit } /^- \[/ { found = 1; exit } END { exit !found }' "$SD/kanban.md"; then
     echo
-    echo "WARNING: kanban.md has a card above its first \`## \` heading -- no section, invisible to every reader. Move it under \`## Claude's\`."
+    echo "WARNING: kanban.md has a card above its first \`## \` heading -- no section, invisible to every reader. Move it under \`## Needs ruling\` or \`## Claude's\`."
   fi
 }
 

--- a/.claude/hooks/session-start-continuity.test.sh
+++ b/.claude/hooks/session-start-continuity.test.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Tests for session-start-continuity.sh. Run: bash .claude/hooks/session-start-continuity.test.sh
+# Set AWK_PATH to a directory whose `awk` is another implementation (mawk,
+# original-awk) to check portability; CI runs it under all three.
+#
+# What matters: the board comes from `worklist --brief` and nowhere else; a
+# hung worklist costs at most 6 s and never loses the rest of the brief; a
+# missing worklist is named, not papered over; a card above the first heading
+# is called out instead of silently dropped; the state-repo-missing message is
+# unchanged. HOME and the state repo are both fakes under a scratch dir.
+set -uo pipefail
+[ -n "${AWK_PATH:-}" ] && PATH="$AWK_PATH:$PATH"
+
+HOOK="$(cd "$(dirname "$0")" && pwd)/session-start-continuity.sh"
+pass=0; fail=0
+SCRATCH=$(mktemp -d); trap 'rm -rf "$SCRATCH"' EXIT
+export TMPDIR="$SCRATCH/tmp"; mkdir -p "$TMPDIR"
+export HOME="$SCRATCH/home"; mkdir -p "$HOME/.local/bin" "$SCRATCH/bin"
+unset CLAUDE_CODE_REMOTE
+
+# git must not reach the network from a hook test; the pull is a courtesy.
+printf '#!/bin/sh\nexit 0\n' > "$SCRATCH/bin/git"; chmod +x "$SCRATCH/bin/git"
+export PATH="$SCRATCH/bin:$PATH"
+
+STATE="$SCRATCH/state"; SD="$STATE/state/global"
+export CLAUDE_STATE_REPO="$STATE"
+reset_state() {
+  rm -rf "$STATE"
+  mkdir -p "$STATE/.git" "$SD/log/auto" "$SD/metrics/decisions"
+  printf -- '- session abc — worked on the thing\n- next: more thing\n\n## Uncommitted at Stop\n M foo.sh\n\n## Other\n' \
+    > "$SD/log/auto/2026-01-01-1200-abc.md"
+  printf '{"ts":"%s","type":"gate"}\n{"ts":"%s","type":"scoping"}\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$SD/metrics/decisions/x.jsonl"
+  printf '# Board\n\n## Claude'"'"'s\n\n- [ ] Ordinary card https://example.invalid/1\n- [x] TICKED-CARD-TEXT https://example.invalid/2\n\n## Yours\n\n- [ ] LEGACY-SECTION-CARD https://example.invalid/3\n' \
+    > "$SD/kanban.md"
+}
+# worklist_shim <body>   -- installs $HOME/.local/bin/worklist with the given sh body
+worklist_shim() { printf '#!/bin/sh\n%s\n' "$1" > "$HOME/.local/bin/worklist"; chmod +x "$HOME/.local/bin/worklist"; }
+no_worklist() { rm -f "$HOME/.local/bin/worklist"; }
+
+# run  -- executes the hook, sets CTX (additionalContext) and ELAPSED (seconds)
+run() {
+  local out t0 t1
+  t0=$(date +%s)
+  out=$(printf '{"session_id":"t","hook_event_name":"SessionStart"}' | bash "$HOOK" 2>"$SCRATCH/stderr")
+  t1=$(date +%s)
+  ELAPSED=$((t1 - t0))
+  CTX=$(printf '%s' "$out" | jq -r '.hookSpecificOutput | select(.hookEventName == "SessionStart") | .additionalContext' 2>/dev/null)
+  RAW=$out
+}
+ok()   { pass=$((pass + 1)); }
+bad()  { fail=$((fail + 1)); printf 'FAIL: %s\n' "$1"; [ -n "${2:-}" ] && printf '  %s\n' "$2"; }
+has()    { if printf '%s' "$CTX" | grep -Fq -- "$2"; then ok; else bad "$1 (context lacks [$2])" "$(printf '%s' "$CTX" | head -20)"; fi; }
+lacks()  { if printf '%s' "$CTX" | grep -Fq -- "$2"; then bad "$1 (context has [$2])"; else ok; fi; }
+valid_json() { if [ -n "$CTX" ]; then ok; else bad "$1: no SessionStart additionalContext" "$RAW"; fi; }
+
+# --- worklist present and fast -----------------------------------------------
+reset_state
+worklist_shim 'echo "as of 12:00Z (cached 3 min)"; echo "## Board"; echo "- WORKLIST-BOARD-LINE https://example.invalid/9"'
+run
+valid_json 'fast worklist'
+has   'worklist output is the board'          'as of 12:00Z (cached 3 min)'
+has   'worklist board line carried through'    'WORKLIST-BOARD-LINE'
+lacks 'no kanban dump: ticked card absent'     'TICKED-CARD-TEXT'
+lacks 'no kanban dump: legacy section absent'  'LEGACY-SECTION-CARD'
+lacks 'old heading gone'                       'Open board items'
+lacks 'no missing-worklist line'               'worklist not installed'
+lacks 'no lint warning on a clean board'       'WARNING: kanban.md'
+has   'checkpoints still printed'              'Where recent sessions left off'
+has   'checkpoint session line'                'session abc'
+has   'decision load still printed'            'Decision load, last 7 days'
+has   'state repo line kept'                   "State repo: \`$STATE\`"
+if [ "$ELAPSED" -le 3 ]; then ok; else bad "fast worklist took ${ELAPSED}s"; fi
+
+# --- worklist missing ------------------------------------------------------
+reset_state; no_worklist
+run
+valid_json 'missing worklist'
+has   'names the gap'                          'worklist not installed -- live board view unavailable; this is not a clean state (run dotsync / cloud-session-setup.sh)'
+lacks 'no dump as fallback'                    'TICKED-CARD-TEXT'
+has   'rest of brief intact'                   'Decision load, last 7 days'
+
+# --- worklist hangs --------------------------------------------------------
+reset_state
+worklist_shim 'echo "as of 12:00Z"; sleep 30; echo "NEVER-PRINTED"'
+run
+valid_json 'hung worklist'
+if [ "$ELAPSED" -le 8 ]; then ok; else bad "hung worklist: hook took ${ELAPSED}s, cap is 8"; fi
+has   'says it timed out'                      'did not return in 6 s'
+has   'partial output kept'                    'as of 12:00Z'
+lacks 'nothing after the kill'                 'NEVER-PRINTED'
+has   'checkpoints survive the timeout'        'Where recent sessions left off'
+has   'decision load survives the timeout'     'Decision load, last 7 days'
+
+# --- worklist fails --------------------------------------------------------
+reset_state
+worklist_shim 'echo "no gh"; exit 2'
+run
+has   'nonzero exit named'                     'worklist --brief exited 2'
+has   'its own failure line kept'              'no gh'
+
+# --- worklist over budget is clipped ------------------------------------------
+reset_state
+worklist_shim 'echo "as of 12:00Z"; awk '"'"'BEGIN { for (i = 0; i < 400; i++) print "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" }'"'"
+run
+n=$(printf '%s' "$CTX" | wc -c)
+if [ "$n" -lt 6000 ]; then ok; else bad "oversize worklist not clipped: context is $n bytes"; fi
+has   'clipped output still starts with the stamp' 'as of 12:00Z'
+
+# --- card above the first heading ----------------------------------------------
+reset_state
+worklist_shim 'echo "as of 12:00Z"'
+printf -- '# Board\n\n- [ ] ORPHAN-CARD https://example.invalid/4\n\n## Claude'"'"'s\n\n- [ ] fine https://example.invalid/5\n' > "$SD/kanban.md"
+run
+has   'orphan card warned'                     "WARNING: kanban.md has a card above its first \`## \` heading"
+reset_state
+printf -- '# Board\n\nProse intro, not a card.\n\n## Claude'"'"'s\n\n- [ ] fine https://example.invalid/5\n' > "$SD/kanban.md"
+run
+lacks 'prose above heading is not a card'      'WARNING: kanban.md'
+reset_state
+printf -- '## Claude'"'"'s\n\n- [x] ticked https://example.invalid/6\n' > "$SD/kanban.md"
+run
+lacks 'ticked card under a heading: no orphan warning' 'WARNING: kanban.md'
+rm -f "$SD/kanban.md"
+run
+lacks 'no kanban file: no warning'             'WARNING: kanban.md'
+
+# --- state repo missing ----------------------------------------------------
+rm -rf "$STATE"
+worklist_shim 'echo "as of 12:00Z"'
+run
+valid_json 'state repo missing'
+has   'existing message unchanged'             '## Continuity: state repo NOT available'
+has   'names the fix'                          'mcp__Claude_Code_Remote__add_repo'
+lacks 'worklist not run without a state repo'  'as of 12:00Z'
+
+# --- no jq at all: silent, exit 0 -------------------------------------------
+reset_state
+mkdir -p "$SCRATCH/nojq"; for b in bash sh dirname cat mktemp head sed awk date; do ln -s "$(command -v $b)" "$SCRATCH/nojq/$b" 2>/dev/null; done
+out=$(printf '{}' | PATH="$SCRATCH/nojq" bash "$HOOK" 2>&1); rc=$?
+if [ -z "$out" ] && [ "$rc" -eq 0 ]; then ok; else bad "without jq should be silent and exit 0" "rc=$rc out=$out"; fi
+
+printf '%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/.claude/hooks/stop-continuity.sh
+++ b/.claude/hooks/stop-continuity.sh
@@ -218,17 +218,29 @@ fi
 # checkpoint; a missing lint is treated the same way, never as a pass.
 board=state/global/kanban.md
 board_ok=1
+# If a human had already staged board edits, the unstage below must not eat
+# them: remember the exact staged blob and put it back in the index once this
+# hook is done committing.
+board_pre_blob=
+git diff --cached --quiet -- "$board" 2>/dev/null || board_pre_blob=$(git rev-parse ":$board" 2>/dev/null)
+restore_board() {
+  [ -n "$board_pre_blob" ] || return 0
+  git update-index --cacheinfo "100644,$board_pre_blob,$board" >/dev/null 2>&1
+}
 if [ -n "$(git status --porcelain -- "$board" 2>/dev/null)" ]; then
   if [ -f "$HOOK_DIR/kanban-lint.sh" ]; then
     lint_out=$(sh "$HOOK_DIR/kanban-lint.sh" --diff "$SR" "$board" 2>&1) || board_ok=0
   else
     lint_out="kanban-lint.sh is missing from $HOOK_DIR, so the board could not be linted"; board_ok=0
   fi
-  [ "$board_ok" = 1 ] || printf '\n## Board NOT committed\n\n`%s` failed kanban-lint; its edits stay uncommitted in the working tree. Fix or delete the lines, then commit by hand or let the next Stop try again.\n\n```\n%s\n```\n' "$board" "$lint_out" >> "$ckpt"
+  [ "$board_ok" = 1 ] || printf '\n## Board NOT committed\n\n`%s` failed kanban-lint; its edits stay uncommitted in the working tree (anything you had already staged for it is left staged). Fix or delete the lines, then commit by hand or let the next Stop try again.\n\n```\n%s\n```\n' "$board" "$lint_out" >> "$ckpt"
 fi
 
 git add state/ >/dev/null 2>&1
-[ "$board_ok" = 1 ] || git reset -q -- "$board" >/dev/null 2>&1
+if [ "$board_ok" != 1 ]; then
+  git reset -q -- "$board" >/dev/null 2>&1
+  [ -n "$board_pre_blob" ] && trap restore_board EXIT
+fi
 git diff --cached --quiet 2>/dev/null && exit 0   # nothing changed
 
 git -c user.name="${GIT_AUTHOR_NAME:-Claude}" \

--- a/.claude/hooks/stop-continuity.sh
+++ b/.claude/hooks/stop-continuity.sh
@@ -211,7 +211,24 @@ if [ -f .gitattributes ] && grep -qE '(^|[[:space:]])filter=' .gitattributes; th
   done
 fi
 
+# The board is linted before it is staged. This hook commits and pushes at
+# every Stop, so a card that restates a PR's state or a line ticked instead
+# of deleted would be in history before anyone read it. A failing lint
+# leaves the board's edits in the working tree and names them in the
+# checkpoint; a missing lint is treated the same way, never as a pass.
+board=state/global/kanban.md
+board_ok=1
+if [ -n "$(git status --porcelain -- "$board" 2>/dev/null)" ]; then
+  if [ -f "$HOOK_DIR/kanban-lint.sh" ]; then
+    lint_out=$(sh "$HOOK_DIR/kanban-lint.sh" --diff "$SR" "$board" 2>&1) || board_ok=0
+  else
+    lint_out="kanban-lint.sh is missing from $HOOK_DIR, so the board could not be linted"; board_ok=0
+  fi
+  [ "$board_ok" = 1 ] || printf '\n## Board NOT committed\n\n`%s` failed kanban-lint; its edits stay uncommitted in the working tree. Fix or delete the lines, then commit by hand or let the next Stop try again.\n\n```\n%s\n```\n' "$board" "$lint_out" >> "$ckpt"
+fi
+
 git add state/ >/dev/null 2>&1
+[ "$board_ok" = 1 ] || git reset -q -- "$board" >/dev/null 2>&1
 git diff --cached --quiet 2>/dev/null && exit 0   # nothing changed
 
 git -c user.name="${GIT_AUTHOR_NAME:-Claude}" \

--- a/.claude/rules/code.md
+++ b/.claude/rules/code.md
@@ -244,8 +244,8 @@ public" section.
   review, CI chasing, branch cleanup) costs far more than its wall-clock
   suggests. Scope these tightly; prefer one considered pass over iterative
   poking.
-- **Park open questions somewhere durable** — the project's board per
-  CLAUDE.md "Open loops", or ask directly when the answer blocks the task —
+- **Park open questions somewhere durable** — as an issue or card per
+  `/card-write`, or ask directly when the answer blocks the task —
   never only in session scrollback. A question that lives solely in a
   session's last response is invisible the moment that session scrolls out
   of view.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -197,8 +197,7 @@
             "command": "h=\"$HOME/.claude/hooks/no-late-pr-subscribe.sh\"; [ -f \"$h\" ] && bash \"$h\" || true"
           }
         ]
-      }
-,
+      },
       {
         "matcher": "Bash|mcp__.*github.*__.*",
         "hooks": [
@@ -206,6 +205,16 @@
             "type": "command",
             "command": "h=\"$HOME/.claude/hooks/pr-ownership-context.sh\"; [ -f \"$h\" ] && sh \"$h\" || true",
             "statusMessage": "Loading the PR ownership rules"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash|mcp__.*__(create_issue|update_issue|issue_write|add_issue_comment|create_pull_request|update_pull_request|add_pull_request_review_comment|create_pull_request_review|pull_request_review_write|add_comment_to_pending_review|create_and_submit_pull_request_review|submit_pending_pull_request_review)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "h=\"$HOME/.claude/hooks/public-issue-guard.sh\"; { [ -f \"$h\" ] && sh \"$h\"; } || printf '%s\\n' '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"public-issue-guard.sh is missing from $HOME/.claude/hooks or crashed, so the issue or PR text could not be checked against the private-terms list. This is a gate and fails closed: run dotsync (or cloud-session-setup.sh) and retry.\"}}'",
+            "statusMessage": "Checking issue/PR text against the private-terms list"
           }
         ]
       }
@@ -218,6 +227,16 @@
             "command": "p=$(cat); [ \"$(printf '%s' \"$p\" | jq -r '.stop_hook_active // false' 2>/dev/null)\" = true ] && exit 0; h=\"$HOME/.claude/hooks/pr-threads-gate.sh\"; { [ -f \"$h\" ] && printf '%s' \"$p\" | sh \"$h\"; } || printf '%s\\n' '{\"decision\":\"block\",\"reason\":\"pr-threads-gate.sh is missing from $HOME/.claude/hooks or crashed, so review threads on the PR this session worked could not be re-checked. This is a gate and fails closed: if you touched a PR this session, state per thread id which are resolved and which are open, then end the turn again.\"}'",
             "timeout": 60,
             "statusMessage": "Re-checking review threads on PRs this session touched"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "p=$(cat); [ \"$(printf '%s' \"$p\" | jq -r '.stop_hook_active // false' 2>/dev/null)\" = true ] && exit 0; h=\"$HOME/.claude/hooks/kanban-gate.sh\"; { [ -f \"$h\" ] && printf '%s' \"$p\" | sh \"$h\"; } || printf '%s\\n' '{\"decision\":\"block\",\"reason\":\"kanban-gate.sh is missing from $HOME/.claude/hooks or crashed, so uncommitted kanban.md changes in the state repo could not be linted. This is a gate and fails closed: run dotsync (or cloud-session-setup.sh) and retry; if you edited kanban.md this session, say which cards changed, then end the turn again.\"}'",
+            "timeout": 30,
+            "statusMessage": "Linting uncommitted kanban.md changes in the state repo"
           }
         ]
       },
@@ -246,6 +265,15 @@
           {
             "type": "command",
             "command": "h=\"$HOME/.claude/hooks/prose-budget-edit.sh\"; [ -f \"$h\" ] && bash \"$h\" || true"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "h=\"$HOME/.claude/hooks/kanban-lint.sh\"; [ -f \"$h\" ] && sh \"$h\" || true"
           }
         ]
       },

--- a/.claude/skills/card-helper/SKILL.md
+++ b/.claude/skills/card-helper/SKILL.md
@@ -11,12 +11,12 @@ their screen outranks anything you believe about it.
 
 ## Pick the card
 
-Find the board the way `/card-write` says to; its routing rules are the
-contract, don't paraphrase them here. Read the whole file, then default to
-walking one card from `## Solace's` (older boards: `## Yours`):
+Find it the way `/card-write` routes; its rules are the contract, don't
+paraphrase them here. A `needs-ruling` or assigned issue is walked exactly
+like a card. The board's one section is `## Claude's`, so the default is
+the issue Solace names, or the oldest `needs-ruling` issue `worklist` shows:
 that's the work only the user can close, which is what this skill is for.
-If the argument names a different card or section, walk that one instead.
-Never start a second card without being asked.
+Never start a second one without being asked.
 
 ## Load the real context first
 
@@ -68,13 +68,15 @@ same step. Losing their position is the one thing worse than a wrong step.
 
 ## Closing the card
 
-When the card is done, close it the way the board says to, and commit with
-a message naming what was closed. Say in one line what changed and stop.
+When the card is done, delete it and commit with a message naming what
+was closed. A `needs-ruling` issue stays open until the PR that lands the
+ruling closes it; an assigned issue closes when Solace says the action is
+done. Say in one line what changed and stop.
 
-If the walk stalls, write what you learned **into the card** before ending
-— the step that failed, what the UI actually showed, what would unblock
-it. A card that has been half-walked twice with nothing recorded is worse
-than one nobody touched.
+If the walk stalls, write what you learned **into the card or issue**
+before ending — the step that failed, what the UI actually showed, what
+would unblock it. A loop that has been half-walked twice with nothing
+recorded is worse than one nobody touched.
 
 ## Cadence
 

--- a/.claude/skills/card-helper/SKILL.md
+++ b/.claude/skills/card-helper/SKILL.md
@@ -12,11 +12,11 @@ their screen outranks anything you believe about it.
 ## Pick the card
 
 Find it the way `/card-write` routes; its rules are the contract, don't
-paraphrase them here. A `needs-ruling` or assigned issue is walked exactly
-like a card. The board's one section is `## Claude's`, so the default is
-the issue Solace names, or the oldest `needs-ruling` issue `worklist` shows:
-that's the work only the user can close, which is what this skill is for.
-Never start a second one without being asked.
+paraphrase them here. An issue is walked exactly like a card. The default
+is the card or issue Solace names, or the oldest card under `## Needs
+ruling` that `worklist` shows: that's the work only the user can close,
+which is what this skill is for. Never start a second one without being
+asked.
 
 ## Load the real context first
 
@@ -69,9 +69,9 @@ same step. Losing their position is the one thing worse than a wrong step.
 ## Closing the card
 
 When the card is done, delete it and commit with a message naming what
-was closed. A `needs-ruling` issue stays open until the PR that lands the
-ruling closes it; an assigned issue closes when Solace says the action is
-done. Say in one line what changed and stop.
+was closed. A `## Needs ruling` card stays on the board until the ruling
+has landed somewhere durable — the PR, the ADR, the doc it settles — then
+the same commit deletes the card. Say in one line what changed and stop.
 
 If the walk stalls, write what you learned **into the card or issue**
 before ending — the step that failed, what the UI actually showed, what

--- a/.claude/skills/card-write/SKILL.md
+++ b/.claude/skills/card-write/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: card-write
-description: Route an open loop to its one home — a GitHub issue, or a card on a kanban.md board in the house format: one line, imperative, link mandatory. Use whenever a loop is found that must be captured ("card that", "add a card", "put it on the board", "file that", a unilateral call, a finding that doesn't belong in this session). Not for walking a card or issue with the user — that is /card-helper.
+description: Route an open loop to its one home — work it around, a GitHub issue, or a card on a kanban.md board in the house format: one line, imperative, link mandatory. Use whenever a loop is found that must be captured ("card that", "add a card", "put it on the board", "file that", a unilateral call, a finding that doesn't belong in this session). Not for walking a card or issue with the user — that is /card-helper.
 ---
 
 # Writing a card
@@ -11,19 +11,26 @@ exact wording still exist.
 
 ## Where the loop lives
 
-One home per fact. GitHub owns work state; the board holds only what has
-no GitHub home. Take the first line that fits:
+One home per fact. GitHub owns work state; the board holds what has no
+GitHub home. Take the first line that fits:
 
 - **Work state** — open, merged, closed, CI, threads — lives on the PR or
   issue and nowhere else. Never write it down; `worklist` reads it live.
-- **A question only Solace can answer** → an issue labelled `needs-ruling`,
-  in the repo where the ruling lands. Body: one line plus a link to where
-  the argument lives (a `requirements.md` Q-nn, an ADR draft, or "context:
-  private log <slug>"). Solace rules with a comment starting `Ruled`; the PR
-  that lands the ruling closes the issue. The ruling itself goes in the
-  repo, via that PR — the log records the link only.
-- **An action only Solace can do** — install, flash, email, click → an issue
-  assigned to him.
+- **A question only Solace can answer** → **work around it.** Decide it
+  yourself, record the assumption where the work lands — the PR body or the
+  commit message — and carry on. Most rulings get deferred anyway, so a
+  question parked on a board is usually a question that never gets answered;
+  a decision with its assumption written down is reversible work.
+- **A one-way door** — a choice that would cost more than a session to
+  reverse — → a card under `## Needs ruling`. One line, imperative
+  question, with a link to where the argument lives (a `requirements.md`
+  Q-nn, an ADR draft, a PR). That is the only kind of question that earns a
+  card. There is no `needs-ruling` label and no ruling issue.
+- **The issue bar** — an issue is filed only when a fresh session could
+  start work from the body alone: a link to evidence **and** a concrete next
+  action, or real work with a real owner. Status mirrors, notes, vague
+  loops and "review/merge X" are never issues. Below that bar it is a log
+  line or nothing.
 - **Public or private repo?** An issue goes on the public repo when its
   text passes the private-terms check — `state/global/private-terms.txt`
   in the state repo, read by path and never copied. When it would fail,
@@ -38,8 +45,8 @@ no GitHub home. Take the first line that fits:
 - **Half-done agent work** → the log and the hand-off prompt, as bare
   links with no state adjectives. A pushed branch has a PR or is a
   finding.
-- **An agent rabbit-trail** not worth a public issue, or too private for
-  one → a card. That is the only thing a card is for.
+- **An agent rabbit-trail** not worth an issue, or too private for one →
+  a card under `## Claude's`.
 
 ## The board
 
@@ -50,9 +57,12 @@ create a board unilaterally. A public repo's board never carries boats,
 hosts or services — those cards go global, with a link back. Dotfiles has
 no board: its cards go global.
 
-A board has one section, `## Claude's`. `## Solace's` (older boards:
-`## Yours`) is retired — Solace's loops are issues, and their GitHub
-"Assigned" tab is where he sees them.
+A board has two sections, in this order:
+
+- `## Needs ruling` — one-way doors waiting on Solace. Normally empty.
+- `## Claude's` — agent rabbit-trails with no GitHub home.
+
+`## Solace's` (older boards: `## Yours`) is retired.
 
 ## The line
 
@@ -77,10 +87,11 @@ repo's uncommitted board diff again at Stop. It rejects:
 
 1. a ticked box — `- [x]`;
 2. a bullet above the first `## ` heading;
-3. a heading other than `## Claude's`;
+3. a heading other than `## Needs ruling` or `## Claude's`;
 4. a card whose verb is review, merge, land, bump, close, approve, ship,
    ratify, rule on, decide, confirm, answer or watch, pointing at a
-   `/pull/N` or `/issues/N` — that loop's home is the PR or issue;
+   `/pull/N` or `/issues/N` — that loop's home is the PR or issue. Not
+   applied under `## Needs ruling`, where "decide X on PR N" is the point;
 5. a state word: merged, awaiting, not merged, CI green, open as;
 6. a card with no link.
 

--- a/.claude/skills/card-write/SKILL.md
+++ b/.claude/skills/card-write/SKILL.md
@@ -9,6 +9,14 @@ A card is capture, not activation: the work still waits for a pull. Write
 it the moment the loop is found, while the comment link, timestamp and
 exact wording still exist.
 
+**The default owner is you.** An item exists because an agent found work: do
+the work, or prove there is none and close it with the proof. Handing an item
+to Solace needs a written reason.
+
+**A migration is a triage, never a copy.** A bulk move between trackers applies
+the destination's bar to every item and records the counts kept and dropped;
+what cannot be restated from scratch closes rather than moves.
+
 ## Where the loop lives
 
 One home per fact. GitHub owns work state; the board holds what has no
@@ -18,49 +26,52 @@ GitHub home. Take the first line that fits:
   issue and nowhere else. Never write it down; `worklist` reads it live.
 - **A question only Solace can answer** → **work around it.** Decide it
   yourself, record the assumption where the work lands — the PR body or the
-  commit message — and carry on. Most rulings get deferred anyway, so a
-  question parked on a board is usually a question that never gets answered;
-  a decision with its assumption written down is reversible work.
+  commit message — and carry on. A parked question is usually one that never
+  gets answered; a recorded assumption is reversible work.
 - **A one-way door** — a choice that would cost more than a session to
   reverse — → a card under `## Needs ruling`. One line, imperative
   question, with a link to where the argument lives (a `requirements.md`
   Q-nn, an ADR draft, a PR). That is the only kind of question that earns a
   card. There is no `needs-ruling` label and no ruling issue.
-- **The issue bar** — an issue is filed only when a fresh session could
-  start work from the body alone: a link to evidence **and** a concrete next
-  action, or real work with a real owner. Status mirrors, notes, vague
-  loops and "review/merge X" are never issues. Below that bar it is a log
-  line or nothing.
-- **Public or private repo?** An issue goes on the public repo when its
-  text passes the private-terms check — `state/global/private-terms.txt`
-  in the state repo, read by path and never copied. When it would fail,
-  the issue goes on `mark-brannan/claude_prompts_scratch` instead. The
-  public-issue guard refuses the public one anyway.
+- **The issue bar** — file an issue only when a fresh session could start
+  from the body alone: a link to the evidence **and** a next action an agent
+  can execute without asking. Verify/confirm notes, status mirrors, vague
+  loops, "review/merge X" and hand-chores only Solace can do are never
+  issues; a question with a defensible default is answered by taking the
+  default and recording it, not filed. Below that bar it is a log line or
+  nothing.
+- **Public or private repo?** An issue goes on the public repo when its text
+  passes the private-terms check — `state/global/private-terms.txt` in the
+  state repo, read by path, never copied. When it would fail it goes on
+  `mark-brannan/claude_prompts_scratch`; the public-issue guard refuses it
+  anyway.
 - **Agent-startable work** → an issue labelled `ready`. Unlabelled is
   untriaged, and only ever a count.
 - **Blocked** → label `blocked`, plus a body line `Blocked by owner/repo#N`.
 - **Deferred to after 1.0** → the `1.0` milestone.
 - **A launchable session** — prompt written, model and effort sized → the
   epic file's session list; a `ready` issue when no epic owns it.
-- **Half-done agent work** → the log and the hand-off prompt, as bare
-  links with no state adjectives. A pushed branch has a PR or is a
-  finding.
+- **Half-done agent work** → the log and the hand-off prompt, as bare links
+  with no state adjectives. A pushed branch has a PR or is a finding.
 - **An agent rabbit-trail** not worth an issue, or too private for one →
   a card under `## Claude's`.
 
 ## The board
 
 Every project keeps one board: `kanban.md` at the repo root, or the path
-its own CLAUDE.md names. A loop that belongs to no project, or a repo with
-no board, goes to `~/claude_prompts_scratch/state/global/kanban.md`; don't
-create a board unilaterally. A public repo's board never carries boats,
-hosts or services — those cards go global, with a link back. Dotfiles has
-no board: its cards go global.
+its own CLAUDE.md names. A loop that belongs to no project, or a repo with no
+board, goes to `~/claude_prompts_scratch/state/global/kanban.md`; don't create
+a board unilaterally. A public repo's board never carries boats, hosts or
+services — those cards go global. Dotfiles has no board: its cards go global.
 
 A board has two sections, in this order:
 
 - `## Needs ruling` — one-way doors waiting on Solace. Normally empty.
-- `## Claude's` — agent rabbit-trails with no GitHub home.
+  Its cards are grouped under `### <project>` subheadings — the
+  `project-<name>` GitHub topic `worklist` resolves, `### global` when no
+  project owns it. Put the card under its group, creating the group if it is
+  missing; `###` headings appear nowhere else on the board.
+- `## Claude's` — agent rabbit-trails with no GitHub home. One flat list.
 
 `## Solace's` (older boards: `## Yours`) is retired.
 
@@ -72,7 +83,8 @@ A board has two sections, in this order:
 
 - One line per card: a link, and the action in the imperative.
 - **The link is never optional** — a card nobody but its author can
-  resolve is not a card.
+  resolve is not a card. Neither is the action: a card that cannot state it
+  without private paths, hosts or ports is not ready to be one.
 - The short name or the link must be distinctive enough for a future
   session to find the card.
 - Add `blocked:` and the dependency only when the card is actually blocked.
@@ -87,25 +99,24 @@ repo's uncommitted board diff again at Stop. It rejects:
 
 1. a ticked box — `- [x]`;
 2. a bullet above the first `## ` heading;
-3. a heading other than `## Needs ruling` or `## Claude's`;
+3. a heading other than `## Needs ruling` or `## Claude's`, or a `###`
+   group heading outside `## Needs ruling`;
 4. a card whose verb is review, merge, land, bump, close, approve, ship,
    ratify, rule on, decide, confirm, answer or watch, pointing at a
    `/pull/N` or `/issues/N` — that loop's home is the PR or issue. Not
    applied under `## Needs ruling`, where "decide X on PR N" is the point;
 5. a state word: merged, awaiting, not merged, CI green, open as;
-6. a card with no link.
+6. a card with no link;
+7. a ruling card with no `### <project>` group above it.
 
 ## Lifecycle
 
 - **Cards die when done.** Delete the line, never tick it — this is a
   work-in-progress list, not a log; `git log` and the session logs keep
   the history.
-- Keep the board short: 15 cards or fewer. Past about 20, some repo needs
-  issues. A list nobody can hold in their head is a second place to lose
-  things; finish or delete before adding.
-- If a loop is not worth a card, it is not worth telling Solace about either.
+- Keep the board short: 15 cards or fewer. A list nobody can hold in their
+  head is a second place to lose things; finish or delete before adding.
 - A sweep — "reconcile", "what's outstanding", "what's stale" — is
   `worklist` and a report. It never edits a board, epic or log.
-- Commit the board in its own repo, and never stage one project's work
-  under another's. The Stop hook commits the global state repo; a project
-  board is committed with that project's work.
+- Commit the board in its own repo, never one project's work under
+  another's. The Stop hook commits the global state repo.

--- a/.claude/skills/card-write/SKILL.md
+++ b/.claude/skills/card-write/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: card-write
-description: Write or edit an open-loop card on a kanban.md board in the house format — one line, imperative, link mandatory, right section, right board. Use whenever a loop is found that must be captured ("card that", "add a card", "put it on the board", a unilateral call, a finding that doesn't belong in this session). Not for walking a card with the user — that is /card-helper.
+description: Route an open loop to its one home — a GitHub issue, or a card on a kanban.md board in the house format: one line, imperative, link mandatory. Use whenever a loop is found that must be captured ("card that", "add a card", "put it on the board", "file that", a unilateral call, a finding that doesn't belong in this session). Not for walking a card or issue with the user — that is /card-helper.
 ---
 
 # Writing a card
@@ -9,28 +9,50 @@ A card is capture, not activation: the work still waits for a pull. Write
 it the moment the loop is found, while the comment link, timestamp and
 exact wording still exist.
 
-## Which board
+## Where the loop lives
 
-- Every project keeps one board: `kanban.md` at the repo root, or the path
-  its own CLAUDE.md names.
-- A loop that belongs to no project, or the first card of a repo with no
-  board, goes to `~/claude_prompts_scratch/state/global/kanban.md`. Don't
-  create a board unilaterally — a card landing global is the signal to
-  decide whether that repo earns one.
-- A **question** goes to an issue; an **action** goes on a board.
-- A **public repo's board never carries boats, hosts or services.** Those
-  cards go global, with a link back.
-- Dotfiles has no board: its cards go global, and anything with a question
-  in it becomes a dotfiles issue the card links to.
+One home per fact. GitHub owns work state; the board holds only what has
+no GitHub home. Take the first line that fits:
 
-## Which section
+- **Work state** — open, merged, closed, CI, threads — lives on the PR or
+  issue and nowhere else. Never write it down; `worklist` reads it live.
+- **A question only Solace can answer** → an issue labelled `needs-ruling`,
+  in the repo where the ruling lands. Body: one line plus a link to where
+  the argument lives (a `requirements.md` Q-nn, an ADR draft, or "context:
+  private log <slug>"). Solace rules with a comment starting `Ruled`; the PR
+  that lands the ruling closes the issue. The ruling itself goes in the
+  repo, via that PR — the log records the link only.
+- **An action only Solace can do** — install, flash, email, click → an issue
+  assigned to him.
+- **Public or private repo?** An issue goes on the public repo when its
+  text passes the private-terms check — `state/global/private-terms.txt`
+  in the state repo, read by path and never copied. When it would fail,
+  the issue goes on `mark-brannan/claude_prompts_scratch` instead. The
+  public-issue guard refuses the public one anyway.
+- **Agent-startable work** → an issue labelled `ready`. Unlabelled is
+  untriaged, and only ever a count.
+- **Blocked** → label `blocked`, plus a body line `Blocked by owner/repo#N`.
+- **Deferred to after 1.0** → the `1.0` milestone.
+- **A launchable session** — prompt written, model and effort sized → the
+  epic file's session list; a `ready` issue when no epic owns it.
+- **Half-done agent work** → the log and the hand-off prompt, as bare
+  links with no state adjectives. A pushed branch has a PR or is a
+  finding.
+- **An agent rabbit-trail** not worth a public issue, or too private for
+  one → a card. That is the only thing a card is for.
 
-One file, two sections: `## Solace's` for loops only Solace can close, and
-`## Claude's` for loops an agent can. One file, not two, because the useful
-edges cross — an agent's card is routinely blocked on one of Solace's, and two
-files would show each list clear while the work sits deadlocked. Older
-boards still head the first section `## Yours`; treat it as the same section
-and don't rename it as a side effect of adding a card.
+## The board
+
+Every project keeps one board: `kanban.md` at the repo root, or the path
+its own CLAUDE.md names. A loop that belongs to no project, or a repo with
+no board, goes to `~/claude_prompts_scratch/state/global/kanban.md`; don't
+create a board unilaterally. A public repo's board never carries boats,
+hosts or services — those cards go global, with a link back. Dotfiles has
+no board: its cards go global.
+
+A board has one section, `## Claude's`. `## Solace's` (older boards:
+`## Yours`) is retired — Solace's loops are issues, and their GitHub
+"Assigned" tab is where he sees them.
 
 ## The line
 
@@ -48,14 +70,31 @@ and don't rename it as a side effect of adding a card.
 - **Order is priority.** The top card in a section is the next one to pull.
   Place a new card where it belongs, not at the bottom by default.
 
+## The lint
+
+`kanban-lint.sh` checks every edit to a `kanban.md`, and checks the state
+repo's uncommitted board diff again at Stop. It rejects:
+
+1. a ticked box — `- [x]`;
+2. a bullet above the first `## ` heading;
+3. a heading other than `## Claude's`;
+4. a card whose verb is review, merge, land, bump, close, approve, ship,
+   ratify, rule on, decide, confirm, answer or watch, pointing at a
+   `/pull/N` or `/issues/N` — that loop's home is the PR or issue;
+5. a state word: merged, awaiting, not merged, CI green, open as;
+6. a card with no link.
+
 ## Lifecycle
 
-- **Cards die when done.** Delete the line — this is a work-in-progress
-  list, not a log; `git log` and the session logs keep the history. A ticked
-  box is at most a placeholder until the next tidy.
-- Keep each section short. A list nobody can hold in their head is a second
-  place to lose things; finish or delete before adding.
+- **Cards die when done.** Delete the line, never tick it — this is a
+  work-in-progress list, not a log; `git log` and the session logs keep
+  the history.
+- Keep the board short: 15 cards or fewer. Past about 20, some repo needs
+  issues. A list nobody can hold in their head is a second place to lose
+  things; finish or delete before adding.
 - If a loop is not worth a card, it is not worth telling Solace about either.
+- A sweep — "reconcile", "what's outstanding", "what's stale" — is
+  `worklist` and a report. It never edits a board, epic or log.
 - Commit the board in its own repo, and never stage one project's work
   under another's. The Stop hook commits the global state repo; a project
   board is committed with that project's work.

--- a/.claude/skills/worklist/SKILL.md
+++ b/.claude/skills/worklist/SKILL.md
@@ -1,106 +1,48 @@
 ---
 name: worklist
-description: Report a project's overall status and the next unblocked work items, in one standard format, to help decide what to kick off in a new session, a subagent, or a stream. Use when Solace asks "what's next", "what can we work on", "project status", "what's on the roadmap", or "/worklist".
+description: Report a project's status and the next unblocked work, by running the worklist script and reading its output. Use when Solace asks "what's next", "what can we work on", "project status", "what's on the roadmap", "what's outstanding", "what's stale", "what's my turn", asks for a sweep or a reconcile, or says "/worklist".
 ---
 
-# Worklist: status + next work
+# Worklist
 
-Read-only. This skill never files issues, ticks boxes, or starts work — it
-answers "what's the state of things and what could a session pick up right
-now," then stops and lets Solace choose.
+Read-only. Run `~/.local/bin/worklist [project]` — add `--fresh` when Solace
+asks for current state rather than what the cache holds — read its output,
+add judgment only where a bucket needs it (a dependency the script can't
+see, which ready item you'd start first if asked), and stop. Never file,
+label, tick or edit anything from here: a sweep, a reconcile and "what's
+stale" are all this command plus a report, and they never touch a board,
+epic or log.
 
-## Which project, and which repos it spans
+## Output shape
 
-If Solace named a project, use it. If not, ask — one question, not a guess —
-unless the current repo makes it obvious.
-
-A project is usually **not** one repo. Resolve its full repo set before
-reading anything else:
-
-1. Check the epic file first (see below) — it typically states its scope up
-   front ("Spans colregs (data), colregs-engine (evaluator), searoom
-   (simulator/demo)..."). That line is the repo list.
-2. If there's no epic, or it doesn't name repos, check that project's own
-   `kanban.md` for repo links, and check whether a GitHub org/user search
-   (`gh repo list <owner> --limit 100 | grep -i <project>`) turns up
-   siblings — a data repo, an engine/library repo, a demo/app repo are the
-   common split.
-3. If still unclear, ask which repos count rather than guessing and missing
-   one — a worklist that silently skips a repo is worse than a slower start.
-
-Once resolved, treat every repo in the set as in scope for every step below.
-Name the repo alongside every item in the output — never let a multi-repo
-project's report read as if it were about one repo.
-
-## Where to look, in order
-
-Read narrowly and iteratively. Don't `cat` whole repos; grep for the
-project name, read the specific file a hit points to, stop once the picture
-is clear. If the sweep would take more than a few targeted reads — likely
-once there are 3+ repos — delegate it to an Explore agent (or one agent per
-repo, run concurrently) and take its summary rather than reading everything
-yourself.
-
-1. **Each repo's own `kanban.md`** (repo root, or wherever its own
-   CLAUDE.md says) — small loose cards, not epic-level plans. Check every
-   repo in the set; don't stop at the first one that has a board.
-2. **The global board** — `~/claude_prompts_scratch/state/global/kanban.md`
-   — for cards that fell out of sessions but belong to no project board.
-   Match on any repo in the set, not just the project's name as a string.
-3. **Epic files** — `~/claude_prompts_scratch/state/global/epics/*.md` —
-   grep for the project name or any repo in its set. An epic holds phases,
-   sessions, dependencies, and a `## Status` log; that log is the source
-   for the status summary, not your own inference from ticked boxes.
-4. **Public tracking issues** — if the epic names one (e.g. "public:
-   `<repo>#N`"), treat it as authoritative for phase *definitions* when the
-   epic says so; the epic file stays authoritative for session-level
-   sequencing and model/effort sizing.
-5. **Open GitHub issues in every repo in the set** —
-   `gh issue list --repo <owner>/<repo> --state open --json number,title`,
-   one call per repo. These are real, independently-startable work whether
-   or not they're on any board yet. A dependency can cross repos (an engine
-   phase waiting on a data-repo issue) — say so explicitly when it does.
-
-## Computing "unblocked"
-
-An item is ready now only if every dependency it names (`Depends:`, a
-blocking card, a prerequisite issue) is already done. Say what it depends
-on even when satisfied — don't just drop the dependency silently. Personal/
-learning items with no repo output are their own category: never blocking,
-never blocked by the rest.
-
-## Output format
-
-Always this shape, always cite a source (file, line, or issue link) for
-every claim — never assert a status you haven't just read.
+The script prints it; don't rewrite it into another format. First line
+`as of HH:MMZ` (`cached N min` when served from cache), then the repo set
+and the account-wide counts, then these buckets. An empty bucket prints
+`none` — that is "checked, nothing there", not a failure:
 
 ```
-# <Project> — status & next work
-_as of <date> · repos: <owner/repo1>, <owner/repo2>, ... + global board_
-
-## Status
-<1-3 lines from the epic's own Status log or board, with source>
-
-## Ready now (unblocked)
-- **<item>** — <repo/file it touches> — <recommended model, effort> —
-  <one line why it's ready> (<source link>)
-
-## Blocked
-- <item> — blocked on <dependency> (<source link>)
-
-## Personal / learning (parallel, non-blocking)
-- <item> (<source link>)
-
-## Needs Solace's decision first
-- <item> — <the one-line question> (<source link>)
+Solace's turn             PRs ready for her: not draft, mergeable, checks
+                          green, no unresolved threads, no auto-merge
+                          (failing check names printed, never a boolean)
+Queued (auto-merge)       auto-merge enabled, waiting on checks
+Needs ruling              `needs-ruling` issues with no `Ruled` comment
+Ruled, unlanded           `Ruled` comment present, landing PR not yet closed it
+Ready                     `ready` issues — agent-startable now
+Blocked                   `blocked` issues, with what blocks them
+Not ready (agent's turn)  open PRs that are none of the above, with why
+Untriaged: N              unlabelled issues, count only
+Stranded branches         pushed branches with no PR
+Board                     the `## Claude's` cards, at most 8
 ```
 
-Skip a section entirely rather than writing "none."
+Every line carries its repo; the full view carries links too, `--brief`
+does not. Failure lines are per cause — `no gh`, `gh unauthenticated`,
+`<repo>: 403 — attach the repo`, `network` — and a bucket missing for one
+of those reasons is not an empty bucket; say so.
 
 ## After reporting
 
-Stop. Don't recommend a single item unless asked — the point of this skill
-is to hand over the ranked list so Solace can pick what fits the moment
-(one session, a subagent, or a stream of several). If asked which one you'd
-start, give one sentence naming it before any explanation, per standing
-orders.
+Stop. Don't recommend a single item unless asked — the point is to hand
+over the list so Solace can pick what fits the moment (one session, a
+subagent, or a stream of several). If asked which one you'd start, give one
+sentence naming it before any explanation, per standing orders.

--- a/.claude/skills/worklist/SKILL.md
+++ b/.claude/skills/worklist/SKILL.md
@@ -25,13 +25,13 @@ Solace's turn             PRs ready for her: not draft, mergeable, checks
                           green, no unresolved threads, no auto-merge
                           (failing check names printed, never a boolean)
 Queued (auto-merge)       auto-merge enabled, waiting on checks
-Needs ruling              `needs-ruling` issues with no `Ruled` comment
-Ruled, unlanded           `Ruled` comment present, landing PR not yet closed it
 Ready                     `ready` issues — agent-startable now
 Blocked                   `blocked` issues, with what blocks them
 Not ready (agent's turn)  open PRs that are none of the above, with why
 Untriaged: N              unlabelled issues, count only
 Stranded branches         pushed branches with no PR
+Needs ruling              the board's `## Needs ruling` cards, at most 8 —
+                          one-way doors only, so normally empty
 Board                     the `## Claude's` cards, at most 8
 ```
 

--- a/.claude/skills/wrapup/SKILL.md
+++ b/.claude/skills/wrapup/SKILL.md
@@ -73,5 +73,6 @@ does not.
 End with a prompt, not a status bullet or observation. A closing that reads
 "the vague thing is borked, your call" costs a read and returns nothing
 actionable. The closing message holds exactly two things: the hand-off
-prompt, and links to the `needs-ruling` issues awaiting Solace. Nothing else
-goes in it.
+prompt, and links to the `## Needs ruling` cards awaiting Solace. Nothing
+else goes in it. If nothing hit a one-way door, that half is simply absent —
+a question you worked around is reported in the PR body, not here.

--- a/.claude/skills/wrapup/SKILL.md
+++ b/.claude/skills/wrapup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wrapup
-description: Close a session — write the narrative log to the right state repo, bring the session's cards for batch accept/edit/delete, and end with a paste-ready hand-off prompt. Use when Solace says "wrap up", "log it", "hand off", "hand-off prompt", "call it there", or when a session is ending with work still open.
+description: Close a session — write the narrative log to the right state repo, list the issues the session opened or labelled, and end with a paste-ready hand-off prompt. Use when Solace says "wrap up", "log it", "hand off", "hand-off prompt", "call it there", or when a session is ending with work still open.
 ---
 
 # Wrapping up
@@ -21,7 +21,7 @@ repo. Never stage one project's work under another's.
 | Symphony | `~/symphony/intermediate_files/claude_slop/` (`kanban.md` + `log.md`). Its human-facing `maintenance/log.md` and `priorities.md` get only finished, high-level results. |
 | Global and cross-cutting — standing orders, rules, hooks, Claude tooling, anything spanning projects | The private repo `~/claude_prompts_scratch`, under `state/global/kanban.md` and `state/global/log/`. Work on `main` there; `git pull --rebase` before pushing. |
 | Any project with no private repo of its own | The same global paths. |
-| Dotfiles | **Never** — it is public, and session notes name boats, hosts and services. Dotfiles has no board of its own: its cards sit on the global board, and anything with a question in it becomes a dotfiles issue the card links to. |
+| Dotfiles | **Never** — it is public, and session notes name boats, hosts and services. Dotfiles has no board of its own: its loops are dotfiles issues, or cards on the global board when they have no GitHub home. |
 | Any other project with its own board | That repo, at the path its CLAUDE.md names. |
 
 ## 2. Narrative log
@@ -31,39 +31,21 @@ auto-checkpoint records what happened; only you can record what it meant
 and what should happen next. The machine one is evidence, not a substitute.
 Put in it:
 
-- what was decided, and why — including calls that reversed or narrowed an
-  earlier one;
+- what was decided, and why — as a link to where each decision landed (the
+  Q-nn footnote, the ADR, the closed issue, the PR), including calls that
+  reversed or narrowed an earlier one. The log holds the link, not a copy;
 - what was tried and abandoned, so the next session doesn't retry it;
 - what comes next: the hand-off prompt from step 4, verbatim;
 - observations worth keeping. They go here, silently — never as an aside in
   chat.
 
-## 3. Cards
+## 3. Issues
 
-Bring every card written during the session for batch accept / edit /
-delete: one list, one line per card, each with its link. Apply Solace's
-decisions to the board before the session ends. Anything only Solace can do
-personally is a card, referenced by link and by a short name; either the
-link or the short name must be distinctive enough for a future session to
-find it.
-
-**Before surfacing any card that asks Solace to decide on or act on a PR
-(merge it, review it, close it), check its live state first** —
-`gh pr view <PR> --json state,mergedAt,mergeCommit` (or the equivalent for
-the board's existing PR cards, not just ones from this session). If it's
-already merged or closed, don't hand it to her as a decision: mark it done
-and note how, or drop it if it was already reflected on the board. If the
-check itself fails — `gh` errors, isn't authenticated, or the reply carries
-no `state` — that's not the same as "still open": leave the card pending
-and say its live state couldn't be verified, the same failure-closed stance
-`pr-threads-gate.sh` already takes. Only mark done or drop after a state
-check actually succeeds. This
-applies to every open PR card being carried forward, not only ones this
-session touched — a PR can merge after the session that filed the card
-ended. A card that asks them to decide something already decided outside
-the chat is wasted attention.
-
-Board selection and card format: `/card-write`.
+List the issues this session opened or labelled: one line each, with its
+link. Nothing else — no sweep of the board, no card batch to accept or
+delete, no checking what merged. State lives on GitHub and `worklist`
+reads it; a wrap-up that edits it is a second copy. Routing and format:
+`/card-write`.
 
 ## 4. Hand-off prompt
 
@@ -73,6 +55,11 @@ the next one. It must:
 - be **ready to paste** — no "as discussed", no context the reader has to
   supply;
 - name the **branch, PR, file, card, etc.** it acts on;
+- carry **links, not state adjectives** — `#42`, not "PR #42 (merged, CI
+  green)". State is read live at the other end; written down it is stale by
+  the time it's read;
+- **never ask Solace to review or merge.** The PR is where that lives, and
+  `worklist` shows him when it is his turn;
 - name a **recommended model and difficulty (effort) setting** — both,
   every time, e.g. `Model: opus · Effort: high`. A hand-off prompt missing
   either is not finished;
@@ -86,5 +73,5 @@ does not.
 End with a prompt, not a status bullet or observation. A closing that reads
 "the vague thing is borked, your call" costs a read and returns nothing
 actionable. The closing message holds exactly two things: the hand-off
-prompt, and the cards only Solace can act on, by link and short name. Nothing
-else goes in it.
+prompt, and links to the `needs-ruling` issues awaiting Solace. Nothing else
+goes in it.

--- a/.claude/skills/wrapup/SKILL.md
+++ b/.claude/skills/wrapup/SKILL.md
@@ -60,6 +60,10 @@ the next one. It must:
   the time it's read;
 - **never ask Solace to review or merge.** The PR is where that lives, and
   `worklist` shows him when it is his turn;
+- rate every item it puts in front of Solace **twice** — difficulty for
+  Solace, and difficulty for an agent with full permissions and high stakes —
+  and answer `could an agent do it: yes/no`. Low for an agent means do it, not
+  ask;
 - name a **recommended model and difficulty (effort) setting** — both,
   every time, e.g. `Model: opus · Effort: high`. A hand-off prompt missing
   either is not finished;

--- a/.github/workflows/hook-tests.yml
+++ b/.github/workflows/hook-tests.yml
@@ -36,7 +36,7 @@ jobs:
           for impl in mawk gawk original-awk; do
             d=$(mktemp -d)
             ln -s "$(command -v $impl)" "$d/awk"
-            for t in .claude/hooks/*.test.sh; do
+            for t in .claude/hooks/*.test.sh .local/bin/*.test.sh; do
               echo "::group::$t under $impl"
               if AWK_PATH=$d bash "$t"; then echo "ok"; else status=1; echo "::error::$t failed under $impl"; fi
               echo "::endgroup::"

--- a/.local/bin/cloud-session-setup.sh
+++ b/.local/bin/cloud-session-setup.sh
@@ -56,6 +56,7 @@ INSTALL="
 .claude/skills/card-helper/SKILL.md
 .claude/skills/card-write/SKILL.md
 .claude/skills/wrapup/SKILL.md
+.claude/skills/worklist/SKILL.md
 .claude/hooks/lib-state.sh
 .claude/hooks/session-metrics.jq
 .claude/hooks/lib-metrics-fmt.jq
@@ -82,9 +83,13 @@ INSTALL="
 .claude/hooks/connector-budget.sh
 .claude/hooks/prose-budget-commit.sh
 .claude/hooks/prose-budget-edit.sh
+.claude/hooks/kanban-lint.sh
+.claude/hooks/kanban-gate.sh
+.claude/hooks/public-issue-guard.sh
 .claude/hooks/fixtures
 .local/bin/metrics-preview.sh
 .local/bin/prose-budget
+.local/bin/worklist
 "
 
 # --- what is wholly owned by this installer -------------------------------

--- a/.local/bin/worklist
+++ b/.local/bin/worklist
@@ -361,8 +361,13 @@ render() {
     echo "$stamp"
     [ -n "$3" ] && echo "$3"
     if [ -n "$1" ]; then
-      jq -r --arg brief "$brief" "$RENDER" "$1" \
-        | awk -v r="$rulings" '$0 == "@@RULINGS@@" { if (r != "") { print r; print "" } ; next } { print }'
+      # The buckets come out of jq in one piece with a @@RULINGS@@ marker in
+      # them; the rulings are spliced in here rather than by awk, because a
+      # multi-line -v assignment is a syntax error in one-true-awk.
+      body=$(jq -r --arg brief "$brief" "$RENDER" "$1")
+      printf '%s' "${body%%@@RULINGS@@*}"
+      [ -n "$rulings" ] && printf '%s\n' "$rulings"
+      printf '%s\n' "${body#*@@RULINGS@@}"
     elif [ -n "$rulings" ]; then
       printf '%s\n\n' "$rulings"
     fi

--- a/.local/bin/worklist
+++ b/.local/bin/worklist
@@ -12,7 +12,7 @@
 # Anything that asks "what's stale / outstanding / next" runs this and
 # reports; nothing edits.
 #
-#   worklist [project|--here] [--brief] [--fresh] [--json]
+#   worklist [project|--here] [--brief] [--fresh] [--json] [--all-rulings]
 #
 # Repo set: the cwd repo's GitHub topic `project-<name>`, else the cwd repo
 # alone; a project name argument skips the topic lookup; --here forces the
@@ -30,15 +30,16 @@
 # CONVENIENCE: exit 0 always, except --json with nothing fetched.
 set -u
 
-usage() { printf 'usage: worklist [project|--here] [--brief] [--fresh] [--json]\n'; }
+usage() { printf 'usage: worklist [project|--here] [--brief] [--fresh] [--json] [--all-rulings]\n'; }
 
-brief=0; fresh=0; json=0; here=0; project=""; refresh=0; marker=""
+brief=0; fresh=0; json=0; here=0; project=""; refresh=0; marker=""; all_rulings=0
 while [ $# -gt 0 ]; do
   case $1 in
     --brief) brief=1 ;;
     --fresh) fresh=1 ;;
     --json) json=1 ;;
     --here) here=1 ;;
+    --all-rulings) all_rulings=1 ;;
     --_refresh) refresh=1 ;;
     --_marker) shift; marker=${1:-} ;;
     -h|--help) usage; exit 0 ;;
@@ -263,7 +264,7 @@ def ms_sfx: if .milestone then "  [\(.milestone.title)]" else "" end;
       then "counts: unavailable (\(.prs))"
       else "counts: \(.prs) open PRs, \(.issues) open issues across \($owner)" end) as $counts
 | [ $c.label + " " + ($c.repos | map(split("/")[1]) | join(", ")) ]
-  + $fails + $trunc + [ $counts, "",
+  + $fails + $trunc + [ $counts, "", "@@RULINGS@@",
   bucket("Solace'"'"'s turn"; $prs | map(select(awaiting_human) | .line)),
   bucket("Queued (auto-merge)"; $prs | map(select(.autoMergeRequest != null) | .line)),
   bucket("Ready"; $rd | map(.line)),
@@ -274,30 +275,66 @@ def ms_sfx: if .milestone then "  [\(.milestone.title)]" else "" end;
 | join("\n")
 '
 
-# board_sections -- the two sections of the board, read at print time. The
-# Needs-ruling cards are the questions only Solace can settle; a card is
-# written there only for a one-way door, so the bucket is normally empty.
-board_sections() {
+# board_path -- sets $kb to the kanban.md this view reads. Returns 1 with
+# $board_err set and $kb empty when there is none.
+board_err=""; kb=""
+board_path() {
+  board_err=""; kb=""
   lib=""
   for c in "$self_dir/../../.claude/hooks/lib-state.sh" "$HOME/.claude/hooks/lib-state.sh"; do
     [ -f "$c" ] && { lib=$c; break; }
   done
-  [ -n "$lib" ] || { echo "Board: unavailable (lib-state.sh not found)"; return 0; }
+  [ -n "$lib" ] || { board_err="Board: unavailable (lib-state.sh not found)"; return 1; }
   # shellcheck disable=SC1090
   . "$lib"
   kb="$(state_dir)/kanban.md"
-  [ -f "$kb" ] || { echo "Board: no kanban.md at $kb"; return 0; }
-  section_of "$kb" '^## Needs ruling[[:space:]]*$' "Needs ruling" ""
-  echo
-  section_of "$kb" '^## Claude' "Board (## Claude's" ")"
+  [ -f "$kb" ] || { board_err="Board: no kanban.md at $kb"; kb=""; return 1; }
+  return 0
 }
 
-# section_of <board> <heading regex> <label> <suffix>
+count_lines() { [ -n "$1" ] || { echo 0; return; }; printf '%s\n' "$1" | grep -c '^'; }
+
+# ruling_section <board> <project>
+# The ## Needs ruling cards, grouped by the "### <name>" heading above them --
+# one group per project, "### global" for what no project owns. Inside a
+# project's repo only that project's group and global are shown, with a count
+# of what was hidden; --all-rulings, or no project at all, shows every group
+# and prefixes each card with its group. Printed first because it is the one
+# thing here that is waiting on the user.
+ruling_section() {
+  rows=$(awk '
+    /^## / { f = ($0 ~ /^## Needs ruling[[:space:]]*$/); g = "global"; next }
+    !f { next }
+    /^### / { g = $0; sub(/^###[ \t]+/, "", g); sub(/[ \t]+$/, "", g); next }
+    /^- \[ \]/ { t = substr($0, 7); print g "\t" t }
+  ' "$1")
+  showall=$all_rulings
+  [ -n "$2" ] || showall=1
+  if [ "$showall" = 1 ]; then
+    inscope=$rows; other=0
+  else
+    inscope=$(printf '%s\n' "$rows" | awk -F'\t' -v p="$2" 'NF > 1 && ($1 == p || $1 == "global")')
+    other=$(count_lines "$(printf '%s\n' "$rows" | awk -F'\t' -v p="$2" 'NF > 1 && $1 != p && $1 != "global"')")
+  fi
+  total=$(count_lines "$inscope")
+  if [ "$total" -eq 0 ]; then printf 'Needs ruling: none\n'
+  else
+    printf 'Needs ruling, showing %s of %s\n' "$( [ "$total" -gt 8 ] && echo 8 || echo "$total" )" "$total"
+    # jq, not awk, for the cut: it counts codepoints, so an em-dash never splits
+    printf '%s\n' "$inscope" | head -8 | jq -Rr --arg brief "$brief" --arg all "$showall" '
+      split("\t") | (if $all == "1" then .[0] + ": " else "" end) + .[1]
+      | if $brief == "1" and length > 80 then .[:77] + "..." else . end | "  " + .'
+  fi
+  [ "$other" -gt 0 ] && printf '  +%s in other projects (worklist --all-rulings)\n' "$other"
+  return 0
+}
+
+# section_of <board> <heading regex> <label> <suffix>  -- the flat ## Claude's
 # Prints "<label>: none", or "<label>, showing N of T<suffix>" and up to 8
-# cards. Same cut rules for both sections.
+# cards. Same cut rules as the ruling groups.
 section_of() {
   cards=$(awk -v pat="$2" '/^## /{f=($0 ~ pat)} f && /^- \[ \]/' "$1")
-  total=$(printf '%s' "$cards" | grep -c '^- ')
+  total=$(count_lines "$cards")
   if [ "$total" -eq 0 ]; then printf '%s: none\n' "$3$4"; return 0; fi
   printf '%s, showing %s of %s%s\n' "$3" "$( [ "$total" -gt 8 ] && echo 8 || echo "$total" )" "$total" "$4"
   # jq, not awk, for the cut: it counts codepoints, so an em-dash never splits
@@ -307,20 +344,31 @@ section_of() {
 # render <cache file or ""> <cached 0|1> <extra line or "">
 render() {
   stamp="as of $(date -u +%H:%MZ)"
+  proj=""
   if [ -n "$1" ]; then
     stamp="as of $(jq -r .written_hm "$1")"
+    proj=$(jq -r '.project // ""' "$1")
     if [ "$2" = 1 ]; then
       age=$(( (now - $(jq -r .written_at "$1")) / 60 ))
       [ "$age" -lt 1 ] && age="<1"
       stamp="$stamp (cached $age min)"
     fi
   fi
+  board_path || :
+  rulings=""
+  [ -n "$kb" ] && rulings=$(ruling_section "$kb" "$proj")
   {
     echo "$stamp"
     [ -n "$3" ] && echo "$3"
-    if [ -n "$1" ]; then jq -r --arg brief "$brief" "$RENDER" "$1"; fi
+    if [ -n "$1" ]; then
+      jq -r --arg brief "$brief" "$RENDER" "$1" \
+        | awk -v r="$rulings" '$0 == "@@RULINGS@@" { if (r != "") { print r; print "" } ; next } { print }'
+    elif [ -n "$rulings" ]; then
+      printf '%s\n\n' "$rulings"
+    fi
     echo
-    board_sections
+    if [ -n "$kb" ]; then section_of "$kb" '^## Claude' "Board (## Claude's" ")"
+    else echo "$board_err"; fi
   } | if [ "$brief" = 1 ]; then
     awk -v max=2900 '{ n += length($0) + 1; if (n > max) { print "... (cut at 3 KB; run worklist)"; exit } print }'
   else cat; fi

--- a/.local/bin/worklist
+++ b/.local/bin/worklist
@@ -1,0 +1,356 @@
+#!/bin/sh
+# worklist -- what is outstanding across a project's repos, computed from
+# GitHub at read time and never stored anywhere but a cache.
+#
+# Why: the state of a loop used to be copied into up to five places (issue,
+# PR, card, epic Status line, log) and every copy drifted. Sessions then spent
+# their opening turns "sweeping" the board -- editing prose to match GitHub
+# -- and the user still could not tell what was theirs to do. Every fact now has one
+# home (the PR or issue) and this is the one view over them: Solace's turn,
+# queued, needs a ruling, ruled but unlanded, ready, blocked, untriaged,
+# stranded branches, and the agent's private board. Anything that asks
+# "what's stale / outstanding / next" runs this and reports; nothing edits.
+#
+#   worklist [project|--here] [--brief] [--fresh] [--json]
+#
+# Repo set: the cwd repo's GitHub topic `project-<name>`, else the cwd repo
+# alone; a project name argument skips the topic lookup; --here forces the
+# cwd repo alone. One GraphQL call per repo, run in parallel.
+#
+# Cache: $XDG_CACHE_HOME/worklist/<owner>-<key>.json, stale-while-revalidate.
+# A cached view prints at once and a detached process refreshes it for the
+# next run; only a missing cache waits, and --brief waits at most 5 s because
+# it is what SessionStart injects. `timeout` is used only where it exists
+# (macOS has none). Failures are named per cause -- `no gh`, `gh
+# unauthenticated`, `<repo>: 403 -- attach the repo`, `network` -- because a
+# view that goes quiet when it cannot look is indistinguishable from one that
+# looked and found nothing.
+#
+# CONVENIENCE: exit 0 always, except --json with nothing fetched.
+set -u
+
+usage() { printf 'usage: worklist [project|--here] [--brief] [--fresh] [--json]\n'; }
+
+brief=0; fresh=0; json=0; here=0; project=""; refresh=0; marker=""
+while [ $# -gt 0 ]; do
+  case $1 in
+    --brief) brief=1 ;;
+    --fresh) fresh=1 ;;
+    --json) json=1 ;;
+    --here) here=1 ;;
+    --_refresh) refresh=1 ;;
+    --_marker) shift; marker=${1:-} ;;
+    -h|--help) usage; exit 0 ;;
+    -*) printf 'worklist: unknown option %s\n' "$1" >&2; usage >&2; exit 2 ;;
+    *) project=$1 ;;
+  esac
+  shift
+done
+
+self=$0
+case $self in */*) ;; *) self=$(command -v "$self" 2>/dev/null || printf '%s' "$self") ;; esac
+self_dir=$(cd "$(dirname "$self")" 2>/dev/null && pwd)
+cache_root=${XDG_CACHE_HOME:-$HOME/.cache}/worklist
+mkdir -p "$cache_root" 2>/dev/null
+TIMEOUT=$(command -v timeout 2>/dev/null || :)
+run_t() { if [ -n "$TIMEOUT" ]; then "$TIMEOUT" 20 "$@"; else "$@"; fi; }
+now=$(date +%s)
+have_gh=1; command -v gh >/dev/null 2>&1 || have_gh=0
+command -v jq >/dev/null 2>&1 || { echo "no jq -- worklist needs jq"; exit 0; }
+
+# owner/name of the cwd repo from its origin URL: no network, so the cache
+# can be found before gh is ever called.
+cwd_repo() {
+  u=$(git remote get-url origin 2>/dev/null) || return 1
+  r=$(printf '%s' "$u" | sed -e 's#^https://github\.com/##' -e 's#^ssh://git@github\.com/##' \
+        -e 's#^git@github\.com:##' -e 's#/$##' -e 's#\.git$##')
+  [ "$r" = "$u" ] && return 1
+  case $r in */*/*|/*|*/) return 1 ;; */*) printf '%s' "$r" ;; *) return 1 ;; esac
+}
+
+# stdout = cause; $1 = exit code, $2 = file holding the command's stderr+stdout
+cause_of() {
+  [ "$1" = 124 ] && { printf 'network'; return; }
+  if grep -Eqi 'HTTP 401|Bad credentials|gh auth login|not logged in' "$2"; then printf 'gh unauthenticated'
+  elif grep -Eqi 'HTTP 403|Resource not accessible|FORBIDDEN|SAML' "$2"; then printf '403 -- attach the repo'
+  elif grep -Eqi 'HTTP 404|Could not resolve to a Repository|NOT_FOUND' "$2"; then printf 'not found'
+  elif grep -Eqi 'dial tcp|no such host|connection refused|i/o timeout|TLS handshake|network is unreachable|error connecting|Could not resolve host|HTTP 5[0-9][0-9]' "$2"; then printf 'network'
+  else head -1 "$2" | tr -d '\r' | cut -c1-120; fi
+}
+
+# shellcheck disable=SC2016  # GraphQL variables, not shell ones
+QUERY='query($owner:String!,$name:String!){ repository(owner:$owner,name:$name){
+  defaultBranchRef{name}
+  pullRequests(states:OPEN,first:50){pageInfo{hasNextPage} nodes{number title url isDraft mergeable autoMergeRequest{enabledAt} author{login}
+    reviewThreads(first:100){nodes{isResolved}}
+    commits(last:1){nodes{commit{statusCheckRollup{state contexts(first:50){nodes{
+      ... on CheckRun{name conclusion} ... on StatusContext{context state}}}}}}}}}
+  issues(states:OPEN,first:100){pageInfo{hasNextPage} nodes{number title url labels(first:20){nodes{name}} assignees(first:10){nodes{login}}
+    milestone{title} comments(last:20){nodes{author{login} body}}}}
+  refs(refPrefix:"refs/heads/",first:100){nodes{name associatedPullRequests(first:1){totalCount}}}
+}}'
+
+# Resolve owner, key, label and the repo list into globals. Returns 1 with
+# scope_error set when nothing sensible can be fetched.
+resolve_scope() {
+  scope_error=""; repos=""
+  cwd=$(cwd_repo) || cwd=""
+  if [ -n "$cwd" ]; then owner=${cwd%%/*}
+  elif [ -n "$project" ]; then
+    owner=$(run_t gh api user --jq .login 2>/dev/null) || owner=""
+    [ -n "$owner" ] || { scope_error="not in a GitHub repo and gh could not name the account"; return 1; }
+  else scope_error="not in a GitHub repo; pass a project name or --here"; return 1; fi
+
+  if [ "$here" = 1 ] && [ -n "$cwd" ]; then :
+  elif [ -n "$project" ]; then :
+  elif [ -n "$cwd" ]; then
+    project=$(run_t gh repo view "$cwd" --json repositoryTopics 2>/dev/null \
+      | jq -r '(.repositoryTopics // [])[].name | select(startswith("project-"))' 2>/dev/null | head -1)
+    project=${project#project-}
+  fi
+
+  if [ -n "$project" ]; then
+    if list=$(run_t gh repo list "$owner" --topic "project-$project" --limit 100 --json name 2>"$cache_root/.list.err.$$") \
+       && [ -n "$list" ]; then
+      for n in $(printf '%s' "$list" | jq -r '.[].name'); do repos="$repos $owner/$n"; done
+    fi
+    rm -f "$cache_root/.list.err.$$"
+    [ -n "$repos" ] || repos=${cwd:+" $cwd"}
+    [ -n "$repos" ] || { scope_error="no repos carry topic project-$project"; return 1; }
+    key="$owner-$project"; label="project $project ($owner):"
+  else
+    repos=" $cwd"; key="$owner-${cwd#*/}"; label="repo $cwd"
+  fi
+  return 0
+}
+
+# Fetch everything, write the cache, print the key. Holds <key>.lock so two
+# sessions starting together do not both hit the API.
+do_fetch() {
+  resolve_scope || { [ -n "$marker" ] && printf 'error\t%s\n' "$scope_error" > "$marker"; return 1; }
+  lock="$cache_root/$key.lock"
+  if [ -f "$lock" ] && pid=$(cat "$lock" 2>/dev/null) && [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+    i=0; while [ -f "$lock" ] && kill -0 "$pid" 2>/dev/null && [ "$i" -lt 60 ]; do sleep 1; i=$((i + 1)); done
+    [ -n "$marker" ] && printf 'key\t%s\n' "$key" > "$marker"
+    return 0
+  fi
+  printf '%s' $$ > "$lock"
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/worklist.XXXXXX") || { rm -f "$lock"; return 1; }
+
+  for r in $repos; do
+    ( o=${r%%/*}; n=${r#*/}
+      run_t gh api graphql -f owner="$o" -f name="$n" -f query="$QUERY" >"$tmp/$n.out" 2>"$tmp/$n.err"
+      echo $? >"$tmp/$n.rc" ) &
+  done
+  ( run_t gh search prs --owner "$owner" --state open --limit 300 --json number >"$tmp/_prs.out" 2>"$tmp/_prs.err"; echo $? >"$tmp/_prs.rc" ) &
+  ( run_t gh search issues --owner "$owner" --state open --limit 300 --json number >"$tmp/_iss.out" 2>"$tmp/_iss.err"; echo $? >"$tmp/_iss.rc" ) &
+  wait
+
+  : > "$tmp/recs"
+  for r in $repos; do
+    n=${r#*/}
+    if [ "$(cat "$tmp/$n.rc")" = 0 ] && jq -e '.data.repository != null' "$tmp/$n.out" >/dev/null 2>&1; then
+      jq -c --arg repo "$r" '{repo:$repo, data:.data.repository}' "$tmp/$n.out" >> "$tmp/recs"
+    else
+      cat "$tmp/$n.err" "$tmp/$n.out" > "$tmp/$n.txt"
+      cause=$(cause_of "$(cat "$tmp/$n.rc")" "$tmp/$n.txt")
+      jq -nc --arg repo "$r" --arg c "${cause:-unknown error}" '{repo:$repo, error:$c}' >> "$tmp/recs"
+    fi
+  done
+  count_of() { # $1 = _prs|_iss ; prints a JSON number or a quoted cause
+    if [ "$(cat "$tmp/$1.rc")" = 0 ] && c=$(jq 'length' "$tmp/$1.out" 2>/dev/null); then
+      if [ "$c" -ge 300 ]; then printf '"300+"'; else printf '%s' "$c"; fi
+    else cat "$tmp/$1.err" "$tmp/$1.out" > "$tmp/$1.txt"; cause_of "$(cat "$tmp/$1.rc")" "$tmp/$1.txt" | jq -R .; fi
+  }
+  jq -n --arg key "$key" --arg owner "$owner" --arg project "$project" --arg label "$label" \
+     --argjson now "$(date +%s)" --arg hm "$(date -u +%H:%MZ)" \
+     --slurpfile recs "$tmp/recs" --argjson prs "$(count_of _prs)" --argjson issues "$(count_of _iss)" \
+     '{key:$key, owner:$owner, project:$project, label:$label, written_at:$now, written_hm:$hm,
+       repos:[$recs[].repo], records:$recs, counts:{prs:$prs, issues:$issues}}' > "$tmp/cache.json" \
+    && mv -f "$tmp/cache.json" "$cache_root/$key.json"
+  rm -rf "$tmp" "$lock"
+  [ -n "$marker" ] && printf 'key\t%s\n' "$key" > "$marker"
+  printf '%s\n' "$key"
+}
+
+if [ "$refresh" = 1 ]; then do_fetch >/dev/null 2>&1; exit 0; fi
+
+# Detached so the caller's exit (a SessionStart hook ending) does not kill it.
+spawn_refresh() {
+  set -- --_refresh
+  [ "$here" = 1 ] && set -- "$@" --here
+  [ -n "$project" ] && set -- "$@" "$project"
+  if [ -n "$wait_marker" ]; then set -- "$@" --_marker "$wait_marker"; fi
+  if command -v setsid >/dev/null 2>&1; then setsid nohup sh "$self" "$@" >/dev/null 2>&1 </dev/null &
+  else nohup sh "$self" "$@" >/dev/null 2>&1 </dev/null & fi
+}
+
+# Which cache file answers this invocation, without the network.
+find_cache() {
+  cwd=$(cwd_repo) || cwd=""
+  if [ -n "$project" ]; then
+    o=${cwd%%/*}
+    if [ -n "$o" ]; then f="$cache_root/$o-$project.json"
+    else for f in "$cache_root"/*"-$project.json"; do break; done; fi
+    [ -f "$f" ] && printf '%s' "$f"; return
+  fi
+  [ -n "$cwd" ] || return
+  if [ "$here" != 1 ]; then
+    for f in "$cache_root"/*.json; do
+      [ -f "$f" ] || continue
+      if jq -e --arg r "$cwd" '.project != "" and any(.repos[]; . == $r)' "$f" >/dev/null 2>&1; then printf '%s' "$f"; return; fi
+    done
+  fi
+  [ -f "$cache_root/${cwd%%/*}-${cwd#*/}.json" ] && printf '%s' "$cache_root/${cwd%%/*}-${cwd#*/}.json"
+}
+
+# --- render --------------------------------------------------------------------
+# shellcheck disable=SC2016  # jq program, not shell
+RENDER='
+def brief: $brief == "1";
+def cut: if brief and length > 80 then .[:77] + "..." else . end;
+def limit: if brief then 5 else 1000000 end;
+def bucket($title; $lines):
+  if ($lines|length) == 0 then "\($title): none"
+  else ([$title] + ($lines[:limit] | map("  " + .))
+        + (if ($lines|length) > limit then ["  +\(($lines|length) - limit) more (run worklist)"] else [] end)) | join("\n") end;
+def url_sfx: if brief then "" else "  " + .url end;
+def failing_names: [ (.commits.nodes[0].commit.statusCheckRollup.contexts.nodes // [])[]
+  | select( ((.conclusion // "") | IN("FAILURE","TIMED_OUT","CANCELLED","ACTION_REQUIRED","STARTUP_FAILURE"))
+         or ((.state // "") | IN("FAILURE","ERROR")) )
+  | (.name // .context // "?") ];
+def rollup: .commits.nodes[0].commit.statusCheckRollup.state // "NONE";
+def unresolved: [ (.reviewThreads.nodes // [])[] | select(.isResolved | not) ] | length;
+def pr_notes($owner): [
+  ((.author.login // "ghost") | if . != $owner then "by \(.)" else empty end),
+  (if .isDraft then "draft" else empty end),
+  (if .mergeable == "CONFLICTING" then "conflicting" elif .mergeable == "UNKNOWN" then "mergeability unknown" else empty end),
+  (failing_names | if length > 0 then "failing: " + join(", ") else empty end),
+  (if (failing_names|length) == 0 and (rollup|IN("FAILURE","ERROR")) then "checks \(rollup|ascii_downcase), names past the first 50 contexts" else empty end),
+  (if (failing_names|length) == 0 and (rollup|IN("PENDING","EXPECTED")) then "checks pending" else empty end),
+  (unresolved | if . > 0 then "\(.) unresolved thread(s)" else empty end) ];
+# rollup NONE (no checks at all) counts as ready: a repo without CI still needs the user to merge. Ruled on #90.
+def marks_turn: (.isDraft|not) and .mergeable == "MERGEABLE" and (failing_names|length) == 0
+  and (rollup|IN("SUCCESS","NONE")) and unresolved == 0 and .autoMergeRequest == null;
+def notes_sfx($owner): pr_notes($owner) | if length > 0 then "  -- " + join("; ") else "" end;
+def labels: [(.labels.nodes // [])[].name];
+def assigned($owner): any((.assignees.nodes // [])[]; .login == $owner);
+def ruled($owner): any((.comments.nodes // [])[]; (.author.login // "") == $owner and ((.body // "") | test("^\\s*Ruled"; "i")));
+def ms_sfx: if .milestone then "  [\(.milestone.title)]" else "" end;
+
+. as $c | $c.owner as $owner
+| [ $c.records[] | select(.data) | (.repo|split("/")[1]) as $s | (.data.pullRequests.nodes // [])[]
+    | . + {line: ("\($s)#\(.number)  \(.title|cut)" + notes_sfx($owner) + url_sfx)} ] as $prs
+| [ $c.records[] | select(.data) | (.repo|split("/")[1]) as $s | (.data.issues.nodes // [])[]
+    | . + {lbl: labels, asg: assigned($owner), rld: ruled($owner),
+           line: ("\($s)#\(.number)  \(.title|cut)" + ms_sfx + url_sfx)} ] as $is
+| ($is | map(select(.lbl|index("needs-ruling")))) as $nr
+| ($is | map(select((.lbl|index("needs-ruling")|not) and (.lbl|index("blocked"))))) as $bl
+| ($is | map(select((.lbl|index("needs-ruling")|not) and (.lbl|index("blocked")|not) and .asg))) as $asg
+| ($is | map(select((.lbl|index("needs-ruling")|not) and (.lbl|index("blocked")|not) and (.asg|not) and (.lbl|index("ready"))))) as $rd
+| ($is | map(select((.lbl|index("needs-ruling")|not) and (.lbl|index("blocked")|not) and (.asg|not) and (.lbl|index("ready")|not)))) as $rest
+| ($rest | map(select(.milestone)) | length) as $deferred
+| ($rest | map(select(.milestone|not)) | length) as $untriaged
+| [ $c.records[] | select(.data) | (.repo|split("/")[1]) as $s | (.data.defaultBranchRef.name // "main") as $def
+    | [ (.data.refs.nodes // [])[] | select(.associatedPullRequests.totalCount == 0 and (.name|IN("main","master",$def)|not)
+        and (.name|startswith("release-please--")|not)) | .name ]
+    | select(length > 0) | ("\($s): " + join(", ") | cut) ] as $stranded
+| [ ($c.records | map(select(.error))) as $e
+    | if ($e|length) > 0 and ($e|length) == ($c.records|length) and ([$e[].error]|unique|length) == 1
+         and ($e[0].error|IN("gh unauthenticated","network")) then $e[0].error
+      else $e[] | "\(.repo): \(.error)" end ] as $fails
+| [ $c.records[] | select(.data) | (.repo|split("/")[1]) as $s
+    | (if .data.pullRequests.pageInfo.hasNextPage then "\($s): more than 50 open PRs -- PR buckets truncated" else empty end),
+      (if .data.issues.pageInfo.hasNextPage then "\($s): more than 100 open issues -- issue buckets and Untriaged truncated" else empty end) ] as $trunc
+| ($c.counts | if (.prs|type) == "string" and (.issues|type) == "string" and .prs == .issues and (.prs|test("^[0-9]")|not)
+      then "counts: unavailable (\(.prs))"
+      else "counts: \(.prs) open PRs, \(.issues) open issues across \($owner)" end) as $counts
+| [ $c.label + " " + ($c.repos | map(split("/")[1]) | join(", ")) ]
+  + $fails + $trunc + [ $counts, "",
+  bucket("Solace'"'"'s turn"; ($prs | map(select(marks_turn) | .line)) + ($asg | map(.line + "  (assigned)"))),
+  bucket("Queued (auto-merge)"; $prs | map(select(.autoMergeRequest != null) | .line)),
+  bucket("Needs ruling"; $nr | map(select(.rld|not) | .line)),
+  bucket("Ruled, unlanded"; $nr | map(select(.rld) | .line)),
+  bucket("Ready"; $rd | map(.line)),
+  bucket("Blocked"; $bl | map(.line)),
+  bucket("Not ready (agent'"'"'s turn)"; $prs | map(select(.autoMergeRequest == null and (marks_turn|not)) | .line)),
+  "Untriaged: \($untriaged)" + (if $deferred > 0 then " (deferred to a milestone: \($deferred))" else "" end),
+  bucket("Stranded branches (no PR)"; $stranded) ]
+| join("\n")
+'
+
+board_section() {
+  lib=""
+  for c in "$self_dir/../../.claude/hooks/lib-state.sh" "$HOME/.claude/hooks/lib-state.sh"; do
+    [ -f "$c" ] && { lib=$c; break; }
+  done
+  [ -n "$lib" ] || { echo "Board: unavailable (lib-state.sh not found)"; return 0; }
+  # shellcheck disable=SC1090
+  . "$lib"
+  kb="$(state_dir)/kanban.md"
+  [ -f "$kb" ] || { echo "Board: no kanban.md at $kb"; return 0; }
+  cards=$(awk '/^## /{f=($0 ~ /^## Claude/)} f && /^- \[ \]/' "$kb")
+  total=$(printf '%s' "$cards" | grep -c '^- ')
+  if [ "$total" -eq 0 ]; then echo "Board (## Claude's): none"; return 0; fi
+  echo "Board (## Claude's, showing $( [ "$total" -gt 8 ] && echo 8 || echo "$total" ) of $total)"
+  # jq, not awk, for the cut: it counts codepoints, so an em-dash never splits
+  printf '%s\n' "$cards" | head -8 | jq -Rr --arg brief "$brief" '.[6:] | if $brief == "1" and length > 80 then .[:77] + "..." else . end | "  " + .'
+}
+
+# render <cache file or ""> <cached 0|1> <extra line or "">
+render() {
+  stamp="as of $(date -u +%H:%MZ)"
+  if [ -n "$1" ]; then
+    stamp="as of $(jq -r .written_hm "$1")"
+    if [ "$2" = 1 ]; then
+      age=$(( (now - $(jq -r .written_at "$1")) / 60 ))
+      [ "$age" -lt 1 ] && age="<1"
+      stamp="$stamp (cached $age min)"
+    fi
+  fi
+  {
+    echo "$stamp"
+    [ -n "$3" ] && echo "$3"
+    if [ -n "$1" ]; then jq -r --arg brief "$brief" "$RENDER" "$1"; fi
+    echo
+    board_section
+  } | if [ "$brief" = 1 ]; then
+    awk -v max=2900 '{ n += length($0) + 1; if (n > max) { print "... (cut at 3 KB; run worklist)"; exit } print }'
+  else cat; fi
+}
+
+# --- main ------------------------------------------------------------------
+if [ "$have_gh" = 0 ]; then
+  cache=$(find_cache)
+  [ "$json" = 1 ] && { [ -n "$cache" ] && cat "$cache" && exit 0; echo '{"error":"no gh"}'; exit 1; }
+  render "$cache" 1 "no gh -- live GitHub view unavailable${cache:+; showing the last cached view}"
+  exit 0
+fi
+
+cache=""; [ "$fresh" = 1 ] || cache=$(find_cache)
+wait_marker=""
+if [ -n "$cache" ]; then
+  age=$(( now - $(jq -r .written_at "$cache") ))
+  [ "$age" -gt 120 ] && spawn_refresh
+  if [ "$json" = 1 ]; then cat "$cache"; exit 0; fi
+  render "$cache" 1 ""
+  exit 0
+fi
+
+# Nothing cached: fetch now, in the background so the wait can be capped.
+wait_marker=$(mktemp "${TMPDIR:-/tmp}/worklist-marker.XXXXXX") && rm -f "$wait_marker"
+spawn_refresh
+cap=90; [ "$brief" = 1 ] && cap=5
+i=0; while [ ! -f "$wait_marker" ] && [ "$i" -lt "$cap" ]; do sleep 1; i=$((i + 1)); done
+if [ -f "$wait_marker" ]; then
+  IFS="$(printf '\t')" read -r kind val < "$wait_marker"; rm -f "$wait_marker"
+  if [ "$kind" = key ] && [ -f "$cache_root/$val.json" ]; then
+    [ "$json" = 1 ] && { cat "$cache_root/$val.json"; jq -e '[.records[]|select(.data)]|length > 0' "$cache_root/$val.json" >/dev/null 2>&1; exit $?; }
+    render "$cache_root/$val.json" 0 ""; exit 0
+  fi
+  [ "$json" = 1 ] && { jq -n --arg e "${val:-fetch failed}" '{error:$e}'; exit 1; }
+  render "" 0 "${val:-fetch failed; nothing cached}"; exit 0
+fi
+[ "$json" = 1 ] && { echo '{"error":"still fetching"}'; exit 1; }
+render "" 0 "GitHub has not answered in ${cap} s; fetching continues in the background -- run worklist again"
+exit 0

--- a/.local/bin/worklist
+++ b/.local/bin/worklist
@@ -7,9 +7,10 @@
 # their opening turns "sweeping" the board -- editing prose to match GitHub
 # -- and the user still could not tell what was theirs to do. Every fact now has one
 # home (the PR or issue) and this is the one view over them: Solace's turn,
-# queued, needs a ruling, ruled but unlanded, ready, blocked, untriaged,
-# stranded branches, and the agent's private board. Anything that asks
-# "what's stale / outstanding / next" runs this and reports; nothing edits.
+# queued, ready, blocked, untriaged, stranded branches, and the two board
+# sections -- questions that need a ruling, and the agent's rabbit-trails.
+# Anything that asks "what's stale / outstanding / next" runs this and
+# reports; nothing edits.
 #
 #   worklist [project|--here] [--brief] [--fresh] [--json]
 #
@@ -85,8 +86,8 @@ QUERY='query($owner:String!,$name:String!){ repository(owner:$owner,name:$name){
     reviewThreads(first:100){nodes{isResolved}}
     commits(last:1){nodes{commit{statusCheckRollup{state contexts(first:50){nodes{
       ... on CheckRun{name conclusion} ... on StatusContext{context state}}}}}}}}}
-  issues(states:OPEN,first:100){pageInfo{hasNextPage} nodes{number title url labels(first:20){nodes{name}} assignees(first:10){nodes{login}}
-    milestone{title} comments(last:20){nodes{author{login} body}}}}
+  issues(states:OPEN,first:100){pageInfo{hasNextPage} nodes{number title url labels(first:20){nodes{name}}
+    milestone{title}}}
   refs(refPrefix:"refs/heads/",first:100){nodes{name associatedPullRequests(first:1){totalCount}}}
 }}'
 
@@ -234,21 +235,17 @@ def awaiting_human: (.isDraft|not) and .mergeable == "MERGEABLE" and (failing_na
   and (rollup|IN("SUCCESS","NONE")) and unresolved == 0 and .autoMergeRequest == null;
 def notes_sfx($owner): pr_notes($owner) | if length > 0 then "  -- " + join("; ") else "" end;
 def labels: [(.labels.nodes // [])[].name];
-def assigned($owner): any((.assignees.nodes // [])[]; .login == $owner);
-def ruled($owner): any((.comments.nodes // [])[]; (.author.login // "") == $owner and ((.body // "") | test("^\\s*Ruled"; "i")));
 def ms_sfx: if .milestone then "  [\(.milestone.title)]" else "" end;
 
 . as $c | $c.owner as $owner
 | [ $c.records[] | select(.data) | (.repo|split("/")[1]) as $s | (.data.pullRequests.nodes // [])[]
     | . + {line: ("\($s)#\(.number)  \(.title|cut)" + notes_sfx($owner) + url_sfx)} ] as $prs
 | [ $c.records[] | select(.data) | (.repo|split("/")[1]) as $s | (.data.issues.nodes // [])[]
-    | . + {lbl: labels, asg: assigned($owner), rld: ruled($owner),
+    | . + {lbl: labels,
            line: ("\($s)#\(.number)  \(.title|cut)" + ms_sfx + url_sfx)} ] as $is
-| ($is | map(select(.lbl|index("needs-ruling")))) as $nr
-| ($is | map(select((.lbl|index("needs-ruling")|not) and (.lbl|index("blocked"))))) as $bl
-| ($is | map(select((.lbl|index("needs-ruling")|not) and (.lbl|index("blocked")|not) and .asg))) as $asg
-| ($is | map(select((.lbl|index("needs-ruling")|not) and (.lbl|index("blocked")|not) and (.asg|not) and (.lbl|index("ready"))))) as $rd
-| ($is | map(select((.lbl|index("needs-ruling")|not) and (.lbl|index("blocked")|not) and (.asg|not) and (.lbl|index("ready")|not)))) as $rest
+| ($is | map(select(.lbl|index("blocked")))) as $bl
+| ($is | map(select((.lbl|index("blocked")|not) and (.lbl|index("ready"))))) as $rd
+| ($is | map(select((.lbl|index("blocked")|not) and (.lbl|index("ready")|not)))) as $rest
 | ($rest | map(select(.milestone)) | length) as $deferred
 | ($rest | map(select(.milestone|not)) | length) as $untriaged
 | [ $c.records[] | select(.data) | (.repo|split("/")[1]) as $s | (.data.defaultBranchRef.name // "main") as $def
@@ -267,10 +264,8 @@ def ms_sfx: if .milestone then "  [\(.milestone.title)]" else "" end;
       else "counts: \(.prs) open PRs, \(.issues) open issues across \($owner)" end) as $counts
 | [ $c.label + " " + ($c.repos | map(split("/")[1]) | join(", ")) ]
   + $fails + $trunc + [ $counts, "",
-  bucket("Solace'"'"'s turn"; ($prs | map(select(awaiting_human) | .line)) + ($asg | map(.line + "  (assigned)"))),
+  bucket("Solace'"'"'s turn"; $prs | map(select(awaiting_human) | .line)),
   bucket("Queued (auto-merge)"; $prs | map(select(.autoMergeRequest != null) | .line)),
-  bucket("Needs ruling"; $nr | map(select(.rld|not) | .line)),
-  bucket("Ruled, unlanded"; $nr | map(select(.rld) | .line)),
   bucket("Ready"; $rd | map(.line)),
   bucket("Blocked"; $bl | map(.line)),
   bucket("Not ready (agent'"'"'s turn)"; $prs | map(select(.autoMergeRequest == null and (awaiting_human|not)) | .line)),
@@ -279,7 +274,10 @@ def ms_sfx: if .milestone then "  [\(.milestone.title)]" else "" end;
 | join("\n")
 '
 
-board_section() {
+# board_sections -- the two sections of the board, read at print time. The
+# Needs-ruling cards are the questions only Solace can settle; a card is
+# written there only for a one-way door, so the bucket is normally empty.
+board_sections() {
   lib=""
   for c in "$self_dir/../../.claude/hooks/lib-state.sh" "$HOME/.claude/hooks/lib-state.sh"; do
     [ -f "$c" ] && { lib=$c; break; }
@@ -289,10 +287,19 @@ board_section() {
   . "$lib"
   kb="$(state_dir)/kanban.md"
   [ -f "$kb" ] || { echo "Board: no kanban.md at $kb"; return 0; }
-  cards=$(awk '/^## /{f=($0 ~ /^## Claude/)} f && /^- \[ \]/' "$kb")
+  section_of "$kb" '^## Needs ruling[[:space:]]*$' "Needs ruling" ""
+  echo
+  section_of "$kb" '^## Claude' "Board (## Claude's" ")"
+}
+
+# section_of <board> <heading regex> <label> <suffix>
+# Prints "<label>: none", or "<label>, showing N of T<suffix>" and up to 8
+# cards. Same cut rules for both sections.
+section_of() {
+  cards=$(awk -v pat="$2" '/^## /{f=($0 ~ pat)} f && /^- \[ \]/' "$1")
   total=$(printf '%s' "$cards" | grep -c '^- ')
-  if [ "$total" -eq 0 ]; then echo "Board (## Claude's): none"; return 0; fi
-  echo "Board (## Claude's, showing $( [ "$total" -gt 8 ] && echo 8 || echo "$total" ) of $total)"
+  if [ "$total" -eq 0 ]; then printf '%s: none\n' "$3$4"; return 0; fi
+  printf '%s, showing %s of %s%s\n' "$3" "$( [ "$total" -gt 8 ] && echo 8 || echo "$total" )" "$total" "$4"
   # jq, not awk, for the cut: it counts codepoints, so an em-dash never splits
   printf '%s\n' "$cards" | head -8 | jq -Rr --arg brief "$brief" '.[6:] | if $brief == "1" and length > 80 then .[:77] + "..." else . end | "  " + .'
 }
@@ -313,7 +320,7 @@ render() {
     [ -n "$3" ] && echo "$3"
     if [ -n "$1" ]; then jq -r --arg brief "$brief" "$RENDER" "$1"; fi
     echo
-    board_section
+    board_sections
   } | if [ "$brief" = 1 ]; then
     awk -v max=2900 '{ n += length($0) + 1; if (n > max) { print "... (cut at 3 KB; run worklist)"; exit } print }'
   else cat; fi

--- a/.local/bin/worklist
+++ b/.local/bin/worklist
@@ -230,7 +230,7 @@ def pr_notes($owner): [
   (if (failing_names|length) == 0 and (rollup|IN("PENDING","EXPECTED")) then "checks pending" else empty end),
   (unresolved | if . > 0 then "\(.) unresolved thread(s)" else empty end) ];
 # rollup NONE (no checks at all) counts as ready: a repo without CI still needs the user to merge. Ruled on #90.
-def marks_turn: (.isDraft|not) and .mergeable == "MERGEABLE" and (failing_names|length) == 0
+def awaiting_human: (.isDraft|not) and .mergeable == "MERGEABLE" and (failing_names|length) == 0
   and (rollup|IN("SUCCESS","NONE")) and unresolved == 0 and .autoMergeRequest == null;
 def notes_sfx($owner): pr_notes($owner) | if length > 0 then "  -- " + join("; ") else "" end;
 def labels: [(.labels.nodes // [])[].name];
@@ -267,13 +267,13 @@ def ms_sfx: if .milestone then "  [\(.milestone.title)]" else "" end;
       else "counts: \(.prs) open PRs, \(.issues) open issues across \($owner)" end) as $counts
 | [ $c.label + " " + ($c.repos | map(split("/")[1]) | join(", ")) ]
   + $fails + $trunc + [ $counts, "",
-  bucket("Solace'"'"'s turn"; ($prs | map(select(marks_turn) | .line)) + ($asg | map(.line + "  (assigned)"))),
+  bucket("Solace'"'"'s turn"; ($prs | map(select(awaiting_human) | .line)) + ($asg | map(.line + "  (assigned)"))),
   bucket("Queued (auto-merge)"; $prs | map(select(.autoMergeRequest != null) | .line)),
   bucket("Needs ruling"; $nr | map(select(.rld|not) | .line)),
   bucket("Ruled, unlanded"; $nr | map(select(.rld) | .line)),
   bucket("Ready"; $rd | map(.line)),
   bucket("Blocked"; $bl | map(.line)),
-  bucket("Not ready (agent'"'"'s turn)"; $prs | map(select(.autoMergeRequest == null and (marks_turn|not)) | .line)),
+  bucket("Not ready (agent'"'"'s turn)"; $prs | map(select(.autoMergeRequest == null and (awaiting_human|not)) | .line)),
   "Untriaged: \($untriaged)" + (if $deferred > 0 then " (deferred to a milestone: \($deferred))" else "" end),
   bucket("Stranded branches (no PR)"; $stranded) ]
 | join("\n")

--- a/.local/bin/worklist
+++ b/.local/bin/worklist
@@ -133,7 +133,13 @@ do_fetch() {
   lock="$cache_root/$key.lock"
   if [ -f "$lock" ] && pid=$(cat "$lock" 2>/dev/null) && [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
     i=0; while [ -f "$lock" ] && kill -0 "$pid" 2>/dev/null && [ "$i" -lt 60 ]; do sleep 1; i=$((i + 1)); done
-    [ -n "$marker" ] && printf 'key\t%s\n' "$key" > "$marker"
+    if [ -n "$marker" ]; then
+      if [ -f "$cache_root/$key.json" ]; then
+        printf 'key\t%s\n' "$key" > "$marker"
+      else
+        printf 'error\t%s\n' "another worklist fetch has held the lock for ${i} s and has not written a cache yet -- it is still running or it died; retry shortly" > "$marker"
+      fi
+    fi
     return 0
   fi
   printf '%s' $$ > "$lock"

--- a/.local/bin/worklist.test.sh
+++ b/.local/bin/worklist.test.sh
@@ -30,7 +30,10 @@ cd "$S/repo" || exit 1
 
 # --- the board -----------------------------------------------------------------
 {
-  printf '# Board\n\n## Solace'"'"'s\n- [ ] **Not an agent card** — [x](https://example.invalid)\n\n## Claude'"'"'s\n'
+  printf '# Board\n\n## Needs ruling\n'
+  printf -- '- [ ] **Board sections** — decide whether a question is a card or an issue ([o/r#90](https://github.com/o/r/pull/90))\n'
+  printf -- '- [ ] **Engine pin** — decide whether to pin the engine by tag ([o/r#93](https://github.com/o/r/pull/93))\n'
+  printf '\n## Solace'"'"'s\n- [ ] **Not an agent card** — [x](https://example.invalid)\n\n## Claude'"'"'s\n'
   for i in 1 2 3 4 5 6 7 8 9 10; do
     printf -- '- [ ] **Card %s** — a card body long enough to be cut at eighty characters when brief is asked for ([link](https://example.invalid/%s))\n' "$i" "$i"
   done
@@ -45,10 +48,10 @@ pr() { # number title draft mergeable rollup automerge unresolved contexts-json 
      reviewThreads:{nodes:(([range($u)] | map({isResolved:false})) + [{isResolved:true}])},
      commits:{nodes:[{commit:{statusCheckRollup:(if $r == "NONE" then null else {state:$r, contexts:{nodes:$cx}} end)}}]}}'
 }
-issue() { # number title labels-json assignees-json milestone-or-null comments-json
-  jq -n --argjson n "$1" --arg t "$2" --argjson l "$3" --argjson a "$4" --argjson ms "$5" --argjson c "$6" '
+issue() { # number title labels-json milestone-or-null
+  jq -n --argjson n "$1" --arg t "$2" --argjson l "$3" --argjson ms "$4" '
     {number:$n, title:$t, url:"https://github.com/o/alpha/issues/\($n)", labels:{nodes:($l|map({name:.}))},
-     assignees:{nodes:($a|map({login:.}))}, milestone:(if $ms then {title:$ms} else null end), comments:{nodes:$c}}'
+     milestone:(if $ms then {title:$ms} else null end)}'
 }
 green='[{"name":"ci-gate / gate","conclusion":"SUCCESS"}]'
 red='[{"name":"ci-gate / gate","conclusion":"FAILURE"},{"context":"coverage","state":"FAILURE"},{"name":"lint","conclusion":"SUCCESS"}]'
@@ -61,15 +64,12 @@ long_title="A title that runs well past the eighty character mark so that brief 
   pr 13 "Red PR" false MERGEABLE FAILURE false 0 "$red" o; echo ,
   pr 14 "Release PR" false MERGEABLE NONE false 0 '[]' 'release-please[bot]'
   echo ']},"issues":{"nodes":['
-  issue 20 "Needs a ruling" '["needs-ruling"]' '[]' null '[]'; echo ,
-  issue 21 "Ruled thing" '["needs-ruling"]' '[]' null '[{"author":{"login":"o"},"body":"Ruled: yes, do it"}]'; echo ,
-  issue 22 "Ruled by a stranger" '["needs-ruling"]' '[]' null '[{"author":{"login":"someone"},"body":"Ruled: no"}]'; echo ,
-  issue 23 "Ready issue" '["ready"]' '[]' null '[]'; echo ,
-  issue 24 "Blocked issue" '["blocked","ready"]' '[]' null '[]'; echo ,
-  issue 25 "Unlabelled" '[]' '[]' null '[]'; echo ,
-  issue 26 "Deferred" '[]' '[]' '"1.0"' '[]'; echo ,
-  issue 27 "Assigned" '[]' '["o"]' null '[]'; echo ,
-  issue 28 "$long_title" '["ready"]' '[]' null '[]'
+  issue 23 "Ready issue" '["ready"]' null; echo ,
+  issue 24 "Blocked issue" '["blocked","ready"]' null; echo ,
+  issue 25 "Unlabelled" '[]' null; echo ,
+  issue 26 "Deferred" '[]' '"1.0"'; echo ,
+  issue 27 "Formerly assigned" '[]' null; echo ,
+  issue 28 "$long_title" '["ready"]' null
   echo ']},"refs":{"nodes":[{"name":"main","associatedPullRequests":{"totalCount":0}},{"name":"release-please--branches--main","associatedPullRequests":{"totalCount":0}},{"name":"feature-x","associatedPullRequests":{"totalCount":0}},{"name":"pr-branch","associatedPullRequests":{"totalCount":1}}]}}}}'
 } | jq -c . > "$FIXTURES/alpha.json"
 jq -nc '{data:{repository:{defaultBranchRef:{name:"main"},pullRequests:{nodes:[{number:5,title:"Draft PR",url:"https://github.com/o/beta/pull/5",isDraft:true,mergeable:"MERGEABLE",autoMergeRequest:null,author:{login:"o"},reviewThreads:{nodes:[]},commits:{nodes:[{commit:{statusCheckRollup:null}}]}}]},issues:{nodes:[]},refs:{nodes:[{name:"main",associatedPullRequests:{totalCount:0}}]}}}}' > "$FIXTURES/beta.json"
@@ -131,18 +131,21 @@ OUT_ALL=$OUT
 OUT=$(section "Solace's turn")
 has 'ready PR is Solace'"'"'s turn' '^  alpha#10  Ready PR  https://github.com/o/alpha/pull/10$'
 has 'release PR (no checks, bot author) is Solace'"'"'s turn, author named' '^  alpha#14  Release PR  -- by release-please\[bot\]'
-has 'assigned issue is Solace'"'"'s turn' '^  alpha#27  Assigned .* \(assigned\)$'
+lacks 'no issue reaches Solace'"'"'s turn' 'alpha#2[0-9]'
+lacks 'the (assigned) suffix is gone' '\(assigned\)'
 lacks 'queued PR not Solace'"'"'s turn' 'alpha#11'
 lacks 'threaded PR not Solace'"'"'s turn' 'alpha#12'
 lacks 'red PR not Solace'"'"'s turn' 'alpha#13'
 lacks 'draft PR not Solace'"'"'s turn' 'beta#5'
 OUT=$(section "Queued (auto-merge)"); has 'queued PR listed separately' '^  alpha#11  Queued PR'
+OUT=$OUT_ALL
+has 'Needs ruling reads the board section' "^Needs ruling, showing 2 of 2$"
 OUT=$(section "Needs ruling")
-has 'needs-ruling without a ruling' '^  alpha#20  Needs a ruling'
-has 'a stranger'"'"'s Ruled comment does not count' '^  alpha#22  Ruled by a stranger'
-lacks 'ruled issue left this bucket' 'alpha#21'
-OUT=$(section "Ruled, unlanded"); has 'owner comment starting Ruled' '^  alpha#21  Ruled thing'
-OUT=$(section "Ready"); has 'ready label' '^  alpha#23  Ready issue'; lacks 'blocked beats ready' 'alpha#24'; lacks 'needs-ruling beats ready' 'alpha#2[012]'
+has 'a ruling card renders' '^  \*\*Board sections\*\* — decide whether a question is a card or an issue'
+lacks 'no issue reaches Needs ruling' 'alpha#'
+OUT=$OUT_ALL
+lacks 'the Ruled, unlanded bucket is gone' 'Ruled, unlanded'
+OUT=$(section "Ready"); has 'ready label' '^  alpha#23  Ready issue'; lacks 'blocked beats ready' 'alpha#24'
 OUT=$(section "Blocked"); has 'blocked label' '^  alpha#24  Blocked issue'
 OUT=$(section "Not ready (agent's turn)")
 has 'unresolved thread named as a count' '^  alpha#12  Threaded PR  -- 1 unresolved thread\(s\)'
@@ -150,7 +153,7 @@ has 'failing checks named, never a boolean' '^  alpha#13  Red PR  -- failing: ci
 lacks 'a green check is not listed as failing' 'lint'
 has 'draft noted' '^  beta#5  Draft PR  -- draft'
 OUT=$OUT_ALL
-has 'untriaged is a count, deferred separately' '^Untriaged: 1 \(deferred to a milestone: 1\)$'
+has 'untriaged is a count, deferred separately' '^Untriaged: 2 \(deferred to a milestone: 1\)$'
 OUT=$(section "Stranded branches (no PR)")
 has 'branch with no PR' '^  alpha: feature-x$'
 lacks 'main is not stranded' 'main'; lacks 'release-please branch is not stranded' 'release-please'; lacks 'branch with a PR is not stranded' 'pr-branch'

--- a/.local/bin/worklist.test.sh
+++ b/.local/bin/worklist.test.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# Tests for worklist. Run: bash .local/bin/worklist.test.sh
+# Set AWK_PATH to a directory whose `awk` is another implementation (mawk,
+# gawk, original-awk) to run the same cases under it.
+#
+# What matters: every PR and issue lands in the bucket the routing table says,
+# failing checks are named, a cached view is served at once and refreshed
+# behind the caller, --brief never waits on a hung GitHub, and every failure
+# is named by cause rather than swallowed. gh is faked; GH_MODE picks a reply.
+set -uo pipefail
+[ -n "${AWK_PATH:-}" ] && PATH="$AWK_PATH:$PATH"
+
+WL="$(cd "$(dirname "$0")" && pwd)/worklist"
+pass=0; fail=0
+S=$(mktemp -d); export S
+cleanup() {
+  pkill -f "$S/tmp/worklist-marker" 2>/dev/null
+  pkill -f "$S/bin/gh" 2>/dev/null
+  rm -rf "$S"
+}
+trap cleanup EXIT
+mkdir -p "$S/bin" "$S/home" "$S/cache" "$S/tmp" "$S/fx" "$S/repo" "$S/nogit" "$S/state/.git" "$S/state/state/global"
+export HOME="$S/home" XDG_CACHE_HOME="$S/cache" TMPDIR="$S/tmp" CLAUDE_STATE_REPO="$S/state" FIXTURES="$S/fx"
+export GH_LOG="$S/gh.log"; : > "$GH_LOG"
+CACHE="$S/cache/worklist"
+export PATH="$S/bin:$PATH"
+
+git -C "$S/repo" init -q && git -C "$S/repo" remote add origin https://github.com/o/alpha.git
+cd "$S/repo" || exit 1
+
+# --- the board -----------------------------------------------------------------
+{
+  printf '# Board\n\n## Solace'"'"'s\n- [ ] **Not an agent card** — [x](https://example.invalid)\n\n## Claude'"'"'s\n'
+  for i in 1 2 3 4 5 6 7 8 9 10; do
+    printf -- '- [ ] **Card %s** — a card body long enough to be cut at eighty characters when brief is asked for ([link](https://example.invalid/%s))\n' "$i" "$i"
+  done
+  printf -- '- [x] **Ticked card** — done ([link](https://example.invalid/t))\n'
+} > "$S/state/state/global/kanban.md"
+
+# --- canned GitHub -------------------------------------------------------------
+pr() { # number title draft mergeable rollup automerge unresolved contexts-json author
+  jq -n --argjson n "$1" --arg t "$2" --argjson d "$3" --arg m "$4" --arg r "$5" --argjson am "$6" --argjson u "$7" --argjson cx "$8" --arg a "$9" '
+    {number:$n, title:$t, url:"https://github.com/o/alpha/pull/\($n)", isDraft:$d, mergeable:$m,
+     autoMergeRequest:(if $am then {enabledAt:"2026-09-08T00:00:00Z"} else null end), author:{login:$a},
+     reviewThreads:{nodes:(([range($u)] | map({isResolved:false})) + [{isResolved:true}])},
+     commits:{nodes:[{commit:{statusCheckRollup:(if $r == "NONE" then null else {state:$r, contexts:{nodes:$cx}} end)}}]}}'
+}
+issue() { # number title labels-json assignees-json milestone-or-null comments-json
+  jq -n --argjson n "$1" --arg t "$2" --argjson l "$3" --argjson a "$4" --argjson ms "$5" --argjson c "$6" '
+    {number:$n, title:$t, url:"https://github.com/o/alpha/issues/\($n)", labels:{nodes:($l|map({name:.}))},
+     assignees:{nodes:($a|map({login:.}))}, milestone:(if $ms then {title:$ms} else null end), comments:{nodes:$c}}'
+}
+green='[{"name":"ci-gate / gate","conclusion":"SUCCESS"}]'
+red='[{"name":"ci-gate / gate","conclusion":"FAILURE"},{"context":"coverage","state":"FAILURE"},{"name":"lint","conclusion":"SUCCESS"}]'
+long_title="A title that runs well past the eighty character mark so that brief output has to cut it short somewhere"
+{
+  echo '{"data":{"repository":{"defaultBranchRef":{"name":"main"},"pullRequests":{"nodes":['
+  pr 10 "Ready PR" false MERGEABLE SUCCESS false 0 "$green" o; echo ,
+  pr 11 "Queued PR" false MERGEABLE SUCCESS true 0 "$green" o; echo ,
+  pr 12 "Threaded PR" false MERGEABLE SUCCESS false 1 "$green" o; echo ,
+  pr 13 "Red PR" false MERGEABLE FAILURE false 0 "$red" o; echo ,
+  pr 14 "Release PR" false MERGEABLE NONE false 0 '[]' 'release-please[bot]'
+  echo ']},"issues":{"nodes":['
+  issue 20 "Needs a ruling" '["needs-ruling"]' '[]' null '[]'; echo ,
+  issue 21 "Ruled thing" '["needs-ruling"]' '[]' null '[{"author":{"login":"o"},"body":"Ruled: yes, do it"}]'; echo ,
+  issue 22 "Ruled by a stranger" '["needs-ruling"]' '[]' null '[{"author":{"login":"someone"},"body":"Ruled: no"}]'; echo ,
+  issue 23 "Ready issue" '["ready"]' '[]' null '[]'; echo ,
+  issue 24 "Blocked issue" '["blocked","ready"]' '[]' null '[]'; echo ,
+  issue 25 "Unlabelled" '[]' '[]' null '[]'; echo ,
+  issue 26 "Deferred" '[]' '[]' '"1.0"' '[]'; echo ,
+  issue 27 "Assigned" '[]' '["o"]' null '[]'; echo ,
+  issue 28 "$long_title" '["ready"]' '[]' null '[]'
+  echo ']},"refs":{"nodes":[{"name":"main","associatedPullRequests":{"totalCount":0}},{"name":"release-please--branches--main","associatedPullRequests":{"totalCount":0}},{"name":"feature-x","associatedPullRequests":{"totalCount":0}},{"name":"pr-branch","associatedPullRequests":{"totalCount":1}}]}}}}'
+} | jq -c . > "$FIXTURES/alpha.json"
+jq -nc '{data:{repository:{defaultBranchRef:{name:"main"},pullRequests:{nodes:[{number:5,title:"Draft PR",url:"https://github.com/o/beta/pull/5",isDraft:true,mergeable:"MERGEABLE",autoMergeRequest:null,author:{login:"o"},reviewThreads:{nodes:[]},commits:{nodes:[{commit:{statusCheckRollup:null}}]}}]},issues:{nodes:[]},refs:{nodes:[{name:"main",associatedPullRequests:{totalCount:0}}]}}}}' > "$FIXTURES/beta.json"
+# seven more ready issues, for the +N more line
+jq -c '.data.repository.issues.nodes += [range(30;37) | {number:., title:"Ready \(.)", url:"https://github.com/o/alpha/issues/\(.)", labels:{nodes:[{name:"ready"}]}, assignees:{nodes:[]}, milestone:null, comments:{nodes:[]}}]' "$FIXTURES/alpha.json" > "$FIXTURES/alpha-many.json"
+
+cat > "$S/bin/gh" <<'GH'
+#!/bin/sh
+echo "$*" >> "$GH_LOG"
+mode=${GH_MODE:-ok}
+case $mode in
+  hang) sleep 30; exit 1 ;;
+  unauth) echo "To get started with GitHub CLI, please run:  gh auth login" >&2; exit 4 ;;
+  network) echo "error connecting to api.github.com" >&2; exit 1 ;;
+esac
+case "$1 $2" in
+  "repo view") printf '{"repositoryTopics":[{"name":"other"},{"name":"project-demo"}]}\n' ;;
+  "repo list") printf '[{"name":"alpha"},{"name":"beta"}]\n' ;;
+  "search prs") printf '[{"number":1},{"number":2},{"number":3}]\n' ;;
+  "search issues") printf '[{"number":1},{"number":2}]\n' ;;
+  "api graphql")
+    name=""; for a in "$@"; do case $a in name=*) name=${a#name=} ;; esac; done
+    if [ "$mode" = 403 ] && [ "$name" = beta ]; then echo "gh: Resource not accessible by integration (HTTP 403)" >&2; exit 1; fi
+    if [ "$mode" = many ] && [ "$name" = alpha ]; then name=alpha-many; fi
+    cat "$FIXTURES/$name.json" ;;
+  *) echo "gh shim: unexpected $*" >&2; exit 1 ;;
+esac
+GH
+chmod +x "$S/bin/gh"
+
+# --- helpers -----------------------------------------------------------------
+ok()   { pass=$((pass + 1)); }
+bad()  { fail=$((fail + 1)); printf 'FAIL: %s\n' "$1"; [ -n "${2:-}" ] && printf '%s\n' "$2" | sed 's/^/    /'; }
+has()  { if printf '%s\n' "$OUT" | grep -Eq -- "$2"; then ok; else bad "$1 (missing /$2/)" "$OUT"; fi; }
+lacks(){ if printf '%s\n' "$OUT" | grep -Eq -- "$2"; then bad "$1 (has /$2/)" "$OUT"; else ok; fi; }
+eq()   { if [ "$2" = "$3" ]; then ok; else bad "$1: want [$2] got [$3]"; fi; }
+assert() { local d=$1; shift; if "$@"; then ok; else bad "$d"; fi; }
+# the lines between a bucket heading and the next unindented line
+section() { printf '%s\n' "$OUT_ALL" | awk -v h="$1" 'f && /^[^ ]/ {exit} f {print} index($0, h) == 1 {f=1}'; }
+run() { OUT=$(sh "$WL" "$@" 2>&1); RC=$?; OUT_ALL=$OUT; }
+calls() { grep -c -- "$1" "$GH_LOG"; }
+wait_refresh() { # until the cache written_at is newer than $1, at most 15 s
+  local i=0
+  while [ "$i" -lt 15 ] && [ "$(jq -r .written_at "$CACHE/o-demo.json")" -le "$1" ]; do sleep 1; i=$((i + 1)); done
+}
+
+# --- ok: two repos, every bucket ---------------------------------------------------
+: > "$GH_LOG"
+run
+eq 'exit 0' 0 "$RC"
+has 'stamp without cache note' '^as of [0-9]{2}:[0-9]{2}Z$'
+has 'scope names the project and repos' '^project demo \(o\): alpha, beta$'
+has 'account-wide counts' '^counts: 3 open PRs, 2 open issues across o$'
+eq 'one GraphQL call per repo' 2 "$(calls 'api graphql')"
+eq 'topic looked up once' 1 "$(calls 'repo view o/alpha --json repositoryTopics')"
+eq 'repo set from the topic' 1 "$(calls 'repo list o --topic project-demo')"
+eq 'two account-wide searches' 2 "$(calls 'search ')"
+OUT_ALL=$OUT
+OUT=$(section "Solace's turn")
+has 'ready PR is Solace'"'"'s turn' '^  alpha#10  Ready PR  https://github.com/o/alpha/pull/10$'
+has 'release PR (no checks, bot author) is Solace'"'"'s turn, author named' '^  alpha#14  Release PR  -- by release-please\[bot\]'
+has 'assigned issue is Solace'"'"'s turn' '^  alpha#27  Assigned .* \(assigned\)$'
+lacks 'queued PR not Solace'"'"'s turn' 'alpha#11'
+lacks 'threaded PR not Solace'"'"'s turn' 'alpha#12'
+lacks 'red PR not Solace'"'"'s turn' 'alpha#13'
+lacks 'draft PR not Solace'"'"'s turn' 'beta#5'
+OUT=$(section "Queued (auto-merge)"); has 'queued PR listed separately' '^  alpha#11  Queued PR'
+OUT=$(section "Needs ruling")
+has 'needs-ruling without a ruling' '^  alpha#20  Needs a ruling'
+has 'a stranger'"'"'s Ruled comment does not count' '^  alpha#22  Ruled by a stranger'
+lacks 'ruled issue left this bucket' 'alpha#21'
+OUT=$(section "Ruled, unlanded"); has 'owner comment starting Ruled' '^  alpha#21  Ruled thing'
+OUT=$(section "Ready"); has 'ready label' '^  alpha#23  Ready issue'; lacks 'blocked beats ready' 'alpha#24'; lacks 'needs-ruling beats ready' 'alpha#2[012]'
+OUT=$(section "Blocked"); has 'blocked label' '^  alpha#24  Blocked issue'
+OUT=$(section "Not ready (agent's turn)")
+has 'unresolved thread named as a count' '^  alpha#12  Threaded PR  -- 1 unresolved thread\(s\)'
+has 'failing checks named, never a boolean' '^  alpha#13  Red PR  -- failing: ci-gate / gate, coverage'
+lacks 'a green check is not listed as failing' 'lint'
+has 'draft noted' '^  beta#5  Draft PR  -- draft'
+OUT=$OUT_ALL
+has 'untriaged is a count, deferred separately' '^Untriaged: 1 \(deferred to a milestone: 1\)$'
+OUT=$(section "Stranded branches (no PR)")
+has 'branch with no PR' '^  alpha: feature-x$'
+lacks 'main is not stranded' 'main'; lacks 'release-please branch is not stranded' 'release-please'; lacks 'branch with a PR is not stranded' 'pr-branch'
+OUT=$OUT_ALL
+has 'board heading with counts' "^Board \(## Claude's, showing 8 of 10\)$"
+eq 'at most eight cards' 8 "$(printf '%s\n' "$OUT" | grep -c '^  \*\*Card ')"
+lacks 'ticked card dropped' 'Ticked card'
+lacks 'other sections dropped' 'Not an agent card'
+has 'full mode keeps the whole card' 'eighty characters when brief is asked for \(\[link\]'
+has 'long title uncut in full mode' "$long_title"
+assert 'cache written under owner-project key' test -f "$CACHE/o-demo.json"
+
+# --- cache-fresh: served at once, nothing fetched ---------------------------------
+: > "$GH_LOG"
+run
+has 'stamp says cached' '^as of [0-9]{2}:[0-9]{2}Z \(cached <1 min\)$'
+has 'content from cache' 'alpha#10  Ready PR'
+eq 'no gh call on a fresh cache' 0 "$(calls '')"
+assert 'no refresh spawned on a fresh cache' test ! -f "$CACHE/o-demo.lock"
+
+# --- cache-stale: served at once, refreshed behind the caller --------------------------
+old=$(( $(date +%s) - 1800 ))
+jq --argjson t "$old" '.written_at = $t' "$CACHE/o-demo.json" > "$CACHE/tmp.json" && mv "$CACHE/tmp.json" "$CACHE/o-demo.json"
+: > "$GH_LOG"
+t0=$(date +%s); run; t1=$(date +%s)
+has 'stamp says how stale' '^as of [0-9]{2}:[0-9]{2}Z \(cached 30 min\)$'
+assert "stale cache served immediately (took $((t1 - t0)) s)" test $((t1 - t0)) -le 2
+wait_refresh "$old"
+assert 'background refresh rewrote the cache' test "$(jq -r .written_at "$CACHE/o-demo.json")" -gt "$old"
+eq 'refresh fetched both repos' 2 "$(calls 'api graphql')"
+
+# --- --fresh bypasses the cache ------------------------------------------------------
+: > "$GH_LOG"; run --fresh
+has 'fresh stamp has no cache note' '^as of [0-9]{2}:[0-9]{2}Z$'
+eq 'fresh fetches' 2 "$(calls 'api graphql')"
+
+# --- --brief ---------------------------------------------------------------------------
+GH_MODE=many run --fresh --brief
+eq 'exit 0' 0 "$RC"
+assert "brief is <= 3 KB ($(printf '%s' "$OUT" | wc -c) bytes)" test "$(printf '%s' "$OUT" | wc -c)" -le 3072
+OUT_ALL=$OUT
+OUT=$(section "Ready")
+eq 'bucket capped at five lines plus the overflow line' 6 "$(printf '%s\n' "$OUT" | grep -c .)"
+has 'overflow line' '^  \+4 more \(run worklist\)$'
+OUT=$OUT_ALL
+lacks 'no urls in brief' 'https://github.com/o/alpha/pull/10'
+cut_title=$(printf '%s\n' "$OUT" | sed -n 's/^  alpha#28  //p')
+eq 'long title cut to 80 chars ending in ...' '80 ...' "$(printf '%s' "$cut_title" | wc -m | tr -d ' ') $(printf '%s' "$cut_title" | tail -c 3)"
+lacks 'long title not whole' 'cut it short somewhere'
+card1=$(printf '%s\n' "$OUT" | sed -n 's/^  \(\*\*Card 1\*\*.*\)$/\1/p')
+eq 'card cut to 80 chars ending in ...' '80 ...' "$(printf '%s' "$card1" | wc -m | tr -d ' ') $(printf '%s' "$card1" | tail -c 3)"
+has 'brief keeps the failing check names' 'failing: ci-gate / gate, coverage'
+
+# --- --json ---------------------------------------------------------------------------
+run --json
+eq 'json exit 0' 0 "$RC"
+eq 'json carries both repos' 2 "$(printf '%s' "$OUT" | jq '.records | length')"
+eq 'json carries the raw PRs' 5 "$(printf '%s' "$OUT" | jq '.records[0].data.pullRequests.nodes | length')"
+
+# --- one repo 403 ---------------------------------------------------------------------------
+GH_MODE=403 run --fresh
+eq 'exit 0' 0 "$RC"
+has 'the 403 repo named with the fix' '^o/beta: 403 -- attach the repo$'
+has 'the other repo still rendered' 'alpha#10  Ready PR'
+GH_MODE=403 run --fresh --json; eq 'json exit 0 when something was fetched' 0 "$RC"
+
+# --- gh missing -------------------------------------------------------------------------
+mkdir -p "$S/nogh"; for b in sh jq awk sed grep head cut tr date sleep cat mktemp mv rm mkdir git wc dirname nohup setsid; do p=$(command -v $b) && ln -sf "$p" "$S/nogh/$b"; done
+rm -f "$CACHE"/*.json
+OUT=$(PATH="$S/nogh" sh "$WL" 2>&1); RC=$?
+eq 'exit 0 without gh' 0 "$RC"
+has 'says no gh' '^no gh'
+has 'board still printed without gh' "^Board \(## Claude's"
+OUT=$(PATH="$S/nogh" sh "$WL" --json 2>&1); RC=$?
+eq 'json exits 1 with nothing fetched' 1 "$RC"
+
+# --- unauthenticated, network: one line, not one per repo -----------------------------------
+GH_MODE=unauth run --fresh
+eq 'exit 0' 0 "$RC"
+has 'unauthenticated named once' '^gh unauthenticated$'
+eq 'not repeated per repo' 1 "$(printf '%s\n' "$OUT" | grep -c '^gh unauthenticated$')"
+has 'counts named unavailable' '^counts: unavailable'
+GH_MODE=network run --fresh
+has 'network named' '^network$'
+GH_MODE=network run --fresh --json; eq 'json exits 1 when nothing fetched' 1 "$RC"
+
+# --- hang: brief returns inside 6 s --------------------------------------------------------
+: > "$GH_LOG"
+t0=$(date +%s); GH_MODE=hang run --fresh --brief; t1=$(date +%s)
+eq 'exit 0' 0 "$RC"
+assert "brief returned in $((t1 - t0)) s (limit 6)" test $((t1 - t0)) -le 6
+has 'says GitHub has not answered' 'has not answered in 5 s'
+has 'board still printed' "^Board \(## Claude's"
+pkill -f "$S/tmp/worklist-marker" 2>/dev/null; pkill -f "$S/bin/gh" 2>/dev/null
+
+# --- --here and an explicit project skip the topic lookup ------------------------------------
+: > "$GH_LOG"; run --here --fresh
+has 'scope is the cwd repo' '^repo o/alpha alpha$'
+eq 'no topic lookup' 0 "$(calls 'repo view')"
+eq 'no repo list' 0 "$(calls 'repo list')"
+assert 'here cache keyed by repo' test -f "$CACHE/o-alpha.json"
+: > "$GH_LOG"; run demo --fresh
+has 'explicit project' '^project demo \(o\): alpha, beta$'
+eq 'no topic lookup with a project name' 0 "$(calls 'repo view')"
+eq 'repo set from the named topic' 1 "$(calls 'repo list o --topic project-demo')"
+
+# --- not in a repo ------------------------------------------------------------------------------
+cd "$S/nogit" || exit 1
+run
+eq 'exit 0 outside a repo' 0 "$RC"
+has 'says so' '^not in a GitHub repo'
+cd "$S/repo" || exit 1
+
+# --- board edge: no kanban ------------------------------------------------------------------
+mv "$S/state/state/global/kanban.md" "$S/kb.bak"; run; has 'missing board named' '^Board: no kanban.md at'; mv "$S/kb.bak" "$S/state/state/global/kanban.md"
+
+printf '%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/.local/bin/worklist.test.sh
+++ b/.local/bin/worklist.test.sh
@@ -31,8 +31,12 @@ cd "$S/repo" || exit 1
 # --- the board -----------------------------------------------------------------
 {
   printf '# Board\n\n## Needs ruling\n'
+  printf -- '### demo\n'
   printf -- '- [ ] **Board sections** — decide whether a question is a card or an issue ([o/r#90](https://github.com/o/r/pull/90))\n'
+  printf -- '### global\n'
   printf -- '- [ ] **Engine pin** — decide whether to pin the engine by tag ([o/r#93](https://github.com/o/r/pull/93))\n'
+  printf -- '### colregs\n'
+  printf -- '- [ ] **Give-way rule** — decide whether rule 15 wins ([o/r#94](https://github.com/o/r/pull/94))\n'
   printf '\n## Solace'"'"'s\n- [ ] **Not an agent card** — [x](https://example.invalid)\n\n## Claude'"'"'s\n'
   for i in 1 2 3 4 5 6 7 8 9 10; do
     printf -- '- [ ] **Card %s** — a card body long enough to be cut at eighty characters when brief is asked for ([link](https://example.invalid/%s))\n' "$i" "$i"
@@ -140,9 +144,27 @@ lacks 'draft PR not Solace'"'"'s turn' 'beta#5'
 OUT=$(section "Queued (auto-merge)"); has 'queued PR listed separately' '^  alpha#11  Queued PR'
 OUT=$OUT_ALL
 has 'Needs ruling reads the board section' "^Needs ruling, showing 2 of 2$"
+first_section=$(printf '%s\n' "$OUT_ALL" | grep -E "^(Needs ruling|Solace's turn|Queued|Ready:|Board \()" | head -1)
+assert 'Needs ruling prints before every GitHub bucket' [ "$first_section" = "Needs ruling, showing 2 of 2" ]
+assert 'and after the counts header' \
+  [ "$(printf '%s\n' "$OUT_ALL" | grep -nE '^(counts:|Needs ruling)' | head -1 | cut -d: -f1)" -lt \
+    "$(printf '%s\n' "$OUT_ALL" | grep -n '^Needs ruling' | cut -d: -f1)" ]
 OUT=$(section "Needs ruling")
-has 'a ruling card renders' '^  \*\*Board sections\*\* — decide whether a question is a card or an issue'
+has 'a ruling card renders, unprefixed in its own project' '^  \*\*Board sections\*\* — decide whether a question is a card or an issue'
+has '### global is in scope everywhere' '^  \*\*Engine pin\*\*'
+lacks 'another project'"'"'s group is out of scope' 'Give-way rule'
+has 'the hidden groups are counted' '^  \+1 in other projects \(worklist --all-rulings\)$'
 lacks 'no issue reaches Needs ruling' 'alpha#'
+OUT=$OUT_ALL
+
+# --all-rulings: every group, each card named by its group.
+run --all-rulings
+has 'all rulings shows every group' '^Needs ruling, showing 3 of 3$'
+OUT=$(section "Needs ruling")
+has 'a card carries its group'      '^  demo: \*\*Board sections\*\*'
+has 'the other project is listed'   '^  colregs: \*\*Give-way rule\*\*'
+lacks 'nothing is hidden'           'in other projects'
+run
 OUT=$OUT_ALL
 lacks 'the Ruled, unlanded bucket is gone' 'Ruled, unlanded'
 OUT=$(section "Ready"); has 'ready label' '^  alpha#23  Ready issue'; lacks 'blocked beats ready' 'alpha#24'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,8 +68,9 @@ happen to be tracked here, but they are not *about* this repo. This file is.
   name boats, hosts and services. They go to the private
   `claude_prompts_scratch` repo under `state/global/`. `.gitignore` blocks the
   known paths; that is a backstop, not permission to try.
-- **Dotfiles has no board of its own.** Its loops are dotfiles issues; a
-  card on the global board only when a loop has no GitHub home.
+- **Dotfiles has no board of its own.** A loop that clears the issue bar —
+  a fresh session could start from the body alone — becomes a dotfiles
+  issue; the rest is a card on the global board, a log line, or nothing.
 - Real hostnames, boat names, service URLs and account identifiers stay out of
   tracked files, including in comments and example output. Use placeholders.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,8 +68,8 @@ happen to be tracked here, but they are not *about* this repo. This file is.
   name boats, hosts and services. They go to the private
   `claude_prompts_scratch` repo under `state/global/`. `.gitignore` blocks the
   known paths; that is a backstop, not permission to try.
-- **Dotfiles has no board of its own.** Its cards sit on the global board, and
-  anything carrying a question becomes a dotfiles issue that the card links to.
+- **Dotfiles has no board of its own.** Its loops are dotfiles issues; a
+  card on the global board only when a loop has no GitHub home.
 - Real hostnames, boat names, service URLs and account identifiers stay out of
   tracked files, including in comments and example output. Use placeholders.
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ degrades to `~/.claude/state/global` if it isn't checked out.
 | hook | event | what it does |
 | --- | --- | --- |
 | `session-start-seed-refresh.sh` | SessionStart | re-runs the cloud seed so a reused container tracks this repo, not the commit it was provisioned from |
-| `session-start-continuity.sh` | SessionStart | injects the open board, where the last three sessions left off, and the week's decision load |
+| `session-start-continuity.sh` | SessionStart | injects the live `worklist --brief` (PRs ready, rulings pending, agent-ready issues, the agent's board), where the last three sessions left off, and the week's decision load |
 | `stop-continuity.sh` | Stop | writes the session record, the decision log and an auto-checkpoint, then commits and pushes the state repo |
 | `measure-git-events.sh` | PostToolUse | logs branches created, PRs opened, cherry-picks |
 | `no-persistent-polling.sh` | PreToolUse | denies wakeups bound to a live session, which re-send its whole context on every fire |

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -224,7 +224,7 @@ seed script reads are set inline by the paste blob (`CLOUD_SESSION=1`) or by the
 harness (`CLAUDE_CODE_REMOTE=true`), so the field stays empty.
 
 **Verify** on the next session: `session-start-continuity.sh` prints a
-`config: <channel>@<sha> (installed <timestamp>)` line, then the board. A
+`config: <channel>@<sha> (installed <timestamp>)` line, then the worklist brief. A
 `config: DEGRADED` line means the installer never ran or didn't finish —
 see [a deleted hook keeps running](#a-deleted-hook-keeps-running) for the
 same `~/.claude/.sync-status.json` check. If it instead prints a "state repo
@@ -327,8 +327,8 @@ ls ~/.claude/hooks/
 bash ~/.claude/hooks/statusline-metrics.sh   # prints the status line, or nothing
 ```
 
-Then start a session: `session-start-continuity.sh` injecting the board is the
-end-to-end proof.
+Then start a session: `session-start-continuity.sh` injecting the worklist brief
+is the end-to-end proof.
 
 ## Change what the metrics readouts show
 


### PR DESCRIPTION
GitHub owns work state; the private board keeps only agent loops with no GitHub home; everything a session used to copy onto a card becomes a view computed at read time.

**Why.** The global board reached 128 cards (28 ticked-undeleted, 63 mirroring a PR or issue) and the SessionStart hook injected the first 16 of them, 8 ticked, into every session in every repo. Reconciling that text against GitHub was the sweep Mark called a waste of time. Prose rules against it already existed and were violated the day they were written, so the rules here are gates.

**What.**
- `.local/bin/worklist` — the live view: one GraphQL call per repo in the cwd's project (GitHub topic `project-<name>`), account-wide counts, buckets *Mark's turn / Queued / Needs ruling / Ruled unlanded / Ready / Blocked / Not ready / Untriaged / Stranded branches / Board*. Stale-while-revalidate cache, `--brief` ≤ 3 KB with an as-of stamp, per-cause failure lines, works without GNU `timeout`.
- `session-start-continuity.sh` — board dump replaced by `worklist --brief` under a 6 s cap; loud when the script is missing.
- `kanban-lint.sh` + `kanban-gate.sh` (Stop) + `stop-continuity.sh` refusing to stage a failing board — rules L1–L6 (ticked card, bullet above heading, foreign section, PR-shaped card keyed on the action verb, state words, unlinked card). Diff-based inside a repo so the legacy board does not block edits before migration.
- `public-issue-guard.sh` — PreToolUse gate on `gh issue|pr` writes and GitHub MCP write tools; denies on a hit against the private-terms list in the state repo; fails closed when the list is unreadable.
- Skills: `card-write` carries the routing table; `wrapup` §3 is now "issues this session opened", no sweep; `worklist` runs the script; `card-helper` walks an issue like a card. `CLAUDE.md` "only-I-can-do → card by link" is gone.
- Wiring: settings.json, cloud-session-setup INSTALL, hook-tests.yml runs `.local/bin/*.test.sh`.

**Tests.** Five new suites, 299 assertions, green under mawk and gawk locally; CI is the first `original-awk` run.

**Sequencing.** Merge before the board migration; the lint is diff-based, so the legacy board passes until its lines are touched. The Mergify `ready-for-mark` label rule is a separate PR on `.github` (#12). Migration of the existing 128 cards is a one-time script in the state repo, waiting on Mark's go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
