### PR TITLE
feat(prose-budget): a change that weakens the guard must land on its own

### DIFF
--- a/.local/bin/prose-budget
+++ b/.local/bin/prose-budget
@@ -432,22 +432,28 @@ def _added(items, n=3):
 
 
 def relaxations(old, new):
-    """Every way `new` is a weaker guard than `old`, described for a human."""
+    """Every way `new` is a weaker guard than `old`, described for a human.
+
+    Both sides are compared after defaults are applied: a config that never
+    mentioned `sections` is already bound by the built-in cap, so introducing
+    a more permissive explicit value is a relaxation like any other.
+    """
     out = []
     try:
         old_r, new_r = parse_config(old), parse_config(new)
     except ConfigError:
-        old_r = new_r = None
-    if old_r and new_r:
-        for name, v in old_r.items():
-            if v and not new_r.get(name):
-                out.append(f"{name}: rule turned off")
+        return out
+    for name, v in old_r.items():
+        if v and not new_r.get(name):
+            out.append(f"{name}: rule turned off")
+    if _dig(old_r, "config.enforce") and not _dig(new_r, "config.enforce"):
+        out.append("config.enforce: true -> false")
     for path in RELAX_CAPS:
-        a, b = _dig(old, path), _dig(new, path)
+        a, b = _dig(old_r, path), _dig(new_r, path)
         if isinstance(a, int) and isinstance(b, int) and b > a:
             out.append(f"{path}: {a} -> {b}")
     for path in RELAX_EXEMPT:
-        a, b = _dig(old, path), _dig(new, path)
+        a, b = _dig(old_r, path), _dig(new_r, path)
         if isinstance(b, (list, dict)):
             added = [k for k in b if not isinstance(a, (list, dict)) or k not in a]
             if added:
@@ -457,20 +463,20 @@ def relaxations(old, new):
                 if isinstance(v, int) and isinstance(a.get(k), int) and v > a[k]:
                     out.append(f"{path}.{k}: {a[k]} -> {v}")
     for path in RELAX_COVER:
-        a, b = _dig(old, path), _dig(new, path)
+        a, b = _dig(old_r, path), _dig(new_r, path)
         if isinstance(a, list):
             dropped = [k for k in a if not isinstance(b, list) or k not in b]
             if dropped:
                 out.append(f"{path}: -{len(dropped)} ({', '.join(_label(k) for k in dropped[:3])}"
                            + (", ..." if len(dropped) > 3 else "") + ")")
-    a, b = old.get("lines"), new.get("lines")
+    a, b = _dig(old_r, "lines.files"), _dig(new_r, "lines.files")
     if isinstance(a, dict) and isinstance(b, dict):
         for k, v in b.items():
-            if k not in LINES_META and isinstance(v, int) and isinstance(a.get(k), int) and v > a[k]:
+            if isinstance(v, int) and isinstance(a.get(k), int) and v > a[k]:
                 out.append(f"lines.{k}: {a[k]} -> {v}")
-        if a.get("required") and not b.get("required", False):
-            out.append("lines.required: true -> false")
-    if _dig(old, "voice.scope") == "tree" and _dig(new, "voice.scope") != "tree":
+    if _dig(old_r, "lines.required") and not _dig(new_r, "lines.required"):
+        out.append("lines.required: true -> false")
+    if _dig(old_r, "voice.scope") == "tree" and _dig(new_r, "voice.scope") != "tree":
         out.append("voice.scope: tree -> diff")
     return out
 
@@ -585,8 +591,7 @@ class Checker:
                 self.check_delta(r["delta"])
             if r["land_alone"]:
                 self.check_land_alone(r["land_alone"])
-            if r["config"]:
-                self.check_config(r["config"])
+            self.check_config()
         self.findings.sort(key=lambda f: (f["file"], f["line"] or 0, f["pointer"] or "", f["rule"]))
         return self.findings
 
@@ -792,8 +797,10 @@ class Checker:
                      + " land in their own change so they can be reviewed and rejected on their own; "
                      "also changed: " + ", ".join(strays))
 
