### PR TITLE
hooks: four harness frictions from a fan-out session, none a relaxation

### DIFF
--- a/.claude/hooks/pr-threads-gate.sh
+++ b/.claude/hooks/pr-threads-gate.sh
@@ -56,25 +56,43 @@ prs=$(sort -u "$record" | while IFS="$(printf '\t')" read -r kind a b; do
 done | sort -u)
 [ -n "$prs" ] || exit 0
 
-open=""
-failed=""
+# One fetch per PR, all at once, each bounded by wall clock rather than the
+# list by count: a session that fans out over eight PRs still gets every one
+# checked, and a fetch that hangs is reported as unverified, never skipped.
+# Without `timeout` the bound is gh's own; the fetch still runs.
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/pr-threads-gate.XXXXXX") || block "pr-threads-gate: cannot create a scratch directory, so review threads on the PR you worked could not be re-checked. State in your final message, per thread id, which are resolved and which are open, then end the turn again."
+trap 'rm -rf "$WORK"' EXIT
+TO=""; command -v timeout >/dev/null 2>&1 && TO="timeout ${PR_THREADS_GATE_TIMEOUT:-60}"
 n=0
 while IFS="$(printf '\t')" read -r repo num; do
   if [ -z "$repo" ] || [ -z "$num" ]; then continue; fi
-  # Cap the network calls, but never silently: a PR past the cap is reported
-  # as unverified so the turn still blocks instead of reading as clean.
   n=$((n + 1))
-  [ "$n" -gt 5 ] && { failed="$failed
-- $repo#$num: not checked, more than 5 PRs recorded this session"; continue; }
+  printf '%s\t%s\n' "$repo" "$num" > "$WORK/$n.pr"
   owner=${repo%%/*}; name=${repo#*/}
   # shellcheck disable=SC2016  # GraphQL variables, not shell ones
-  out=$(gh api graphql -f owner="$owner" -f name="$name" -F number="$num" -f query='
+  ( $TO gh api graphql -f owner="$owner" -f name="$name" -F number="$num" -f query='
     query($owner:String!,$name:String!,$number:Int!){
       repository(owner:$owner,name:$name){ pullRequest(number:$number){
         state
         reviewThreads(first:100){ nodes{ id isResolved path
-          comments(first:1){ nodes{ author{login} body } } } } } } }' 2>&1) \
-    || { failed="$failed
+          comments(first:1){ nodes{ author{login} body } } } } } } }' > "$WORK/$n.out" 2>&1
+    echo $? > "$WORK/$n.rc" ) &
+done <<EOF
+$prs
+EOF
+wait
+
+open=""
+failed=""
+i=0
+while [ "$i" -lt "$n" ]; do
+  i=$((i + 1))
+  IFS="$(printf '\t')" read -r repo num < "$WORK/$i.pr"
+  out=$(cat "$WORK/$i.out" 2>/dev/null)
+  rc=$(cat "$WORK/$i.rc" 2>/dev/null)
+  if [ "$rc" = 124 ]; then failed="$failed
+- $repo#$num: fetch timed out"; continue; fi
+  [ "$rc" = 0 ] || { failed="$failed
 - $repo#$num: $(printf '%s' "$out" | head -3 | tr '\n' ' ')"; continue; }
   state=$(printf '%s' "$out" | jq -r '.data.repository.pullRequest.state // empty')
   [ -n "$state" ] || { failed="$failed
@@ -85,9 +103,7 @@ while IFS="$(printf '\t')" read -r repo num; do
   [ -n "$threads" ] && open="$open
 - $repo#$num has $(printf '%s\n' "$threads" | wc -l | tr -d ' ') unresolved review thread(s):
 $threads"
-done <<EOF
-$prs
-EOF
+done
 
 [ -z "$open" ] && [ -z "$failed" ] && exit 0
 

--- a/.claude/hooks/pr-threads-gate.test.sh
+++ b/.claude/hooks/pr-threads-gate.test.sh
@@ -27,6 +27,7 @@ case "${GH_MODE:-}" in
   merged)   printf '{"data":{"repository":{"pullRequest":{"state":"MERGED","reviewThreads":{"nodes":[{"id":"PRRT_z","isResolved":false,"path":null,"comments":{"nodes":[]}}]}}}}}' ;;
   missing)  printf '{"data":{"repository":{"pullRequest":null}}}' ;;
   fail)     echo "gh: HTTP 401: Bad credentials" >&2; exit 1 ;;
