### PR TITLE
rules: don't close an issue until its npm release has published

### DIFF
--- a/.claude/rules/code.md
+++ b/.claude/rules/code.md
@@ -338,6 +338,15 @@ public" section.
   registered and referenced before relying on it or recommending it.
 - Dry-run flags are not always dry. `make -n` executes recursive `$(MAKE)`
   lines for real. Read the file instead of trusting the flag.
+- **A PR merging is not the fix landing, for anything published as a
+  package.** "Done" means the release workflow completed and the registry
+  reflects it — check `npm view <pkg> dist-tags` (or the equivalent for the
+  registry in play), don't infer publish from a merged PR or a green
+  release-please run. In the gap between merge and publish, label the issue
+  (e.g. `blocked`) or leave a comment saying what it's waiting on, rather
+  than closing early or leaving it ambiguous. Scar: 2026-09-08,
+  colregs-engine#32 — closed on PR merge, reopened three minutes later
+  because `npm view colregs dist-tags` still showed the pre-fix version.
 
 ## Cost
 


### PR DESCRIPTION
Adds the convention from #102 to `.claude/rules/code.md`'s Verification section: a merged PR is not the fix landing for a published package — check the registry's dist-tag (`npm view <pkg> dist-tags` or equivalent) before closing, and label or comment the issue in the gap between merge and publish rather than closing early.

Placed in `rules/code.md` rather than a skill: this is a general code/repo convention agents already read before acting, in the same voice and format (a scar-referenced bullet) as the neighboring PR/CI conventions, and it applies to every repo, not just ones with a `card-write`-style close flow.

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)