-    def check_config(self, cfg):
-        if not cfg["enforce"] or not self.config_rel or self.config_rel not in self.changed:
+    def check_config(self):
+        """The base version of the config decides whether this runs, so a diff
+        cannot both switch the rule off and use the switch it just threw."""
+        if not self.config_rel or self.config_rel not in self.changed:
             return
         before = self.repo.show(self.before_ref, self.config_rel)
         after = (self.repo.show(self.after_ref, self.config_rel) if self.mode == "staged"
@@ -801,9 +808,16 @@ class Checker:
         if before is None or after is None:
             return
         try:
-            relaxed = relaxations(json.loads(before), json.loads(after))
+            old, new = json.loads(before), json.loads(after)
         except ValueError:
             return
+        try:
+            was = parse_config(old).get("config")
+        except ConfigError:
+            return
+        if not was or not was["enforce"]:
+            return
+        relaxed = relaxations(old, new)
         if not relaxed:
             return
         detail = "; ".join(relaxed)
@@ -815,7 +829,6 @@ class Checker:
                  "in its own change with the reason in the body, so it can be reviewed and rejected on its "
                  "own -- tightening needs no ceremony. Also changed: "
                  + ", ".join(strays[:5]) + (", ..." if len(strays) > 5 else ""))
-
 
 # --- CLI -------------------------------------------------------------------------
 

--- a/.local/bin/prose-budget
+++ b/.local/bin/prose-budget
@@ -4,7 +4,14 @@
 # Every number and every grandfathered exception lives in the repo's config
 # (docs/budgets.json or .prose-budgets.json), so loosening a rule is a
 # visible diff in review, not a quiet edit to a test. Rules: lines, sections,
-# delta, json_prose, narration, voice, headers, unique_ids, land_alone.
+# delta, json_prose, narration, voice, headers, unique_ids, land_alone, config.
+#
+# The `config` rule closes the obvious hole in that: the config is a file like
+# any other, so an agent that trips a limit can simply raise it in the same
+# commit. A change that weakens the guard -- a cap that rises, an exemption
+# that appears, a coverage list that shrinks, a rule turned off -- is a finding
+# unless it lands on its own, where it can be reviewed and rejected on its own.
+# Tightening is always free.
 #
 # Usage: prose-budget [--config PATH] [--tree | --staged | --base REF]
 #                     [--file PATH ...] [--warn-only] [--json]
@@ -22,14 +29,24 @@ import re
 import subprocess
 import sys
 
-VERSION = "1.0.0"
+VERSION = "1.1.0"
 CONFIG_NAMES = ("docs/budgets.json", ".prose-budgets.json")
-RAISE = "Budgets live in {}; raising one is a deliberate, reviewable diff."
+CUT = "Cut the prose. If a limit is wrong, changing {} is its own PR that says why."
 
 MD_TARGETS = ["README.md", "RUNBOOK.md", "AGENTS.md", "CLAUDE.md", "docs/**/*.md", "runbooks/*.md"]
 RUNBOOK_TARGETS = ["RUNBOOK.md", "runbooks/*.md"]
 LAND_WITH = ["README.md", "CLAUDE.md", "AGENTS.md", "docs/**", "reference/**"]
 PROSE_KEYS = ["note", "$note", "notes", "about", "gap", "narrative", "settled_by", "rationale", "why", "would_settle"]
+# How a config knob moves when the guard gets weaker. A cap that rises, an
+# exemption list that grows, a coverage list that shrinks: each is a relaxation.
+RELAX_CAPS = ["sections.max_words", "delta.max_words", "json_prose.max_chars", "headers.max_lines"]
+RELAX_EXEMPT = ["voice.allow", "sections.exempt", "json_prose.grandfathered", "narration.grandfathered",
+                "narration.disable", "lines.pending", "headers.grandfathered", "land_alone.with"]
+RELAX_COVER = ["lines.must_budget", "voice.words", "json_prose.keys", "sections.targets", "delta.targets",
+               "json_prose.targets", "narration.targets", "voice.targets", "headers.targets",
+               "land_alone.targets", "unique_ids"]
+LINES_META = ("required", "must_budget", "pending")
+
 NARRATION = {
     "pr": r"\bPR ?#?\d+\b",
     "issue": r"(?<![\w./-])[\w-]+(?:/[\w-]+)?#\d+\b",
@@ -329,10 +346,14 @@ def load_config(path):
             cfg = json.load(f)
     except (OSError, ValueError) as e:
         raise ConfigError(f"cannot read {path}: {e}")
+    return parse_config(cfg)
+
+
+def parse_config(cfg):
     if not isinstance(cfg, dict):
         raise ConfigError("top level must be an object")
     known = {"$comment", "preset", "lines", "sections", "delta", "json_prose", "narration", "voice",
-             "headers", "unique_ids", "land_alone"}
+             "headers", "unique_ids", "land_alone", "config"}
     for k in cfg:
         if k not in known:
             raise ConfigError(f"unknown rule {k!r}")
