### PR TITLE
prose-budget: exempt blockquote lines from the voice rule

### DIFF
--- a/.local/bin/prose-budget
+++ b/.local/bin/prose-budget
@@ -726,7 +726,11 @@ class Checker:
                      if matches(cfg["targets"], f) and f != self.config_rel for n, l in lines]
         else:
             return
+        skipped = 0
         for f, (lineno, ptr, text) in units:
+            if ptr is None and text.lstrip().startswith(">"):
+                skipped += 1
+                continue
             for a in cfg["allow"]:
                 text = text.replace(a, "")
             for name, rx in regexes:
@@ -740,6 +744,7 @@ class Checker:
         for p, per_file in counts.items():
             self.info.append(f'voice: "{p}": ' + (", ".join(f"{f} {n}" for f, n in sorted(per_file.items()))
                                                     or "none"))
+        self.info.append(f"voice: {skipped} quoted line(s) skipped")
 
     def check_headers(self, cfg):
         for f in self.targets(cfg["targets"]):

--- a/.local/bin/prose-budget.test.py
+++ b/.local/bin/prose-budget.test.py
@@ -627,6 +627,10 @@ class VoiceTest(RepoCase):
         f = [x for x in self.findings("--base", "main") if x["rule"] == "voice"]
         self.assertEqual([x["message"].split('"')[1] for x in f], ["leverage"])
 
+    def test_blockquote_line_is_exempt_from_voice_only(self):
+        self.assertEqual(self.tree("> a robust quote\na robust line\n"), ["robust"])
+        self.assertIn("voice: 1 quoted line(s) skipped", self.cli("--tree")[2])
+
 
 class HeadersTest(RepoCase):
     def test_cap_grandfather_and_shebang(self):


### PR DESCRIPTION
## Why

The voice rule flagged banned words inside quoted reviewer text, and the only fix was editing someone else's words.

## What

- Lines whose first non-space character is `>` are now skipped by the voice rule's regexes only. Word budgets, diff delta, and every other rule still process them.
- The report prints a `voice: N quoted line(s) skipped` info line.
- New test: a banned word inside a blockquote passes, the same word outside a blockquote still fails, and the skip-count line is correct.

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)
