### PR TITLE
docs: pin the prose-budget engine with tags, and say why it lives here

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,32 @@ refuses, recording the refusal in the checkpoint rather than skipping quietly.
 that blocks the current task), `gate` (open-ended, mid-flight, needs her to
 reload context the session accumulated and she didn't).
 
+## The prose-budget engine
+
+`.local/bin/prose-budget` is one deterministic guard against documentation
+degrading under agent edits — line budgets, section word caps, a net-prose
+delta per change, narration and voice patterns. Three repositories had grown
+three drifting versions of it; this is the one they collapsed into. Each
+repository keeps only its `docs/budgets.json`.
+
+It lives here rather than in `mark-brannan/.github` beside the reusable
+workflow that runs it, because CI is the smaller half of its job: it is on
+`PATH` on every machine, two Claude Code hooks exec it (a `git commit` is
+denied on findings, an Edit or Write gets advice), and
+`cloud-session-setup.sh` seeds it. Hosting it elsewhere would mean fetching or
+vendoring it back into `$HOME` — the unsolved problem of
+[#17](https://github.com/mark-brannan/dotfiles/issues/17), taken on to avoid a
+tag.
+
+What the CI half needs instead is a version. An immutable
+`prose-budget/vX.Y.Z` tag here names an engine; `mark-brannan/.github` carries
+a moving `v1` that names a workflow *and*, through the `dotfiles-ref` default
+baked into it, that engine. Consumers pin `v1` and name a version nowhere,
+which matters because the one outage this design has actually caused was a
+stale pin sitting in three repositories at once, not a bad commit. Promotion
+and rollback are each one moved tag; a commit to `main` here reaches no
+consumer.
+
 ## Ephemeral cloud sessions
 
 Claude Code cloud sessions run as root on a throwaway Ubuntu VM with no

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -410,65 +410,56 @@ prose-budget --tree; echo "exit $?"     # 0, and one "OK" line
 
 ## Cut and promote a prose-budget engine version
 
-Two tags carry the engine into CI and nothing else does. This repository holds
-an immutable `prose-budget/vX.Y.Z` on the commit whose `.local/bin/prose-budget`
-you want; `mark-brannan/.github` holds a moving `v1` that consumer repositories
-pin. **No consumer names an engine version** — a pin in three repositories is
-what left every colregs, colregs-engine and symphony PR red once already.
-
-No checkout is involved, so none of this touches `$HOME`.
+Two tags carry the engine into CI. This repository holds an immutable
+`prose-budget/vX.Y.Z`; `mark-brannan/.github` holds a moving `v1` whose
+workflow names that tag as its `dotfiles-ref` default, and consumers pin `v1`.
+**Don't add a `dotfiles-ref` to a consumer** — a pin in three repositories is
+what went stale in three places at once. Nothing here checks anything out, so
+none of it touches `$HOME`.
 
 ```bash
-# 1. the engine change is on main and hook-tests.yml is green
-gh run list --repo mark-brannan/dotfiles --workflow hook-tests.yml --limit 1
+# 1. take the SHA from the latest green hook-tests run on main -- not
+#    "main" itself, which may have moved since that run
+read -r SHA OK < <(gh run list --repo mark-brannan/dotfiles --workflow hook-tests.yml \
+  --branch main --limit 1 --json headSha,conclusion --jq '.[0] | "\(.headSha) \(.conclusion)"')
+echo "$SHA $OK"                                   # ... success
 
-# 2. cut the engine tag. Its X.Y.Z must equal VERSION at
-#    .local/bin/prose-budget:25 -- the tag adds the `prose-budget/v` prefix,
-#    `prose-budget --version` prints the bare number: `prose-budget 1.1.0`
+# 2. cut the engine tag on that SHA. X.Y.Z is what `prose-budget --version`
+#    prints at that commit; the tag adds the `prose-budget/v` prefix
 gh api -X POST repos/mark-brannan/dotfiles/git/refs \
-  -f ref=refs/tags/prose-budget/v1.1.0 \
-  -f sha="$(gh api repos/mark-brannan/dotfiles/commits/main --jq .sha)"
+  -f ref=refs/tags/prose-budget/vX.Y.Z -f sha="$SHA"
 ```
 
-3. PR on `mark-brannan/.github` changing the `dotfiles-ref` default in
-   `.github/workflows/prose-budget.yml` to the new tag. Merge it.
+3. Open a PR on `mark-brannan/.github` changing the `dotfiles-ref` default in
+   `.github/workflows/prose-budget.yml` to `prose-budget/vX.Y.Z`. Merge it.
 
 ```bash
-# 4. promote: move v1 onto the merged commit. This is the moment all
-#    consumers change; until now nothing has.
+# 4. promote. Until this moment no consumer has changed.
 gh api -X PATCH repos/mark-brannan/.github/git/refs/tags/v1 \
   -f sha="$(gh api repos/mark-brannan/.github/commits/main --jq .sha)" -F force=true
+
+# 5. verify: the workflow at v1 must name the new engine tag
+gh api 'repos/mark-brannan/.github/contents/.github/workflows/prose-budget.yml?ref=v1' \
+  --jq .content | base64 -d | grep -A4 'dotfiles-ref:' | grep default:
 ```
 
-Verify statically first. These three catch a tag moved onto the wrong commit:
-the workflow at `v1` must name the new engine tag, and the engine blob at that
-tag must be byte-identical to the one on `main` that passed `hook-tests.yml`.
-
-```bash
-gh api repos/mark-brannan/.github/contents/.github/workflows/prose-budget.yml \
-  --ref v1 --jq .content | base64 -d | grep -A5 'dotfiles-ref:' | grep default:
-gh api repos/mark-brannan/dotfiles/contents/.local/bin/prose-budget \
-  --ref prose-budget/v1.1.0 --jq .sha
-gh api repos/mark-brannan/dotfiles/contents/.local/bin/prose-budget \
-  --ref main --jq .sha   # the two blob SHAs must match
-```
-
-Then verify end to end, on the first consumer run started **after** the tag
-move — no consumer workflow has a `workflow_dispatch` trigger, so this is the
-next push or pull request in one of them, not something you can force. A run
-from before the move proves nothing, so check its timestamp, not just its log:
+Then verify on the first consumer run that starts **after** the move. No
+consumer has a `workflow_dispatch` trigger, so wait for the next push or PR in
+one of them; a run from before the move proves nothing.
 
 ```bash
 gh run list --repo mark-brannan/colregs --workflow ci.yml --limit 1 \
-  --json databaseId,createdAt,conclusion   # createdAt must postdate the move
-gh run view <databaseId> --repo mark-brannan/colregs --log \
-  | grep -m1 'engine: prose-budget'        # names the engine that actually ran
+  --json databaseId,createdAt                    # createdAt after the move
+JOB=$(gh run view <databaseId> --repo mark-brannan/colregs --json jobs \
+  --jq '.jobs[] | select(.name | test("prose-budget")) | .databaseId')
+gh api "repos/mark-brannan/colregs/actions/jobs/$JOB/logs" | grep -m1 'dotfiles-ref:'
 ```
 
-If that line reports the old version, `v1` did not move or moved onto a commit
-whose workflow still names the old tag.
+That line is the ref the run actually fetched the engine from. If it still
+shows the old tag, `v1` did not move, or moved onto a commit whose workflow
+still names it.
 
-To roll back, move `v1` to the previous commit with the same `PATCH` — one
+To roll back, run step 4 with the previous `.github` commit's SHA. One
 command, all consumers, no PR.
 
 ## Set the auth token for the PR review workflows

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -424,23 +424,28 @@ read -r SHA OK < <(gh run list --repo mark-brannan/dotfiles --workflow hook-test
   --branch main --limit 1 --json headSha,conclusion --jq '.[0] | "\(.headSha) \(.conclusion)"')
 echo "$SHA $OK"                                   # ... success
 
-# 2. cut the engine tag on that SHA. X.Y.Z is what `prose-budget --version`
-#    prints at that commit; the tag adds the `prose-budget/v` prefix
-gh api -X POST repos/mark-brannan/dotfiles/git/refs \
-  -f ref=refs/tags/prose-budget/vX.Y.Z -f sha="$SHA"
+# 2. cut the engine tag on that SHA, named from the VERSION the engine
+#    declares at that commit (what `prose-budget --version` prints)
+TAG="prose-budget/v$(gh api "repos/mark-brannan/dotfiles/contents/.local/bin/prose-budget?ref=$SHA" \
+  --jq .content | base64 -d | awk -F'"' '/^VERSION = / {print $2; exit}')"
+echo "$TAG"                                       # prose-budget/vX.Y.Z
+gh api -X POST repos/mark-brannan/dotfiles/git/refs -f ref="refs/tags/$TAG" -f sha="$SHA"
 ```
 
-3. Open a PR on `mark-brannan/.github` changing the `dotfiles-ref` default in
-   `.github/workflows/prose-budget.yml` to `prose-budget/vX.Y.Z`. Merge it.
+**3 — PR on `mark-brannan/.github`** changing the `dotfiles-ref` default in
+`.github/workflows/prose-budget.yml` to `$TAG`. Merge it.
 
 ```bash
-# 4. promote. Until this moment no consumer has changed.
+# 4. record where v1 points now (the rollback target), then promote.
+#    Until the PATCH no consumer has changed.
+PREV=$(gh api repos/mark-brannan/.github/git/ref/tags/v1 --jq .object.sha); echo "$PREV"
 gh api -X PATCH repos/mark-brannan/.github/git/refs/tags/v1 \
   -f sha="$(gh api repos/mark-brannan/.github/commits/main --jq .sha)" -F force=true
 
-# 5. verify: the workflow at v1 must name the new engine tag
+# 5. verify: the workflow at v1 must name exactly the new tag
 gh api 'repos/mark-brannan/.github/contents/.github/workflows/prose-budget.yml?ref=v1' \
-  --jq .content | base64 -d | grep -A4 'dotfiles-ref:' | grep default:
+  --jq .content | base64 -d | grep -A4 'dotfiles-ref:' | grep -q "default: $TAG" \
+  && echo "v1 -> $TAG" || echo "v1 does NOT name $TAG"
 ```
 
 Then verify on the first consumer run that starts **after** the move. No
@@ -452,14 +457,15 @@ gh run list --repo mark-brannan/colregs --workflow ci.yml --limit 1 \
   --json databaseId,createdAt                    # createdAt after the move
 JOB=$(gh run view <databaseId> --repo mark-brannan/colregs --json jobs \
   --jq '.jobs[] | select(.name | test("prose-budget")) | .databaseId')
-gh api "repos/mark-brannan/colregs/actions/jobs/$JOB/logs" | grep -m1 'dotfiles-ref:'
+gh api "repos/mark-brannan/colregs/actions/jobs/$JOB/logs" | grep -m1 'dotfiles-ref:' \
+  | grep -q "dotfiles-ref: $TAG" && echo "ran $TAG" || echo "ran something else"
 ```
 
-That line is the ref the run actually fetched the engine from. If it still
-shows the old tag, `v1` did not move, or moved onto a commit whose workflow
-still names it.
+That line is the ref the run actually fetched the engine from. If it is not
+the new tag, `v1` did not move, or moved onto a commit whose workflow still
+names the old one.
 
-To roll back, run step 4 with the previous `.github` commit's SHA. One
+To roll back, run the `PATCH` from step 4 with `-f sha="$PREV"`. One
 command, all consumers, no PR.
 
 ## Set the auth token for the PR review workflows

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -422,8 +422,9 @@ No checkout is involved, so none of this touches `$HOME`.
 # 1. the engine change is on main and hook-tests.yml is green
 gh run list --repo mark-brannan/dotfiles --workflow hook-tests.yml --limit 1
 
-# 2. cut the engine tag; the name must equal what --version prints
-#    (VERSION at .local/bin/prose-budget:25)
+# 2. cut the engine tag. Its X.Y.Z must equal VERSION at
+#    .local/bin/prose-budget:25 -- the tag adds the `prose-budget/v` prefix,
+#    `prose-budget --version` prints the bare number: `prose-budget 1.1.0`
 gh api -X POST repos/mark-brannan/dotfiles/git/refs \
   -f ref=refs/tags/prose-budget/v1.1.0 \
   -f sha="$(gh api repos/mark-brannan/dotfiles/commits/main --jq .sha)"
@@ -439,18 +440,33 @@ gh api -X PATCH repos/mark-brannan/.github/git/refs/tags/v1 \
   -f sha="$(gh api repos/mark-brannan/.github/commits/main --jq .sha)" -F force=true
 ```
 
-Verify that `v1` really carries the new engine, and that a consumer run picks it
-up — the second is the one that distinguishes a promotion from a tag that moved
-onto the wrong commit:
+Verify statically first. These three catch a tag moved onto the wrong commit:
+the workflow at `v1` must name the new engine tag, and the engine blob at that
+tag must be byte-identical to the one on `main` that passed `hook-tests.yml`.
 
 ```bash
 gh api repos/mark-brannan/.github/contents/.github/workflows/prose-budget.yml \
-  --ref v1 --jq .content | base64 -d | grep -A6 'dotfiles-ref:' | grep default
-gh run list --repo mark-brannan/colregs --workflow ci.yml --limit 1
+  --ref v1 --jq .content | base64 -d | grep -A5 'dotfiles-ref:' | grep default:
+gh api repos/mark-brannan/dotfiles/contents/.local/bin/prose-budget \
+  --ref prose-budget/v1.1.0 --jq .sha
+gh api repos/mark-brannan/dotfiles/contents/.local/bin/prose-budget \
+  --ref main --jq .sha   # the two blob SHAs must match
 ```
 
-The `prose-budget` step logs `prose-budget X.Y.Z` before it runs, so the run
-log names the engine that produced the findings.
+Then verify end to end, on the first consumer run started **after** the tag
+move — no consumer workflow has a `workflow_dispatch` trigger, so this is the
+next push or pull request in one of them, not something you can force. A run
+from before the move proves nothing, so check its timestamp, not just its log:
+
+```bash
+gh run list --repo mark-brannan/colregs --workflow ci.yml --limit 1 \
+  --json databaseId,createdAt,conclusion   # createdAt must postdate the move
+gh run view <databaseId> --repo mark-brannan/colregs --log \
+  | grep -m1 'engine: prose-budget'        # names the engine that actually ran
+```
+
+If that line reports the old version, `v1` did not move or moved onto a commit
+whose workflow still names the old tag.
 
 To roll back, move `v1` to the previous commit with the same `PATCH` — one
 command, all consumers, no PR.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -37,6 +37,7 @@ and the scars behind them — see [README.md § Conventions](README.md).
 - [Check a repo's prose budgets](#check-a-repos-prose-budgets)
 
 **GitHub repository**
+- [Cut and promote a prose-budget engine version](#cut-and-promote-a-prose-budget-engine-version)
 - [Set the auth token for the PR review workflows](#set-the-auth-token-for-the-pr-review-workflows)
 - [Re-sign a branch whose commits are unsigned](#re-sign-a-branch-whose-commits-are-unsigned)
 
@@ -406,6 +407,53 @@ prints the hash to grandfather).
 ```bash
 prose-budget --tree; echo "exit $?"     # 0, and one "OK" line
 ```
+
+## Cut and promote a prose-budget engine version
+
+Two tags carry the engine into CI and nothing else does. This repository holds
+an immutable `prose-budget/vX.Y.Z` on the commit whose `.local/bin/prose-budget`
+you want; `mark-brannan/.github` holds a moving `v1` that consumer repositories
+pin. **No consumer names an engine version** — a pin in three repositories is
+what left every colregs, colregs-engine and symphony PR red once already.
+
+No checkout is involved, so none of this touches `$HOME`.
+
+```bash
+# 1. the engine change is on main and hook-tests.yml is green
+gh run list --repo mark-brannan/dotfiles --workflow hook-tests.yml --limit 1
+
+# 2. cut the engine tag; the name must equal what --version prints
+#    (VERSION at .local/bin/prose-budget:25)
+gh api -X POST repos/mark-brannan/dotfiles/git/refs \
+  -f ref=refs/tags/prose-budget/v1.1.0 \
+  -f sha="$(gh api repos/mark-brannan/dotfiles/commits/main --jq .sha)"
+```
+
+3. PR on `mark-brannan/.github` changing the `dotfiles-ref` default in
+   `.github/workflows/prose-budget.yml` to the new tag. Merge it.
+
+```bash
+# 4. promote: move v1 onto the merged commit. This is the moment all
+#    consumers change; until now nothing has.
+gh api -X PATCH repos/mark-brannan/.github/git/refs/tags/v1 \
+  -f sha="$(gh api repos/mark-brannan/.github/commits/main --jq .sha)" -F force=true
+```
+
+Verify that `v1` really carries the new engine, and that a consumer run picks it
+up — the second is the one that distinguishes a promotion from a tag that moved
+onto the wrong commit:
+
+```bash
+gh api repos/mark-brannan/.github/contents/.github/workflows/prose-budget.yml \
+  --ref v1 --jq .content | base64 -d | grep -A6 'dotfiles-ref:' | grep default
+gh run list --repo mark-brannan/colregs --workflow ci.yml --limit 1
+```
+
+The `prose-budget` step logs `prose-budget X.Y.Z` before it runs, so the run
+log names the engine that produced the findings.
+
+To roll back, move `v1` to the previous commit with the same `PATCH` — one
+command, all consumers, no PR.
 
 ## Set the auth token for the PR review workflows
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -410,63 +410,34 @@ prose-budget --tree; echo "exit $?"     # 0, and one "OK" line
 
 ## Cut and promote a prose-budget engine version
 
-Two tags carry the engine into CI. This repository holds an immutable
-`prose-budget/vX.Y.Z`; `mark-brannan/.github` holds a moving `v1` whose
-workflow names that tag as its `dotfiles-ref` default, and consumers pin `v1`.
-**Don't add a `dotfiles-ref` to a consumer** — a pin in three repositories is
-what went stale in three places at once. Nothing here checks anything out, so
-none of it touches `$HOME`.
+An immutable `prose-budget/vX.Y.Z` tag here names the engine; a moving `v1`
+on `mark-brannan/.github` names the workflow that fetches it. Consumers pin
+`v1` and nothing else — never add a `dotfiles-ref` to a consumer. No checkout
+below, so nothing touches `$HOME`.
 
 ```bash
-# 1. take the SHA from the latest green hook-tests run on main -- not
-#    "main" itself, which may have moved since that run
+# 1. tag the SHA of the latest green hook-tests run on main, named from its VERSION line
 read -r SHA OK < <(gh run list --repo mark-brannan/dotfiles --workflow hook-tests.yml \
   --branch main --limit 1 --json headSha,conclusion --jq '.[0] | "\(.headSha) \(.conclusion)"')
-echo "$SHA $OK"                                   # ... success
-
-# 2. cut the engine tag on that SHA, named from the VERSION the engine
-#    declares at that commit (what `prose-budget --version` prints)
 TAG="prose-budget/v$(gh api "repos/mark-brannan/dotfiles/contents/.local/bin/prose-budget?ref=$SHA" \
   --jq .content | base64 -d | awk -F'"' '/^VERSION = / {print $2; exit}')"
-echo "$TAG"                                       # prose-budget/vX.Y.Z
+echo "$OK $TAG"                                   # success prose-budget/vX.Y.Z
 gh api -X POST repos/mark-brannan/dotfiles/git/refs -f ref="refs/tags/$TAG" -f sha="$SHA"
-```
 
-**3 — PR on `mark-brannan/.github`** changing the `dotfiles-ref` default in
-`.github/workflows/prose-budget.yml` to `$TAG`. Merge it.
-
-```bash
-# 4. record where v1 points now (the rollback target), then promote.
-#    Until the PATCH no consumer has changed.
-PREV=$(gh api repos/mark-brannan/.github/git/ref/tags/v1 --jq .object.sha); echo "$PREV"
+# 2. PR on mark-brannan/.github: set the dotfiles-ref default in
+#    .github/workflows/prose-budget.yml to $TAG. Merge it. Then promote:
+PREV=$(gh api repos/mark-brannan/.github/git/ref/tags/v1 --jq .object.sha)
 gh api -X PATCH repos/mark-brannan/.github/git/refs/tags/v1 \
   -f sha="$(gh api repos/mark-brannan/.github/commits/main --jq .sha)" -F force=true
 
-# 5. verify: the workflow at v1 must name exactly the new tag
+# 3. verify: the workflow at v1 names $TAG ...
 gh api 'repos/mark-brannan/.github/contents/.github/workflows/prose-budget.yml?ref=v1' \
-  --jq .content | base64 -d | grep -A4 'dotfiles-ref:' | grep -q "default: $TAG" \
-  && echo "v1 -> $TAG" || echo "v1 does NOT name $TAG"
+  --jq .content | base64 -d | grep -c "default: $TAG"            # 1
+# ... and the next consumer PR's prose-budget job fetched it (its log echoes the input)
+gh api repos/mark-brannan/colregs/actions/jobs/<job-id>/logs | grep -c "dotfiles-ref: $TAG"   # 1
 ```
 
-Then verify on the first consumer run that starts **after** the move. No
-consumer has a `workflow_dispatch` trigger, so wait for the next push or PR in
-one of them; a run from before the move proves nothing.
-
-```bash
-gh run list --repo mark-brannan/colregs --workflow ci.yml --limit 1 \
-  --json databaseId,createdAt                    # createdAt after the move
-JOB=$(gh run view <databaseId> --repo mark-brannan/colregs --json jobs \
-  --jq '.jobs[] | select(.name | test("prose-budget")) | .databaseId')
-gh api "repos/mark-brannan/colregs/actions/jobs/$JOB/logs" | grep -m1 'dotfiles-ref:' \
-  | grep -q "dotfiles-ref: $TAG" && echo "ran $TAG" || echo "ran something else"
-```
-
-That line is the ref the run actually fetched the engine from. If it is not
-the new tag, `v1` did not move, or moved onto a commit whose workflow still
-names the old one.
-
-To roll back, run the `PATCH` from step 4 with `-f sha="$PREV"`. One
-command, all consumers, no PR.
+Roll back with the same `PATCH` and `-f sha="$PREV"`.
 
 ## Set the auth token for the PR review workflows
 


### PR DESCRIPTION
Settles the reopened half of the prose-budget placement decision: **where the engine lives, and what pins it.** The engine, its config dialect and its three enforcement points are unchanged.

## The ruling

1. The engine **stays** at `.local/bin/prose-budget`. It does not move to `mark-brannan/.github`.
2. The engine version lives in **exactly one file**: the `dotfiles-ref` default inside `mark-brannan/.github`'s `prose-budget.yml`, pointing at an immutable `prose-budget/vX.Y.Z` tag here.
3. Consumers pin `prose-budget.yml@v1` — a moving tag on `.github`, advanced deliberately. Consumers name an engine version nowhere.

Both hops end up pinned: `v1` determines the workflow, the workflow determines the engine tag.

## Why not move it

The move was a means to pinning, not an end — a tag on `.github` covers workflow *and* engine anyway, once the workflow names an immutable engine tag instead of `main`. And relocating would trade a solved problem for an unsolved one: the engine is on `PATH` everywhere, is exec'd by `prose-budget-commit.sh` and `prose-budget-edit.sh`, is in `cloud-session-setup.sh`'s `INSTALL` list, and its test suite runs in `hook-tests.yml`. Hosting it in `.github` means fetching or vendoring it back into `$HOME` — pinned, atomic, with visible failure — which is exactly what #17 is still open on.

## Why a moving tag rather than a version per consumer

Neither failure this design has actually caused was a bad commit on `main`. One was a stale `dotfiles-ref: claude/prose-budget` pin sitting on three consumers at once; one was the engine's absence from colregs-engine's publish runner. A scheme that puts an immutable version in each consumer reproduces the first with better hygiene. One version, in one file, promoted by moving one tag, cannot go stale in three places.

Rollback is one `PATCH`. A commit to `main` here reaches no consumer.

## What's in the diff

- `README.md` — the *why*, next to the other design scars.
- `RUNBOOK.md` — `Cut and promote a prose-budget engine version`, indexed under **GitHub repository**, ending in the two checks that distinguish a promotion from a tag moved onto the wrong commit.

Nothing executable changes here. The mechanism lands in `mark-brannan/.github` and in the three consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance on the prose-budget engine, including its checks for documentation length, section limits, prose changes, and narration patterns.
  - Documented the versioning and release process using immutable engine versions and a moving compatibility tag.
  - Added instructions for cutting, promoting, verifying, and rolling back engine releases.
  - Updated the runbook contents with a link to the new release procedure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->