@@ -388,7 +409,70 @@ def load_config(path):
             raise ConfigError(f"unique_ids[{entry['file']}].pattern: invalid pattern: {e}") from e
     r["unique_ids"] = ids or None
     r["land_alone"] = _rule(cfg, "land_alone", {"targets": RUNBOOK_TARGETS, "with": LAND_WITH}, True)
+    r["config"] = _rule(cfg, "config", {"enforce": True}, True)
     return r
+
+
+def _dig(cfg, path):
+    cur = cfg
+    for seg in path.split("."):
+        if not isinstance(cur, dict):
+            return None
+        cur = cur.get(seg)
+    return cur
+
+
+def _label(k):
+    return k if isinstance(k, str) else json.dumps(k, sort_keys=True, separators=(",", ":"))
+
+
+def _added(items, n=3):
+    shown = ", ".join(_label(k) for k in items[:n])
+    return f"+{len(items)} ({shown}{', ...' if len(items) > n else ''})"
+
+
+def relaxations(old, new):
+    """Every way `new` is a weaker guard than `old`, described for a human."""
+    out = []
+    try:
+        old_r, new_r = parse_config(old), parse_config(new)
+    except ConfigError:
+        old_r = new_r = None
+    if old_r and new_r:
+        for name, v in old_r.items():
+            if v and not new_r.get(name):
+                out.append(f"{name}: rule turned off")
+    for path in RELAX_CAPS:
+        a, b = _dig(old, path), _dig(new, path)
+        if isinstance(a, int) and isinstance(b, int) and b > a:
+            out.append(f"{path}: {a} -> {b}")
+    for path in RELAX_EXEMPT:
+        a, b = _dig(old, path), _dig(new, path)
+        if isinstance(b, (list, dict)):
+            added = [k for k in b if not isinstance(a, (list, dict)) or k not in a]
+            if added:
+                out.append(f"{path}: " + _added(added))
+        if isinstance(a, dict) and isinstance(b, dict):
+            for k, v in b.items():
+                if isinstance(v, int) and isinstance(a.get(k), int) and v > a[k]:
+                    out.append(f"{path}.{k}: {a[k]} -> {v}")
+    for path in RELAX_COVER:
+        a, b = _dig(old, path), _dig(new, path)
+        if isinstance(a, list):
+            dropped = [k for k in a if not isinstance(b, list) or k not in b]
+            if dropped:
+                out.append(f"{path}: -{len(dropped)} ({', '.join(_label(k) for k in dropped[:3])}"
+                           + (", ..." if len(dropped) > 3 else "") + ")")
+    a, b = old.get("lines"), new.get("lines")
+    if isinstance(a, dict) and isinstance(b, dict):
+        for k, v in b.items():
+            if k not in LINES_META and isinstance(v, int) and isinstance(a.get(k), int) and v > a[k]:
+                out.append(f"lines.{k}: {a[k]} -> {v}")
+        if a.get("required") and not b.get("required", False):
+            out.append("lines.required: true -> false")
+    if _dig(old, "voice.scope") == "tree" and _dig(new, "voice.scope") != "tree":
+        out.append("voice.scope: tree -> diff")
+    return out
 
 
 # --- repo access -------------------------------------------------------------
@@ -501,6 +585,8 @@ class Checker:
                 self.check_delta(r["delta"])
             if r["land_alone"]:
                 self.check_land_alone(r["land_alone"])
+            if r["config"]:
+                self.check_config(r["config"])
         self.findings.sort(key=lambda f: (f["file"], f["line"] or 0, f["pointer"] or "", f["rule"]))
         return self.findings
 
