### PR TITLE
worklist: stranded branches above Ready, listed only with no pointer

### DIFF
--- a/.claude/hooks/branch-home-gate.sh
+++ b/.claude/hooks/branch-home-gate.sh
@@ -38,21 +38,12 @@ HERE=$(cd "$(dirname "$0")" && pwd)
 # shellcheck source=lib-state.sh
 . "$HERE/lib-state.sh"
 
-# json_str() and block() come from lib-state.sh, sourced above.
+# json_str(), block() and names_branch() come from lib-state.sh, sourced above.
 
 # timeout is coreutils; a machine without it runs the command unbounded
 # rather than failing every check and blocking every session.
 run_to() {
   if command -v timeout >/dev/null 2>&1; then timeout "$@"; else shift; "$@"; fi
-}
-
-# True when $1 appears as a whole branch-name token in text on stdin -- not
-# merely as a substring. `-w` alone is not enough: branch names are built
-# from hyphens too, so claude/homed-extra is a `-w` match for claude/homed.
-# Extract every maximal run of branch-name characters and require one to
-# equal the branch exactly.
-names_branch() {
-  grep -oE '[A-Za-z0-9._/-]+' | grep -qxF -- "$1"
 }
 
 payload=$(cat) || exit 0

--- a/.claude/hooks/lib-state.sh
+++ b/.claude/hooks/lib-state.sh
@@ -47,10 +47,14 @@ state_is_repo() { state_repo >/dev/null 2>&1; }
 # merely as a substring. `-w` alone is not enough: branch names are built
 # from hyphens too, so claude/homed-extra is a `-w` match for claude/homed.
 # Extract every maximal run of branch-name characters and require one to
-# equal the branch exactly. Shared by branch-home-gate.sh and worklist so a
-# branch counts as pointed-at the same way in both.
+# equal the branch exactly. The charset is deliberately narrower than every
+# character git allows in a branch name (no `~^:?*[\`, no non-ASCII): it
+# exists to strip prose punctuation (a trailing period or comma) off a
+# branch mention in a sentence, and `+`/`@` are the two git allows that
+# never show up as that kind of padding. Shared by branch-home-gate.sh and
+# worklist so a branch counts as pointed-at the same way in both.
 names_branch() {
-  grep -oE '[A-Za-z0-9._/-]+' | grep -qxF -- "$1"
+  grep -oE '[A-Za-z0-9._/+@-]+' | grep -qxF -- "$1"
 }
 
 # One JSON-string escaper for the hooks that source this. It takes its text as

