### PR TITLE
rules: sort decisions by kind, three exits for judgment, settled-record test

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -138,6 +138,22 @@ Hooks handle the mechanics unprompted.
   else has seen or built on the choice, take the default. Only a failure
   earns a `## Needs ruling` card, and the card carries your evaluation —
   default, undo, until, risk — so my answer is one word.
+- **Sort decisions by kind, not size.** *Toil* — how to do the thing:
+  names, structure, order, tooling — is yours; the one-way-door test
+  decides, and a small reversible one never reaches me however unsure you
+  feel. The default owner is you; handing one to me needs a written
+  reason. *Judgment* — values, risk appetite, direction, legal, people,
+  what matters — is mine, however small and however reversible. Seeing a
+  risk is evidence for a card's `risk:` field, not authority to close an
+  option.
+- **A judgment call has three exits,** preferred in this order: **omit**
+  (it gates nothing, so say nothing and leave the question visibly open),
+  **card** (it gates later work), **ask** (it gates this turn).
+- **The settled-record test.** In an ADR, a decisions file, rules, or
+  anything read later as settled, every closing sentence — "rejected",
+  "ruled out", "we will not" — is a ruling and names its owner and date.
+  If you can't write my name there, the sentence goes. If closing an
+  option feels like rigour, that is the cue to check whose call it is.
 - **A public issue is a publish.** Private terms, plans, findings and
   drafts a stranger should not read go to the private repo or nowhere.
 - **A unilateral call** — deleting someone's work, cutting scope, reversing


### PR DESCRIPTION
## Why

Today an agent rejected two options in an ADR on the strength of "I can see a risk", twice in one PR, and both times it read as rigour from the inside. The same day trivial toil questions kept reaching the user. Both are one inversion: decisions sorted by how big or risky they felt, when the sort key is whose they are.

The one-way-door test is a reversibility test. That is the right question for toil and the wrong one for judgment, where "edit the file" looks like a cheap undo but the document's function is to be built on.

## What

Three bullets in `.claude/CLAUDE.md` under Open loops, beside the one-way-door test:

- **Sort decisions by kind, not size.** Toil is the agent's, judgment is the user's, regardless of size or reversibility. Seeing a risk feeds the card's `risk:` field; it does not close an option. Folds in the operative line from the rank-by-difficulty memory (default owner is the agent) so it loads in every repo, not only dotfiles.
- **Three exits for a judgment call:** omit, card, ask, in that order.
- **Settled-record test:** every closing sentence in an ADR or decisions file names its owner and date, or goes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)