@@ -706,6 +792,30 @@ class Checker:
                      + " land in their own change so they can be reviewed and rejected on their own; "
                      "also changed: " + ", ".join(strays))
 
+    def check_config(self, cfg):
+        if not cfg["enforce"] or not self.config_rel or self.config_rel not in self.changed:
+            return
+        before = self.repo.show(self.before_ref, self.config_rel)
+        after = (self.repo.show(self.after_ref, self.config_rel) if self.mode == "staged"
+                 else self.repo.read_disk(self.config_rel))
+        if before is None or after is None:
+            return
+        try:
+            relaxed = relaxations(json.loads(before), json.loads(after))
+        except ValueError:
+            return
+        if not relaxed:
+            return
+        detail = "; ".join(relaxed)
+        strays = sorted(p for p in self.changed if p != self.config_rel)
+        if not strays:
+            self.info.append(f"config: weakened, landing alone -- {detail}")
+            return
+        self.add("config", self.config_rel, f"this change weakens the guard ({detail}); a weakening lands "
+                 "in its own change with the reason in the body, so it can be reviewed and rejected on its "
+                 "own -- tightening needs no ceremony. Also changed: "
+                 + ", ".join(strays[:5]) + (", ..." if len(strays) > 5 else ""))
+
 
 # --- CLI -------------------------------------------------------------------------
 
@@ -776,7 +886,7 @@ def main(argv=None):
         for f in findings:
             print(format_finding(f))
         if findings:
-            print(RAISE.format(config_rel or config))
+            print(CUT.format(config_rel or config))
         else:
             print(f"prose-budget: OK -- {len(checker.files)} file(s) checked ({which})")
     if findings and not args.warn_only:

--- a/.local/bin/prose-budget.test.py
+++ b/.local/bin/prose-budget.test.py
@@ -164,13 +164,13 @@ class CliTest(RepoCase):
     def test_version(self):
         self.assertEqual(self.cli("--version")[1].strip(), f"prose-budget {pb.VERSION}")
 
-    def test_findings_end_with_the_budget_line_and_name_the_config(self):
+    def test_findings_end_with_the_cut_line_and_name_the_config(self):
         self.config({"lines": {"README.md": 1}}, path="docs/budgets.json")
         self.write("README.md", "a\nb\nc\n")
         code, out, _ = self.cli("--tree")
         self.assertEqual(code, 1)
         self.assertEqual(out.splitlines()[0], "README.md:3: lines: 3 lines, budget 1")
-        self.assertEqual(out.splitlines()[-1], pb.RAISE.format("docs/budgets.json"))
+        self.assertEqual(out.splitlines()[-1], pb.CUT.format("docs/budgets.json"))
 
     def test_warn_only_exits_zero(self):
         self.config({"lines": {"README.md": 1}})
@@ -332,6 +332,109 @@ class LandAloneTest(RepoCase):
         self.config({})
         self.stage("scripts/foo.py", "ansible/x.yml")
         self.assertEqual(self.findings("--staged"), [])