+  hang)     sleep 30 ;;
 esac
 GH
 chmod +x "$SCRATCH/bin/gh"
@@ -107,12 +108,22 @@ out=$(stop_input s8 | PATH="$SCRATCH/nogh" GH_MODE=open /bin/sh "$HOOK" 2>&1); L
 if [ "$(printf '%s' "$out" | jq -r .decision 2>/dev/null)" = block ]; then pass=$((pass+1)); else fail=$((fail+1)); echo "FAIL: gh absent should block: $out"; fi
 reason 'names gh as missing'           'gh is not installed'
 
-# --- more PRs than the cap are unverified, not clean ---------------------------
-for i in 1 2 3 4 5 6 7; do record s9 "$(printf 'repo\to/r\t%s' "$i")"; done
+# --- a fan-out over many PRs checks every one; none is skipped by count ---------
+for i in 1 2 3 4 5 6 7 8; do record s9 "$(printf 'repo\to/r\t%s' "$i")"; done
 : > "$GH_LOG"
-check block 'over the cap -> block'     resolved "$(stop_input s9)"
-reason 'names the unchecked PR'         'o/r#7: not checked, more than 5'
-t 'only 5 queried' 5 "$(grep -c 'api graphql' "$GH_LOG")"
+check silent 'eight clean PRs -> silent' resolved "$(stop_input s9)"
+t 'all eight queried' 8 "$(grep -c 'api graphql' "$GH_LOG")"
+check block 'eight PRs, one open thread each -> block' open "$(stop_input s9)"
+reason 'names the eighth PR'            'o/r#8 has 1 unresolved'
+no_reason 'no count cap'                'not checked'
+
+# --- a hung fetch is reported as unverified, not skipped ------------------------
+if command -v timeout >/dev/null 2>&1; then
+  record s10 "$(printf 'repo\to/r\t1')"
+  out=$(stop_input s10 | PR_THREADS_GATE_TIMEOUT=1 GH_MODE=hang sh "$HOOK" 2>&1); LAST=$out
+  if [ "$(printf '%s' "$out" | jq -r .decision 2>/dev/null)" = block ]; then pass=$((pass+1)); else fail=$((fail+1)); echo "FAIL: hung fetch should block: $out"; fi
+  reason 'names the timeout'             'o/r#1: fetch timed out'
+fi
 
 printf '%d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/.claude/hooks/public-issue-guard.sh
+++ b/.claude/hooks/public-issue-guard.sh
@@ -20,7 +20,9 @@
 # The text judged is the whole command after quote removal (so a term
 # spelled `ho\stname` or split across quotes still reads whole), every
 # heredoc body, the file named by --body-file/-F/--input/-F key=@file, and
-# for MCP every string in tool_input. It is grepped case-insensitively, as
+# for MCP every string in tool_input. The one thing cut out is the path
+# operand of those file flags: a path is read, not posted, and a scratchpad
+# under $HOME would otherwise trip a term that names the home directory. It is grepped case-insensitively, as
 # fixed substrings, against state/global/private-terms.txt in the state repo;
 # comment and blank lines in that file are ignored. The reason names the
 # term(s) that hit and nothing around them.
@@ -175,7 +177,16 @@ case "$tool" in
       printf 'R\t-\n' >> "$META"
     fi
     grep -q '^R	' "$META" || exit 0
-    { printf '%s\n' "$cmd"; sed -n 's/^T	//p' "$META"; } >> "$TEXT"
+    # Mask the file-flag path operands: the file is scanned below, the path
+    # never leaves the machine. Fixed-string, every occurrence, in the raw
+    # command and in the words alike (`--body-file=/p` is one word).
+    sed -n 's/^F	//p' "$META" | grep -v '^$' > "$WORK/fpaths"
+    { printf '%s\n' "$cmd"; sed -n 's/^T	//p' "$META"; } | awk -v pf="$WORK/fpaths" '
+      FILENAME == pf { paths[++np] = $0; next }
+      { for (i = 1; i <= np; i++) { out = ""; s = $0
+          while ((j = index(s, paths[i])) > 0) { out = out substr(s, 1, j - 1) "<file>"; s = substr(s, j + length(paths[i])) }
+          $0 = out s }
+        print }' "$WORK/fpaths" - >> "$TEXT" || deny 'awk failed, cannot inspect the command'
     ;;
   mcp__*__create_issue|mcp__*__update_issue|mcp__*__issue_write|mcp__*__add_issue_comment| \
   mcp__*__create_pull_request|mcp__*__update_pull_request| \