--- a/.claude/hooks/lib-state.sh
+++ b/.claude/hooks/lib-state.sh
@@ -43,6 +43,16 @@ state_dir() {
 # True when state_dir is inside the git repo, i.e. worth committing.
 state_is_repo() { state_repo >/dev/null 2>&1; }
 
+# True when $1 appears as a whole branch-name token in text on stdin -- not
+# merely as a substring. `-w` alone is not enough: branch names are built
+# from hyphens too, so claude/homed-extra is a `-w` match for claude/homed.
+# Extract every maximal run of branch-name characters and require one to
+# equal the branch exactly. Shared by branch-home-gate.sh and worklist so a
+# branch counts as pointed-at the same way in both.
+names_branch() {
+  grep -oE '[A-Za-z0-9._/-]+' | grep -qxF -- "$1"
+}
+
 # One JSON-string escaper for the hooks that source this. It takes its text as
 # an argument, and falls back to sed/awk where jq is absent -- a hook that
 # cannot emit its reason is a hook that fails open. Do not add a second

--- a/.claude/skills/worklist/SKILL.md
+++ b/.claude/skills/worklist/SKILL.md
@@ -41,12 +41,14 @@ Solace's turn             PRs ready for her: not draft, mergeable, checks
                           (failing check names printed in Notes, never a
                           boolean)
 Queued (auto-merge)       auto-merge enabled, waiting on checks
+Stranded branches         pushed branches with no PR and no pointer — a
+                          board card or open issue naming the branch counts
+                          as a home and drops it from this bucket
 Ready                     `ready` issues — agent-startable now
 Blocked                   `blocked` issues, with the updated date
 Not ready (agent's turn)  open PRs that are none of the above, with why
 Untriaged: N              unlabelled issues, table capped like every other
                           bucket — not count-only
-Stranded branches         pushed branches with no PR
 Needs ruling              the board's `## Needs ruling` cards, at most 8 —
                           one-way doors only, so normally empty
 Board                     the `## Claude's` cards, at most 8

--- a/.local/bin/worklist
+++ b/.local/bin/worklist
@@ -279,7 +279,7 @@ def labels: [(.labels.nodes // [])[].name];
       else $e[] | "\(.repo): \(.error)" end ] as $fails
 | [ $c.records[] | select(.data) | (.repo|split("/")[1]) as $s
     | (if .data.pullRequests.pageInfo.hasNextPage then "\($s): more than 50 open PRs -- PR buckets truncated" else empty end),
-      (if .data.issues.pageInfo.hasNextPage then "\($s): more than 100 open issues -- issue buckets and Untriaged truncated" else empty end) ] as $trunc
+      (if .data.issues.pageInfo.hasNextPage then "\($s): more than 100 open issues -- issue buckets, Untriaged and the stranded-branch pointer check truncated" else empty end) ] as $trunc
 | ($c.counts | if (.prs|type) == "string" and (.issues|type) == "string" and .prs == .issues and (.prs|test("^[0-9]")|not)
       then "unavailable (\(.prs))"
       else "\(.prs) open PRs, \(.issues) open issues across \($owner)" end) as $acct
@@ -295,7 +295,7 @@ def labels: [(.labels.nodes // [])[].name];
   + $fails + $trunc + [ $counts, "", "@@RULINGS@@",
   table_bucket("Solace'"'"'s turn"; "Notes"; $prs | map(select(awaiting_human))),
   table_bucket("Queued (auto-merge)"; "Notes"; $prs | map(select(.autoMergeRequest != null))),
-  table_bucket("Stranded branches (no PR)"; "Notes"; $stranded),
+  table_bucket("Stranded branches (no PR)"; "Notes"; $stranded | map(.item |= cut)),
   table_bucket("Ready"; "Updated"; $rd),
   table_bucket("Blocked"; "Updated"; $bl),
   table_bucket("Not ready (agent'"'"'s turn)"; "Notes"; $prs | map(select(.autoMergeRequest == null and (awaiting_human|not)))),
@@ -337,12 +337,16 @@ STRANDED_CANDIDATES='
 '
 
 # stranded_rows <cache file> -- {ref,item,notes} rows for the "Stranded
-# branches" bucket: a branch is dropped from the bucket, not merely
-# annotated, once a home names it -- a board card (names_branch against
-# $kb, set by board_path) or an open issue in the same repo (whole-token
-# match against title+body). Same names_branch as branch-home-gate.sh
-# (dotfiles#114), shared via lib-state.sh so a branch counts as pointed-at
-# the same way in both places. When lib-state.sh could not be found at all
+# branches" bucket, one row per branch (not grouped by repo) so brief mode's
+# row cap and "+N more" line work the same as every other bucket. A branch
+# is dropped from the bucket, not merely annotated, once a home names it --
+# a board card (names_branch against $kb, set by board_path) or an open
+# issue in the same repo (whole-token match against title+body). Same
+# names_branch as branch-home-gate.sh (dotfiles#114), shared via
+# lib-state.sh so a branch counts as pointed-at the same way in both
+# places. Only the first 100 open issues are ever fetched (see $trunc), so
+# a pointer past that page is missed the same way every other issue-derived
+# bucket already accepts. When lib-state.sh could not be found at all
 # (board_path never sourced it, so names_branch is undefined) every no-PR
 # branch is still listed -- "could not check for a pointer" is not the same
 # as "checked, found none".
@@ -360,11 +364,8 @@ stranded_rows() {
       fi
       [ "$pointed" = 0 ] && printf '%s\t%s\n' "$repo" "$branch"
     done
-  done | jq -R -s --arg brief "$brief" '
-    split("\n") | map(select(length > 0) | split("\t") | {repo:.[0], branch:.[1]})
-    | group_by(.repo)
-    | map({ref: .[0].repo, item: ([.[].branch] | join(", ")), notes: ""})
-    | if $brief == "1" then map(.item |= (if length > 80 then .[:77] + "..." else . end)) else . end
+  done | jq -R -s '
+    split("\n") | map(select(length > 0) | split("\t") | {ref:.[0], item:.[1], notes:""})
   '
 }
 

--- a/.local/bin/worklist
+++ b/.local/bin/worklist
@@ -92,7 +92,7 @@ QUERY='query($owner:String!,$name:String!){ repository(owner:$owner,name:$name){
     commits(last:1){nodes{commit{statusCheckRollup{state contexts(first:50){nodes{
       ... on CheckRun{name conclusion} ... on StatusContext{context state}}}}}}}}}
   issues(states:OPEN,first:100){pageInfo{hasNextPage} nodes{number title url updatedAt labels(first:20){nodes{name}}
-    milestone{title}}}
+    milestone{title} body}}
   refs(refPrefix:"refs/heads/",first:100){nodes{name associatedPullRequests(first:1){totalCount}}}
 }}'
 