+
+
+class ConfigRelaxTest(RepoCase):
+    """The guard's own config is a file like any other; weakening it lands alone."""
+
+    def start(self, cfg):
+        self.config(cfg)
+        self.write("README.md", "a\n")
+        self.commit(".prose-budgets.json", "README.md")
+
+    def stage_config(self, cfg, *also):
+        self.config(cfg)
+        paths = [".prose-budgets.json"]
+        for p in also:
+            self.write(p, "x\n")
+            paths.append(p)
+        self.git("add", "--", *paths)
+
+    def config_findings(self, *args):
+        return [f for f in self.findings(*args) if f["rule"] == "config"]
+
+    def test_raising_a_budget_beside_other_edits_fails(self):
+        self.start({"lines": {"README.md": 10}})
+        self.stage_config({"lines": {"README.md": 40}}, "docs/x.md")
+        f = self.config_findings("--staged")
+        self.assertEqual(len(f), 1)
+        self.assertIn("lines.README.md: 10 -> 40", f[0]["message"])
+        self.assertIn("docs/x.md", f[0]["message"])
+
+    def test_the_same_raise_landing_alone_passes(self):
+        self.start({"lines": {"README.md": 10}})
+        self.stage_config({"lines": {"README.md": 40}})
+        self.assertEqual(self.config_findings("--staged"), [])
+
+    def test_a_new_allow_entry_beside_other_edits_fails(self):
+        self.start({"voice": {"allow": ["Foster/Gleirscher"]}})
+        self.stage_config({"voice": {"allow": ["Foster/Gleirscher", "robust policy"]}}, "docs/x.md")
+        f = self.config_findings("--staged")
+        self.assertEqual(len(f), 1)
+        self.assertIn("voice.allow: +1 (robust policy)", f[0]["message"])
+
+    def test_tightening_beside_other_edits_passes(self):
+        self.start({"lines": {"README.md": 40}, "voice": {"allow": ["a", "b"]}})
+        self.stage_config({"lines": {"README.md": 10}, "voice": {"allow": ["a"]}}, "docs/x.md")
+        self.assertEqual(self.config_findings("--staged"), [])
+
+    def test_a_budget_for_a_new_file_is_not_a_relaxation(self):
+        self.start({"lines": {"README.md": 10}})
+        self.stage_config({"lines": {"README.md": 10, "docs/x.md": 300}}, "docs/x.md")
+        self.assertEqual(self.config_findings("--staged"), [])
+
+    def test_turning_a_rule_off_beside_other_edits_fails(self):
+        self.start({"lines": {"README.md": 10}})
+        self.stage_config({"lines": {"README.md": 10}, "voice": False}, "docs/x.md")
+        f = self.config_findings("--staged")
+        self.assertIn("voice: rule turned off", f[0]["message"])
+
+    def test_narrowing_coverage_beside_other_edits_fails(self):
+        self.start({"lines": {"README.md": 10, "must_budget": ["README.md", "docs/**/*.md"]}})
+        self.stage_config({"lines": {"README.md": 10, "must_budget": ["README.md"]}}, "docs/x.md")
+        f = self.config_findings("--staged")
+        self.assertIn("lines.must_budget: -1 (docs/**/*.md)", f[0]["message"])
+
+    def test_base_mode_sees_a_relaxation_from_the_merge_base(self):
+        self.start({"lines": {"README.md": 10}})
+        self.git("checkout", "-qb", "work")
+        self.config({"lines": {"README.md": 40}})
+        self.write("docs/x.md", "x\n")
+        self.commit(".prose-budgets.json", "docs/x.md")
+        f = self.config_findings("--base", "main")
+        self.assertEqual(len(f), 1)
+        self.assertIn("lines.README.md: 10 -> 40", f[0]["message"])
+
+    def test_an_untouched_config_is_never_a_finding(self):
+        self.start({"lines": {"README.md": 10}})
+        self.stage_config({"lines": {"README.md": 10}}, "docs/x.md")
+        self.assertEqual(self.config_findings("--staged"), [])
+
+    def test_enforce_false_disables_the_rule(self):
+        self.start({"lines": {"README.md": 10}, "config": {"enforce": False}})
+        self.stage_config({"lines": {"README.md": 40}, "config": {"enforce": False}}, "docs/x.md")
+        self.assertEqual(self.config_findings("--staged"), [])
+
+
+class RelaxationsTest(unittest.TestCase):
+    def test_a_raised_cap_and_a_grown_exemption(self):
+        old = {"json_prose": {"max_chars": 300}, "narration": {"disable": []}}
+        new = {"json_prose": {"max_chars": 900}, "narration": {"disable": ["issue"]}}
+        self.assertEqual(pb.relaxations(old, new),
+                         ["json_prose.max_chars: 300 -> 900", "narration.disable: +1 (issue)"])
+
+    def test_voice_scope_narrowed_to_the_diff(self):
+        self.assertEqual(pb.relaxations({"voice": {"scope": "tree"}}, {"voice": {"scope": "diff"}}),
+                         ["voice.scope: tree -> diff"])
+
+    def test_a_raised_grandfathered_value(self):
+        old = {"headers": {"targets": ["src/**"], "grandfathered": {"a.ts": 30}}}
+        new = {"headers": {"targets": ["src/**"], "grandfathered": {"a.ts": 48}}}
+        self.assertEqual(pb.relaxations(old, new), ["headers.grandfathered.a.ts: 30 -> 48"])
+
+    def test_identical_configs_are_silent(self):
+        cfg = {"lines": {"README.md": 10}, "voice": {"allow": ["x"]}}
+        self.assertEqual(pb.relaxations(cfg, json.loads(json.dumps(cfg))), [])
 
 
 class JsonProseTest(RepoCase):