--- a/.claude/hooks/public-issue-guard.sh
+++ b/.claude/hooks/public-issue-guard.sh
@@ -92,8 +92,10 @@ case "$tool" in
         name = v; sub(/^\$\{?/, "", name); sub(/[^A-Za-z0-9_].*$/, "", name)
         return name != "" && orig ~ ("(^|[;&|[:space:]])" name "=[\"\047]?\\$\\([^)]*<<")
       }
+      # strip_heredocs has already turned an inline `$(cat <<EOF ...)` into
+      # `$(cat  HEREDOC  )`; either spelling means a heredoc feeds the value.
       function val(v) {
-        if (v ~ /\$\(/ || v ~ /`/) { if (v !~ /<</) print "OPAQUE\t" flat(v) }
+        if (v ~ /\$\(/ || v ~ /`/) { if (v !~ /<</ && v !~ / HEREDOC /) print "OPAQUE\t" flat(v) }
         else if (v ~ /^\$[A-Za-z_{]/) { if (!fed(v)) print "OPAQUE\t" flat(v) }
       }
       function field(v) { sub(/^[^=]*=/, "", v); if (v ~ /^@/) file(substr(v, 2)); else val(v) }

--- a/.claude/hooks/public-issue-guard.test.sh
+++ b/.claude/hooks/public-issue-guard.test.sh
@@ -93,6 +93,14 @@ check deny 'term in --body-file'     "$(bash_in "$PUB" "gh issue create -t x --b
 check deny 'term in -F, relative path' "$(bash_in "$SCRATCH" 'gh pr create -t x -F body.md')"
 check deny 'term in --body-file=~ path' "$(cp "$SCRATCH/body.md" "$HOME/b.md"; bash_in "$PUB" 'gh issue comment 4 --body-file=~/b.md')"
 check allow 'clean --body-file'      "$(bash_in "$PUB" "gh issue create -t x -F $SCRATCH/clean.md")"
+# The path is read, not posted: a term in the directory name is not a hit,
+# while a term in the file at that path still is.
+mkdir -p "$SCRATCH/Wanderlust"; cp "$SCRATCH/clean.md" "$SCRATCH/body.md" "$SCRATCH/Wanderlust/"
+check allow 'term in --body-file path only'   "$(bash_in "$PUB" "gh issue create -t x --body-file $SCRATCH/Wanderlust/clean.md")"
+check allow 'term in --body-file= path only'  "$(bash_in "$PUB" "gh pr comment 4 --body-file=$SCRATCH/Wanderlust/clean.md")"
+check allow 'term in api @file path only'     "$(bash_in "$PUB" "gh api repos/o/r/issues -f title=x -F body=@$SCRATCH/Wanderlust/clean.md")"
+check deny  'term in file under such a path'  "$(bash_in "$PUB" "gh issue create -t x --body-file $SCRATCH/Wanderlust/body.md")"
+check deny  'term elsewhere, path masked'     "$(bash_in "$PUB" "gh issue create -t Wanderlust --body-file $SCRATCH/Wanderlust/clean.md")"
 
 # --- case-insensitive, fixed strings ------------------------------------------
 check deny 'upper-case body, lower-case list' "$(bash_in "$PUB" 'gh issue create -t x -b "ACCT-4471 again"')"

--- a/.claude/hooks/public-issue-guard.test.sh
+++ b/.claude/hooks/public-issue-guard.test.sh
@@ -157,6 +157,14 @@ EOF')"
 check deny 'body from $(...)'        "$(bash_in "$PUB" 'gh issue create -t x -b "$(cat notes.md)"')"
 reason 'says it is built at run time' 'run time'
 check deny 'body from $VAR, no heredoc' "$(bash_in "$PUB" 'gh pr comment 3 --body "$body"')"
+check allow 'inline $(cat <<EOF) clean' "$(bash_in "$PUB" 'gh pr create -t x --body "$(cat <<'"'"'EOF'"'"'
+nothing private
+EOF
+)"')"
+check deny 'inline $(cat <<EOF) with a term' "$(bash_in "$PUB" 'gh pr create -t x --body "$(cat <<'"'"'EOF'"'"'
+seen aboard Wanderlust
+EOF
+)"')"
 check allow '$VAR body fed by a clean heredoc' "$(bash_in "$PUB" 'b=$(cat <<EOF
 public text
 EOF

--- a/.local/bin/worklist
+++ b/.local/bin/worklist
@@ -277,8 +277,16 @@ def labels: [(.labels.nodes // [])[].name];
     | (if .data.pullRequests.pageInfo.hasNextPage then "\($s): more than 50 open PRs -- PR buckets truncated" else empty end),
       (if .data.issues.pageInfo.hasNextPage then "\($s): more than 100 open issues -- issue buckets and Untriaged truncated" else empty end) ] as $trunc
 | ($c.counts | if (.prs|type) == "string" and (.issues|type) == "string" and .prs == .issues and (.prs|test("^[0-9]")|not)
-      then "counts: unavailable (\(.prs))"
-      else "counts: \(.prs) open PRs, \(.issues) open issues across \($owner)" end) as $counts
+      then "unavailable (\(.prs))"
+      else "\(.prs) open PRs, \(.issues) open issues across \($owner)" end) as $acct
+# The number a reader skims sits above project-scoped tables, so the scoped
+# count comes first; the account-wide one follows, labelled.
+| ([$c.records[] | select(.data)]
+   | if length == 0 then null else
+     { prs: (map(.data.pullRequests.nodes | length) | add), prs_more: (map(.data.pullRequests.pageInfo.hasNextPage) | any),
+       issues: (map(.data.issues.nodes | length) | add), issues_more: (map(.data.issues.pageInfo.hasNextPage) | any) } end) as $scope
+| (if $scope == null then "counts: \($acct)"
+   else "counts: \($scope.prs)\(if $scope.prs_more then "+" else "" end) open PRs, \($scope.issues)\(if $scope.issues_more then "+" else "" end) open issues in scope; \($acct)" end) as $counts
 | [ $c.label + " " + ($c.repos | map(split("/")[1]) | join(", ")) ]
   + $fails + $trunc + [ $counts, "", "@@RULINGS@@",
   table_bucket("Solace'"'"'s turn"; "Notes"; $prs | map(select(awaiting_human))),

--- a/.local/bin/worklist.test.sh
+++ b/.local/bin/worklist.test.sh
@@ -128,7 +128,7 @@ run
 eq 'exit 0' 0 "$RC"
 has 'stamp without cache note' '^as of [0-9]{2}:[0-9]{2}Z$'
 has 'scope names the project and repos' '^project demo \(o\): alpha, beta$'
-has 'account-wide counts' '^counts: 3 open PRs, 2 open issues across o$'
+has 'scoped counts first, account-wide after' '^counts: 6 open PRs, 6 open issues in scope; 3 open PRs, 2 open issues across o$'
 eq 'one GraphQL call per repo' 2 "$(calls 'api graphql')"
 eq 'topic looked up once' 1 "$(calls 'repo view o/alpha --json repositoryTopics')"
 eq 'repo set from the topic' 1 "$(calls 'repo list o --topic project-demo')"


### PR DESCRIPTION
A session sequencing colregs work across eight PRs reported three harness frictions. All three checked out against the code and that session's own record; none is a tokenizer failure, so this changes nothing about the awk scanner (#75 stays research). A fourth surfaced while opening this PR.

- **public-issue-guard**: the raw command is appended to the scanned text as a backstop, and one denylist term is the home-directory prefix, so any `--body-file` under the session scratchpad tripped it. The path operands of `--body-file`/`-F`/`--input`/`@file` are now masked before the scan. The file itself is still read and scanned; a term in the file still denies, a term in the directory name does not.
- **public-issue-guard**, also: the inline `--body "$(cat <<'EOF' ... EOF)"` form the header already promises to allow was denied as opaque, because `strip_heredocs` had already replaced the `<<` the check looked for. Both spellings now count as fed. Two tests added.
- **pr-threads-gate**: the 5-PR count cap is gone. Every recorded PR is fetched in parallel, each under `timeout` (`PR_THREADS_GATE_TIMEOUT`, default 60 s) where the binary exists; a hung fetch is reported as unverified and still blocks. That session's record held eight PRs; the three from the last repo sorted past the cap and one open thread was never fetched.
- **worklist**: the counts line now leads with in-scope PR/issue totals and keeps the account-wide numbers after, labelled.

Tests: all three suites green locally (guard 90, gate 39, worklist 100), the guard under mawk and gawk. Live check: the new guard allows a real scratchpad `--body-file`, the installed one denies it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