@@ -273,10 +273,6 @@ def labels: [(.labels.nodes // [])[].name];
 | (if $milestone == "" then ($rest | map(select(.milestone)) | length) else 0 end) as $deferred
 | (if $milestone == "" then ($rest | map(select(.milestone|not))) else $rest end) as $untri
 | ($untri | length) as $untriaged
-| [ $c.records[] | select(.data) | (.repo|split("/")[1]) as $s | (.data.defaultBranchRef.name // "main") as $def
-    | [ (.data.refs.nodes // [])[] | select(.associatedPullRequests.totalCount == 0 and (.name|IN("main","master",$def)|not)
-        and (.name|startswith("release-please--")|not)) | .name ]
-    | select(length > 0) | {ref: $s, item: (join(", ") | cut), notes: ""} ] as $stranded
 | [ ($c.records | map(select(.error))) as $e
     | if ($e|length) > 0 and ($e|length) == ($c.records|length) and ([$e[].error]|unique|length) == 1
          and ($e[0].error|IN("gh unauthenticated","network")) then $e[0].error
@@ -299,12 +295,12 @@ def labels: [(.labels.nodes // [])[].name];
   + $fails + $trunc + [ $counts, "", "@@RULINGS@@",
   table_bucket("Solace'"'"'s turn"; "Notes"; $prs | map(select(awaiting_human))),
   table_bucket("Queued (auto-merge)"; "Notes"; $prs | map(select(.autoMergeRequest != null))),
+  table_bucket("Stranded branches (no PR)"; "Notes"; $stranded),
   table_bucket("Ready"; "Updated"; $rd),
   table_bucket("Blocked"; "Updated"; $bl),
   table_bucket("Not ready (agent'"'"'s turn)"; "Notes"; $prs | map(select(.autoMergeRequest == null and (awaiting_human|not)))),
   (if $untriaged == 0 then "Untriaged: 0"
-   else table_bucket("Untriaged: \($untriaged)" + (if $deferred > 0 then " (deferred to a milestone: \($deferred))" else "" end); "Updated"; $untri) end),
-  table_bucket("Stranded branches (no PR)"; "Notes"; $stranded) ]
+   else table_bucket("Untriaged: \($untriaged)" + (if $deferred > 0 then " (deferred to a milestone: \($deferred))" else "" end); "Updated"; $untri) end) ]
 | join("\n")
 '
 
@@ -326,6 +322,51 @@ board_path() {
 }
 
 count_lines() { [ -n "$1" ] || { echo 0; return; }; printf '%s\n' "$1" | grep -c '^'; }
+
+# Pushed branches with no open PR, one repo object per record, each carrying
+# its candidate branch names and its open issues' title+body (for the
+# pointer check below).
+# shellcheck disable=SC2016  # jq program, not shell
+STRANDED_CANDIDATES='
+[ .records[] | select(.data) | (.repo|split("/")[1]) as $s | (.data.defaultBranchRef.name // "main") as $def
+  | { repo: $s,
+      branches: [ (.data.refs.nodes // [])[] | select(.associatedPullRequests.totalCount == 0 and (.name|IN("main","master",$def)|not)
+        and (.name|startswith("release-please--")|not)) | .name ],
+      issues: [ (.data.issues.nodes // [])[] | ((.title // "") + " " + (.body // "") | gsub("\n"; " ")) ] }
+  | select(.branches | length > 0) ]
+'
+
+# stranded_rows <cache file> -- {ref,item,notes} rows for the "Stranded
+# branches" bucket: a branch is dropped from the bucket, not merely
+# annotated, once a home names it -- a board card (names_branch against
+# $kb, set by board_path) or an open issue in the same repo (whole-token
+# match against title+body). Same names_branch as branch-home-gate.sh
+# (dotfiles#114), shared via lib-state.sh so a branch counts as pointed-at
+# the same way in both places. When lib-state.sh could not be found at all
+# (board_path never sourced it, so names_branch is undefined) every no-PR
+# branch is still listed -- "could not check for a pointer" is not the same
+# as "checked, found none".
+stranded_rows() {
+  have_nb=1; command -v names_branch >/dev/null 2>&1 || have_nb=0
+  jq -c "$STRANDED_CANDIDATES" "$1" 2>/dev/null | jq -c '.[]' 2>/dev/null | while IFS= read -r robj; do
+    repo=$(printf '%s' "$robj" | jq -r '.repo')
+    issues_text=$(printf '%s' "$robj" | jq -r '.issues[]' 2>/dev/null)
+    printf '%s' "$robj" | jq -r '.branches[]' | while IFS= read -r branch; do
+      pointed=0
+      if [ "$have_nb" = 1 ]; then
+        if [ -n "$kb" ] && names_branch "$branch" < "$kb"; then pointed=1
+        elif [ -n "$issues_text" ] && printf '%s\n' "$issues_text" | names_branch "$branch"; then pointed=1
+        fi
+      fi
+      [ "$pointed" = 0 ] && printf '%s\t%s\n' "$repo" "$branch"
+    done
+  done | jq -R -s --arg brief "$brief" '
+    split("\n") | map(select(length > 0) | split("\t") | {repo:.[0], branch:.[1]})
+    | group_by(.repo)
+    | map({ref: .[0].repo, item: ([.[].branch] | join(", ")), notes: ""})
+    | if $brief == "1" then map(.item |= (if length > 80 then .[:77] + "..." else . end)) else . end
+  '
+}
 
 # ruling_section <board> <project>
 # The ## Needs ruling cards, grouped by the "### <name>" heading above them --
@@ -404,7 +445,8 @@ render() {
       # The buckets come out of jq in one piece with a @@RULINGS@@ marker in
       # them; the rulings are spliced in here rather than by awk, because a
       # multi-line -v assignment is a syntax error in one-true-awk.
-      body=$(jq -r --arg brief "$brief" --arg milestone "$milestone" "$RENDER" "$1")
+      stranded_json=$(stranded_rows "$1")
+      body=$(jq -r --arg brief "$brief" --arg milestone "$milestone" --argjson stranded "${stranded_json:-[]}" "$RENDER" "$1")
       printf '%s' "${body%%@@RULINGS@@*}"
       [ -n "$rulings" ] && printf '%s\n' "$rulings"
       printf '%s\n' "${body#*@@RULINGS@@}"

--- a/.local/bin/worklist.test.sh
+++ b/.local/bin/worklist.test.sh
@@ -77,7 +77,11 @@ long_title="A title that runs well past the eighty character mark so that brief 
   issue 40 "Milestone ready" '["ready"]' '"1.0"'; echo ,
   issue 41 "Milestone blocked" '["blocked"]' '"1.0"'; echo ,
   issue 42 "Points at a branch" '[]' null "see the pointed-by-issue branch for the change"
-  echo ']},"refs":{"nodes":[{"name":"main","associatedPullRequests":{"totalCount":0}},{"name":"release-please--branches--main","associatedPullRequests":{"totalCount":0}},{"name":"feature-x","associatedPullRequests":{"totalCount":0}},{"name":"pr-branch","associatedPullRequests":{"totalCount":1}},{"name":"pointed-by-board","associatedPullRequests":{"totalCount":0}},{"name":"pointed-by-issue","associatedPullRequests":{"totalCount":0}}]}}}}'
+  echo ']},"refs":{"nodes":['
+  echo '{"name":"main","associatedPullRequests":{"totalCount":0}},{"name":"release-please--branches--main","associatedPullRequests":{"totalCount":0}},{"name":"feature-x","associatedPullRequests":{"totalCount":0}},{"name":"pr-branch","associatedPullRequests":{"totalCount":1}},{"name":"pointed-by-board","associatedPullRequests":{"totalCount":0}},{"name":"pointed-by-issue","associatedPullRequests":{"totalCount":0}}'
+  # five more unpointed branches, for the stranded bucket's own +N more line
+  for i in 1 2 3 4 5; do printf ',{"name":"stray-%s","associatedPullRequests":{"totalCount":0}}' "$i"; done
+  echo ']}}}}'
 } | jq -c . > "$FIXTURES/alpha.json"
 jq -nc '{data:{repository:{defaultBranchRef:{name:"main"},pullRequests:{nodes:[{number:5,title:"Draft PR",url:"https://github.com/o/beta/pull/5",isDraft:true,mergeable:"MERGEABLE",autoMergeRequest:null,author:{login:"o"},reviewThreads:{nodes:[]},commits:{nodes:[{commit:{statusCheckRollup:null}}]}}]},issues:{nodes:[]},refs:{nodes:[{name:"main",associatedPullRequests:{totalCount:0}}]}}}}' > "$FIXTURES/beta.json"
 # seven more ready issues, for the +N more line
@@ -188,6 +192,9 @@ assert 'Stranded branches sits after Queued' [ "$q_line" -lt "$s_line" ]
 assert 'Stranded branches sits before Ready' [ "$s_line" -lt "$r_line" ]
 OUT=$(section "Stranded branches (no PR)")
 has 'branch with no PR' '^\| alpha \| feature-x \|  \|$'
+has 'each stray branch is its own row' '^\| alpha \| stray-3 \|  \|$'
+eq 'one row per branch, all six shown (full mode cap is eight)' 6 "$(printf '%s\n' "$OUT" | grep -c '^| alpha |')"
+lacks 'no overflow line under the cap' '\+.* more'
 lacks 'main is not stranded' 'main'; lacks 'release-please branch is not stranded' 'release-please'; lacks 'branch with a PR is not stranded' 'pr-branch'
 lacks 'branch pointed at by a board card is not stranded' 'pointed-by-board'
 lacks 'branch pointed at by an open issue is not stranded' 'pointed-by-issue'
@@ -235,6 +242,9 @@ OUT_ALL=$OUT
 OUT=$(section "Ready")
 eq 'bucket capped at five lines plus header, separator and overflow line' 8 "$(printf '%s\n' "$OUT" | grep -c .)"
 has 'overflow line' '^\| \+5 more \| \| run `worklist` \|$'
+OUT=$(section "Stranded branches (no PR)")
+eq 'stranded branches capped at five rows too, one row per branch' 8 "$(printf '%s\n' "$OUT" | grep -c .)"
+has 'stranded overflow line' '^\| \+1 more \| \| run `worklist` \|$'
 OUT=$OUT_ALL
 lacks 'no urls in brief' 'https://github.com/o/alpha/pull/10'
 cut_title=$(printf '%s\n' "$OUT" | sed -n 's/^| alpha#28 | \(.*\) |  |$/\1/p')

--- a/.local/bin/worklist.test.sh
+++ b/.local/bin/worklist.test.sh
@@ -30,7 +30,7 @@ cd "$S/repo" || exit 1
 
 # --- the board -----------------------------------------------------------------
 {
-  printf '# Board\n\n## Needs ruling\n'
+  printf '# Board\n\nA card names the pushed branch pointed-by-board somewhere in its body.\n\n## Needs ruling\n'
   printf -- '### demo\n'
   printf -- '- [ ] **Board sections** — decide whether a question is a card or an issue ([o/r#90](https://github.com/o/r/pull/90))\n'
   printf -- '### global\n'
@@ -52,10 +52,10 @@ pr() { # number title draft mergeable rollup automerge unresolved contexts-json 
      reviewThreads:{nodes:(([range($u)] | map({isResolved:false})) + [{isResolved:true}])},
      commits:{nodes:[{commit:{statusCheckRollup:(if $r == "NONE" then null else {state:$r, contexts:{nodes:$cx}} end)}}]}}'
 }
-issue() { # number title labels-json milestone-or-null
-  jq -n --argjson n "$1" --arg t "$2" --argjson l "$3" --argjson ms "$4" '
+issue() { # number title labels-json milestone-or-null [body]
+  jq -n --argjson n "$1" --arg t "$2" --argjson l "$3" --argjson ms "$4" --arg b "${5:-}" '
     {number:$n, title:$t, url:"https://github.com/o/alpha/issues/\($n)", labels:{nodes:($l|map({name:.}))},
-     milestone:(if $ms then {title:$ms} else null end)}'
+     milestone:(if $ms then {title:$ms} else null end), body:$b}'
 }
 green='[{"name":"ci-gate / gate","conclusion":"SUCCESS"}]'
 red='[{"name":"ci-gate / gate","conclusion":"FAILURE"},{"context":"coverage","state":"FAILURE"},{"name":"lint","conclusion":"SUCCESS"}]'
@@ -75,8 +75,9 @@ long_title="A title that runs well past the eighty character mark so that brief 
   issue 27 "Formerly assigned" '[]' null; echo ,
   issue 28 "$long_title" '["ready"]' null; echo ,
   issue 40 "Milestone ready" '["ready"]' '"1.0"'; echo ,
-  issue 41 "Milestone blocked" '["blocked"]' '"1.0"'
-  echo ']},"refs":{"nodes":[{"name":"main","associatedPullRequests":{"totalCount":0}},{"name":"release-please--branches--main","associatedPullRequests":{"totalCount":0}},{"name":"feature-x","associatedPullRequests":{"totalCount":0}},{"name":"pr-branch","associatedPullRequests":{"totalCount":1}}]}}}}'
+  issue 41 "Milestone blocked" '["blocked"]' '"1.0"'; echo ,
+  issue 42 "Points at a branch" '[]' null "see the pointed-by-issue branch for the change"
+  echo ']},"refs":{"nodes":[{"name":"main","associatedPullRequests":{"totalCount":0}},{"name":"release-please--branches--main","associatedPullRequests":{"totalCount":0}},{"name":"feature-x","associatedPullRequests":{"totalCount":0}},{"name":"pr-branch","associatedPullRequests":{"totalCount":1}},{"name":"pointed-by-board","associatedPullRequests":{"totalCount":0}},{"name":"pointed-by-issue","associatedPullRequests":{"totalCount":0}}]}}}}'
 } | jq -c . > "$FIXTURES/alpha.json"
 jq -nc '{data:{repository:{defaultBranchRef:{name:"main"},pullRequests:{nodes:[{number:5,title:"Draft PR",url:"https://github.com/o/beta/pull/5",isDraft:true,mergeable:"MERGEABLE",autoMergeRequest:null,author:{login:"o"},reviewThreads:{nodes:[]},commits:{nodes:[{commit:{statusCheckRollup:null}}]}}]},issues:{nodes:[]},refs:{nodes:[{name:"main",associatedPullRequests:{totalCount:0}}]}}}}' > "$FIXTURES/beta.json"
 # seven more ready issues, for the +N more line
@@ -130,7 +131,7 @@ run
 eq 'exit 0' 0 "$RC"
 has 'stamp without cache note' '^as of [0-9]{2}:[0-9]{2}Z$'
 has 'scope names the project and repos' '^project demo \(o\): alpha, beta$'
-has 'scoped counts first, account-wide after' '^counts: 6 open PRs, 8 open issues in scope; 3 open PRs, 2 open issues across o$'
+has 'scoped counts first, account-wide after' '^counts: 6 open PRs, 9 open issues in scope; 3 open PRs, 2 open issues across o$'
 eq 'one GraphQL call per repo' 2 "$(calls 'api graphql')"
 eq 'topic looked up once' 1 "$(calls 'repo view o/alpha --json repositoryTopics')"
 eq 'repo set from the topic' 1 "$(calls 'repo list o --topic project-demo')"
@@ -179,10 +180,17 @@ has 'failing checks named, never a boolean' '^\| \[alpha#13\].* \| Red PR \| fai
 lacks 'a green check is not listed as failing' 'lint'
 has 'draft noted' '^\| \[beta#5\].* \| Draft PR \| draft \|'
 OUT=$OUT_ALL
-has 'untriaged is a count, deferred separately' '^Untriaged: 2 \(deferred to a milestone: 1\)$'
+has 'untriaged is a count, deferred separately' '^Untriaged: 3 \(deferred to a milestone: 1\)$'
+q_line=$(printf '%s\n' "$OUT_ALL" | grep -n '^Queued (auto-merge)' | cut -d: -f1)
+s_line=$(printf '%s\n' "$OUT_ALL" | grep -n '^Stranded branches (no PR)' | cut -d: -f1)
+r_line=$(printf '%s\n' "$OUT_ALL" | grep -n '^Ready$\|^Ready:' | head -1 | cut -d: -f1)
+assert 'Stranded branches sits after Queued' [ "$q_line" -lt "$s_line" ]
+assert 'Stranded branches sits before Ready' [ "$s_line" -lt "$r_line" ]
 OUT=$(section "Stranded branches (no PR)")
 has 'branch with no PR' '^\| alpha \| feature-x \|  \|$'
 lacks 'main is not stranded' 'main'; lacks 'release-please branch is not stranded' 'release-please'; lacks 'branch with a PR is not stranded' 'pr-branch'
+lacks 'branch pointed at by a board card is not stranded' 'pointed-by-board'
+lacks 'branch pointed at by an open issue is not stranded' 'pointed-by-issue'
 OUT=$OUT_ALL
 has 'board heading with counts' "^Board \(## Claude's, showing 8 of 10\)$"
 eq 'at most eight cards' 8 "$(printf '%s\n' "$OUT" | grep -c '^- \*\*Card ')"


### PR DESCRIPTION
## What

Closes mark-brannan/dotfiles#109.

- Moves "Stranded branches (no PR)" directly above `Ready`, after `Queued
  (auto-merge)`.
- A branch is stranded only when it has no open PR **and** no open issue or
  board card names it. A pointer **drops the branch from the bucket
  entirely** rather than annotating it with `pointer: <link>` — the
  issue's own title already frames it as "listed only" with a pointer, so
  that's the reading this takes; a dropped branch is still visible to
  anyone who opens the repo or its issues directly.
- Shares the whole-token branch-name match with `branch-home-gate.sh`
  (dotfiles#114) instead of writing a second one: `names_branch()` moved
  into `lib-state.sh`, `branch-home-gate.sh` now sources the shared copy.
- The issues GraphQL query now fetches `body`, so an issue naming a branch
  in its body (not just its title) counts as a pointer, matching
  `branch-home-gate.sh`'s own issue check.
- When `lib-state.sh` can't be found at all (so `names_branch` is
  undefined), every no-PR branch still lists — "couldn't check for a
  pointer" is not the same as "checked, found none."

Rebased onto #119 (`feat/worklist-milestone`, since merged) per the issue's
sequencing note — both touch the same bucket code.

## Verification

- `bash .local/bin/worklist.test.sh` — 118 passed, 0 failed (mawk, gawk,
  and the default awk).
- `bash .claude/hooks/branch-home-gate.test.sh` — 30 passed, 0 failed.
- `shellcheck -s sh .local/bin/worklist` and the hooks — clean.
- New fixture branches `pointed-by-board` (named by a board card) and
  `pointed-by-issue` (named by an issue body) confirm both drop out of the
  bucket while an unpointed `feature-x` still lists; a line-number
  assertion confirms bucket order (Queued → Stranded → Ready).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Worklist now recognizes branches as assigned when referenced by a board card or an open issue.
  - Open issue descriptions are included when identifying branch references.

- **Improvements**
  - Stranded branches now appear directly after queued items for clearer prioritization.
  - Branch matching is more precise, preventing similarly named branches from being incorrectly treated as assigned.

- **Documentation**
  - Updated worklist guidance to explain when branch references count as a home.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->