--- a/.local/bin/prose-budget.test.py
+++ b/.local/bin/prose-budget.test.py
@@ -410,13 +410,48 @@ class ConfigRelaxTest(RepoCase):
         self.stage_config({"lines": {"README.md": 10}}, "docs/x.md")
         self.assertEqual(self.config_findings("--staged"), [])
 
-    def test_enforce_false_disables_the_rule(self):
+    def test_enforce_already_false_at_the_base_disables_the_rule(self):
         self.start({"lines": {"README.md": 10}, "config": {"enforce": False}})
         self.stage_config({"lines": {"README.md": 40}, "config": {"enforce": False}}, "docs/x.md")
         self.assertEqual(self.config_findings("--staged"), [])
 
+    def test_switching_enforce_off_in_the_same_diff_cannot_self_grant(self):
+        self.start({"lines": {"README.md": 10}})
+        self.stage_config({"lines": {"README.md": 999}, "config": {"enforce": False}}, "docs/x.md")
+        f = self.config_findings("--staged")
+        self.assertEqual(len(f), 1)
+        self.assertIn("config.enforce: true -> false", f[0]["message"])
+        self.assertIn("lines.README.md: 10 -> 999", f[0]["message"])
+
+    def test_setting_the_whole_rule_to_false_cannot_self_grant(self):
+        self.start({"lines": {"README.md": 10}})
+        self.stage_config({"lines": {"README.md": 999}, "config": False}, "docs/x.md")
+        f = self.config_findings("--staged")
+        self.assertIn("config: rule turned off", f[0]["message"])
+        self.assertIn("lines.README.md: 10 -> 999", f[0]["message"])
+
+    def test_an_override_more_permissive_than_the_built_in_default_is_a_relaxation(self):
+        self.start({"lines": {"README.md": 10}})
+        self.stage_config({"lines": {"README.md": 10}, "sections": {"max_words": 5000}}, "docs/x.md")
+        f = self.config_findings("--staged")
+        self.assertIn("sections.max_words: 140 -> 5000", f[0]["message"])
+
+    def test_narrowing_default_coverage_with_an_explicit_list_is_a_relaxation(self):
+        self.start({"lines": {"README.md": 10}})
+        self.stage_config({"lines": {"README.md": 10}, "voice": {"targets": ["README.md"]}}, "docs/x.md")
+        f = self.config_findings("--staged")
+        self.assertIn("voice.targets: -", f[0]["message"])
+
 
 class RelaxationsTest(unittest.TestCase):
+    def test_a_cap_introduced_above_the_built_in_default(self):
+        """An on-by-default rule is already binding, so an explicit override loosens it."""
+        self.assertEqual(pb.relaxations({}, {"sections": {"max_words": 5000}}),
+                         ["sections.max_words: 140 -> 5000"])
+
+    def test_switching_an_off_by_default_rule_on_is_a_tightening(self):
+        self.assertEqual(pb.relaxations({}, {"json_prose": {"targets": ["x.json"], "max_chars": 9000}}), [])
+
     def test_a_raised_cap_and_a_grown_exemption(self):
         old = {"json_prose": {"max_chars": 300}, "narration": {"disable": []}}
         new = {"json_prose": {"max_chars": 900}, "narration": {"disable": ["issue"]}}

--- a/README.md
+++ b/README.md
@@ -118,6 +118,16 @@ delta per change, narration and voice patterns. Three repositories had grown
 three drifting versions of it; this is the one they collapsed into. Each
 repository keeps only its `docs/budgets.json`.
 
+That config is the whole design and also its weak point: an agent that trips a
+limit can raise the limit. It happened — three phrases appended to a
+`voice.allow` list inside an unrelated pull request, a JSON hunk small enough
+to scroll past. So the engine reads its own config against the base version and
+treats any weakening as a finding unless the weakening lands by itself. It
+cannot enforce that the reason is written down, only that the change is alone
+in the diff, where a reason is the obvious thing to ask for. Tightening stays
+free, because a guard nobody can strengthen quickly is a guard nobody
+strengthens.
+
 It lives here rather than in `mark-brannan/.github` beside the reusable
 workflow that runs it, because CI is the smaller half of its job: it is on
 `PATH` on every machine, two Claude Code hooks exec it (a `git commit` is

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -400,9 +400,24 @@ prose-budget --tree --file docs/x.md    # one file, as the edit hook does
 ```
 
 Exit 0 is clean, 1 lists findings as `file:line: rule: message`, 2 is a bad
-config. Every finding ends with the config path; edit that file, never the
-engine, to raise a budget or grandfather a hit (the `narration` message
-prints the hash to grandfather).
+config. Cut the prose first; the config, never the engine, is where a limit
+that is genuinely wrong gets changed (the `narration` message prints the hash
+to grandfather).
+
+A config change that weakens the guard — a cap raised, an exemption added, a
+rule switched off — is itself a finding unless it is the only thing in the
+diff. Land it alone, with the reason in the commit or PR body:
+
+```bash
+git add docs/budgets.json && git commit          # nothing else staged
+prose-budget --staged                            # "config: weakened, landing alone -- ..."
+```
+
+Staging anything beside it fails, and names what rode along:
+
+```bash
+prose-budget --base origin/main | grep ': config:'   # empty unless a weakening rode along
+```
 
 ```bash
 prose-budget --tree; echo "exit $?"     # 0, and one "OK" line


### PR DESCRIPTION
## The hole this closes

Every threshold lives in the repo's config so that loosening one is a visible
diff in review. The config is a file like any other, so an agent that trips a
limit can raise the limit in the same commit — and did: three phrases appended
to `voice.allow` in colregs-engine, inside an unrelated 700-line PR, as a
three-line JSON hunk. "A deliberate, reviewable diff" was the only thing
standing in the way, and it is not a mechanism.

## What landed

**A `config` rule.** In `--staged` and `--base` mode, the engine parses its own
config at the base ref and compares. It reports as a relaxation:

| kind | example |
| --- | --- |
| a cap raised | `lines.README.md: 180 -> 240`, `json_prose.max_chars`, `headers.max_lines` |
| an exemption list grown | `voice.allow`, `narration.disable`, `*.grandfathered`, `sections.exempt`, `lines.pending` |
| a coverage list shrunk | `lines.must_budget`, any rule's `targets`, `voice.words`, `json_prose.keys` |
| a rule turned off | `voice: false` |
| scope narrowed | `voice.scope: tree -> diff`, `lines.required: true -> false` |

A relaxation is a **finding** when anything else changed in the same diff, and
an **informational line** when it lands alone. Tightening is always silent.

Deliberately *not* a relaxation: a `lines` entry for a file that had none.
`lines.must_budget` requires one for every new doc, so treating that as a
weakening would make every new document a two-PR dance — friction that gets
routed around, which is how guards die.

`config: {"enforce": false}` turns it off, but doing so is itself a relaxation,
so it cannot be self-granted in the diff that needs it.

**The failure hint.** `Budgets live in {}; raising one is a deliberate,
reviewable diff.` answered the question "where do I go to make this stop" and
named no other remedy. It is now `Cut the prose. If a limit is wrong, changing
{} is its own PR that says why.` — remedy first, escape hatch second.

## What it cannot do

It cannot see PRs, so it cannot require a dedicated one, and it cannot read a
justification. It checks the only thing it can observe: that the weakening is
alone in the diff. That is deliberately less than the rule a human would
write — a message asserting a rule the tool does not enforce is how the current
text failed.

## Verification

76 tests pass (14 new: 10 CLI cases through a real git repo, 4 unit cases on
`relaxations()`). Against the real regression — colregs-engine at the commit
before the entries were stripped — the new rule fires and names the three
phrases and the five files that rode along.

Version 1.0.0 -> 1.1.0. Consumers pin the moving `v1`, so promotion is the
usual tag-and-bump; nothing here changes an existing repo's behaviour unless
its config is edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
