### PR TITLE
grind: work the Ready queue one claude -p session at a time

### DIFF
--- a/.claude/skills/sequence/SKILL.md
+++ b/.claude/skills/sequence/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sequence
-description: Walk one decision card to a ruling, a spawned work item, or an unblocked card — a typed contract (exact question in, one of three outcomes out), not a status update. Use on "/sequence", "walk the decision cards", "what needs deciding", or when `worklist`'s `## Needs ruling` isn't empty. High-judgment, few calls — Opus, Fable for the harder calls.
+description: Walk one decision card to a ruling, a spawned work item, or an unblocked card — a typed contract (exact question in, one of three outcomes out), not a status update. Use on "/sequence", "walk the decision cards", "what needs deciding", or when `worklist`'s `## Needs ruling` isn't empty. High-judgment, few calls — Opus, Fable for the harder calls. Not for doing the work; that is grind.
 ---
 
 # Sequence

--- a/.local/bin/grind
+++ b/.local/bin/grind
@@ -1,0 +1,267 @@
+#!/bin/sh
+# grind -- a zero-token orchestrator that works the Ready queue one
+# `claude -p` session at a time.
+#
+# Why: no skill executes work. `sequence` routes decisions, `worklist`
+# reports, `sweep` and `reconcile` prune the record. This is the one that
+# does the work, and because it is a script rather than a model, measuring
+# and capping spend is free. Ruled 2026-09-09 (Solace).
+#
+# Per Ready item, top (lowest issue number) first:
+#   1. A fresh worktree on a new branch, named after the item.
+#   2. One `claude -p --output-format json --max-budget-usd <item cap>
+#      --model <m> --effort <e>` with the issue body (plus a short contract
+#      appended below) as the prompt. That session does the work and opens
+#      the PR. Merging stays the human's.
+#   3. Parse the JSON result for cost and tokens; print one line: item,
+#      model, cost, tokens, running total, percent of session budget.
+#      Crossing 25/50/75% prints a louder line, once each, per session.
+#   4. A worker that decides an item needs a human ruling ends its final
+#      message with the line "GRIND_STATUS: carded" (having filed the card
+#      itself, per this repo's card-write convention) instead of guessing.
+#      grind matches that line, logs "carded", and moves to the next item
+#      without treating it as a failure.
+#   5. Pause -- print a tally and the exact resume command, then exit 0 --
+#      when: the session budget is reached, one item costs more than twice
+#      the running median, or every N items. Nothing here waits on a
+#      terminal.
+#
+# Defaults, overridable by flag: Sonnet, medium effort, $5/item, $20/session,
+# pause every 3. `--dry-run` prints the plan -- one line per Ready item, the
+# exact command that item would run -- and spends nothing.
+#
+# State (resume bookkeeping only, never committed): a JSON file per grind
+# session under $XDG_STATE_HOME/grind holding the options and which item
+# refs are already done or carded. `--resume <session>` re-reads it, skips
+# what is already accounted for, and keeps appending to the same file.
+#
+#   grind [--dry-run] [--repo owner/name] [--model <m>] [--effort <e>]
+#         [--item-budget <usd>] [--session-budget <usd>] [--pause-every <n>]
+#         [--resume <session-id>]
+set -eu
+
+usage() {
+  printf 'usage: grind [--dry-run] [--repo owner/name] [--model <m>] [--effort <e>]\n'
+  printf '             [--item-budget <usd>] [--session-budget <usd>] [--pause-every <n>]\n'
+  printf '             [--resume <session-id>]\n'
+}
+
+model=sonnet
+effort=medium
+item_budget=5
+session_budget=20
+pause_every=3
+dry_run=0
+repo=""
+resume_id=""
+
+while [ $# -gt 0 ]; do
+  case $1 in
+    --dry-run) dry_run=1 ;;
+    --repo) shift; repo=${1:-} ;;
+    --model) shift; model=${1:-} ;;
+    --effort) shift; effort=${1:-} ;;
+    --item-budget) shift; item_budget=${1:-} ;;
+    --session-budget) shift; session_budget=${1:-} ;;
+    --pause-every) shift; pause_every=${1:-} ;;
+    --resume) shift; resume_id=${1:-} ;;
+    -h|--help) usage; exit 0 ;;
+    -*) printf 'grind: unknown option %s\n' "$1" >&2; usage >&2; exit 2 ;;
+    *) printf 'grind: unexpected argument %s\n' "$1" >&2; usage >&2; exit 2 ;;
+  esac
+  shift
+done
+
+command -v jq >/dev/null 2>&1 || { echo "grind: needs jq" >&2; exit 1; }
+command -v gh >/dev/null 2>&1 || { echo "grind: needs gh" >&2; exit 1; }
+
+state_root=${XDG_STATE_HOME:-$HOME/.local/state}/grind
+mkdir -p "$state_root" 2>/dev/null || true
+
+# --- repo scope --------------------------------------------------------------
+cwd_repo() {
+  u=$(git remote get-url origin 2>/dev/null) || return 1
+  r=$(printf '%s' "$u" | sed -e 's#^https://github\.com/##' -e 's#^ssh://git@github\.com/##' \
+        -e 's#^git@github\.com:##' -e 's#/$##' -e 's#\.git$##')
+  [ "$r" = "$u" ] && return 1
+  printf '%s' "$r"
+}
+
+# --- state file ---------------------------------------------------------------
+# {session, repo, model, effort, item_budget, session_budget, pause_every,
+#  items: [{ref, status, cost}]}
+new_session_id() { date -u +%Y%m%dT%H%M%SZ; }
+
+if [ -n "$resume_id" ]; then
+  state_file="$state_root/$resume_id.json"
+  [ -f "$state_file" ] || { printf 'grind: no session %s at %s\n' "$resume_id" "$state_file" >&2; exit 1; }
+  session_id=$resume_id
+  repo=$(jq -r '.repo' "$state_file")
+  model=$(jq -r '.model' "$state_file")
+  effort=$(jq -r '.effort' "$state_file")
+  item_budget=$(jq -r '.item_budget' "$state_file")
+  session_budget=$(jq -r '.session_budget' "$state_file")
+  pause_every=$(jq -r '.pause_every' "$state_file")
+else
+  session_id=grind-$(new_session_id)
+  state_file="$state_root/$session_id.json"
+  [ -n "$repo" ] || repo=$(cwd_repo) || { printf 'grind: not in a GitHub repo; pass --repo owner/name\n' >&2; exit 1; }
+  if [ "$dry_run" -eq 0 ]; then
+    jq -n --arg repo "$repo" --arg model "$model" --arg effort "$effort" \
+          --argjson ib "$item_budget" --argjson sb "$session_budget" --argjson pe "$pause_every" \
+      '{repo:$repo, model:$model, effort:$effort, item_budget:$ib, session_budget:$sb, pause_every:$pe, items:[]}' \
+      > "$state_file"
+  fi
+fi
+
+resume_cmd="grind --resume $session_id"
+
+# refs (owner/repo#N) already accounted for from a prior run of this session
+done_refs=""
+[ -f "$state_file" ] && done_refs=$(jq -r '.items[].ref' "$state_file")
+
+# --- fetch the Ready queue, top (lowest number) first -------------------------
+ready_json=$(gh issue list --repo "$repo" --label ready --state open --limit 100 \
+  --json number,title,body,url,labels 2>&1) \
+  || { printf 'grind: could not list issues on %s: %s\n' "$repo" "$ready_json" >&2; exit 1; }
+
+items=$(printf '%s' "$ready_json" | jq -c '
+  map(select((.labels | map(.name) | index("blocked")) == null))
+  | sort_by(.number)')
+
+count=$(printf '%s' "$items" | jq 'length')
+if [ "$count" -eq 0 ]; then
+  echo "grind: no Ready items on $repo"
+  exit 0
+fi
+
+# --- one worktree per item -----------------------------------------------------
+worktree_root=${TMPDIR:-/tmp}/grind-worktrees
+
+build_prompt() {
+  body=$1
+  printf '%s\n\n---\n' "$body"
+  printf 'Grind orchestration contract: work this item to a mergeable PR and open\n'
+  printf 'it yourself; do not merge it. If finishing it requires a ruling only the\n'
+  printf 'repo owner can make, do not guess -- file the card per this repo'"'"'s\n'
+  printf 'card-write convention, then end your final message with exactly this\n'
+  printf 'line and nothing after it: GRIND_STATUS: carded\n'
+  printf 'Otherwise end your final message with exactly: GRIND_STATUS: done\n'
+}
+
+# median <space-separated numbers> -> prints 0 when the list is empty
+median() {
+  if [ -z "$1" ]; then printf '0\n'; return; fi
+  printf '%s\n' "$1" | tr ' ' '\n' | awk 'NF' | sort -n | awk '
+    { a[NR]=$1 } END { if (NR==0) { print 0; exit }
+      if (NR % 2) print a[(NR+1)/2]; else print (a[NR/2]+a[NR/2+1])/2 }'
+}
+
+pct() { awk -v a="$1" -v b="$2" 'BEGIN { if (b == 0) { print 0 } else { printf "%.0f", (a / b) * 100 } }'; }
+fmt_usd() { awk -v v="$1" 'BEGIN { printf "$%.2f", v }'; }
+
+running_total=0
+loud_25=0; loud_50=0; loud_75=0
+processed_this_run=0
+costs=""
+
+i=0
+while [ "$i" -lt "$count" ]; do
+  item=$(printf '%s' "$items" | jq -c ".[$i]")
+  i=$((i + 1))
+  number=$(printf '%s' "$item" | jq -r '.number')
+  title=$(printf '%s' "$item" | jq -r '.title')
+  ref="$repo#$number"
+
+  case "$done_refs" in *"$ref"*) continue ;; esac
+
+  branch="grind-$number"
+  wt_path="$worktree_root/$number"
+
+  cmd_display="claude -p <issue $ref body> --output-format json --max-budget-usd $item_budget --model $model --effort $effort"
+
+  if [ "$dry_run" -eq 1 ]; then
+    printf '[%d/%d] %s -- %s\n' "$((i))" "$count" "$ref" "$title"
+    printf '  worktree: git worktree add -b %s %s\n' "$branch" "$wt_path"
+    printf '  command:  %s\n' "$cmd_display"
+    continue
+  fi
+
+  mkdir -p "$worktree_root"
+  git worktree prune >/dev/null 2>&1 || true
+  rm -rf "$wt_path"
+  git branch -D "$branch" >/dev/null 2>&1 || true
+  git worktree add -q -b "$branch" "$wt_path" >/dev/null 2>&1 \
+    || { printf 'grind: could not create worktree for %s -- skipping\n' "$ref" >&2; continue; }
+
+  prompt=$(build_prompt "$(printf '%s' "$item" | jq -r '.body')")
+  result_json=$( (cd "$wt_path" && printf '%s' "$prompt" | \
+    claude -p --output-format json --max-budget-usd "$item_budget" --model "$model" --effort "$effort") ) \
+    || result_json=""
+
+  git worktree remove -f "$wt_path" >/dev/null 2>&1 || true
+
+  cost=$(printf '%s' "$result_json" | jq -r '.total_cost_usd // 0' 2>/dev/null); cost=${cost:-0}
+  tokens=$(printf '%s' "$result_json" | jq -r '
+    ((.usage.input_tokens // 0) + (.usage.output_tokens // 0)
+     + (.usage.cache_creation_input_tokens // 0) + (.usage.cache_read_input_tokens // 0))' 2>/dev/null)
+  tokens=${tokens:-0}
+  text=$(printf '%s' "$result_json" | jq -r '.result // ""' 2>/dev/null)
+
+  status=done
+  case "$text" in *"GRIND_STATUS: carded"*) status=carded ;; esac
+
+  running_total=$(awk -v a="$running_total" -v b="$cost" 'BEGIN { printf "%.4f", a + b }')
+  processed_this_run=$((processed_this_run + 1))
+  jq --arg ref "$ref" --arg status "$status" --argjson cost "$cost" \
+     '.items += [{ref:$ref, status:$status, cost:$cost}]' "$state_file" > "$state_file.tmp" \
+     && mv "$state_file.tmp" "$state_file"
+
+  percent=$(pct "$running_total" "$session_budget")
+  if [ "$status" = carded ]; then
+    printf 'carded: %s -- %s (%s, %s tokens, running %s / %s -- %s%%)\n' \
+      "$ref" "$title" "$(fmt_usd "$cost")" "$tokens" "$(fmt_usd "$running_total")" "$(fmt_usd "$session_budget")" "$percent"
+  else
+    printf '%s: %s -- %s, %s, %s tokens -- running %s / %s -- %s%%\n' \
+      "$ref" "$title" "$model" "$(fmt_usd "$cost")" "$tokens" "$(fmt_usd "$running_total")" "$(fmt_usd "$session_budget")" "$percent"
+  fi
+
+  if [ "$percent" -ge 75 ] && [ "$loud_75" -eq 0 ]; then
+    loud_75=1; printf '*** 75%% of session budget spent (%s / %s) ***\n' "$(fmt_usd "$running_total")" "$(fmt_usd "$session_budget")"
+  elif [ "$percent" -ge 50 ] && [ "$loud_50" -eq 0 ]; then
+    loud_50=1; printf '*** 50%% of session budget spent (%s / %s) ***\n' "$(fmt_usd "$running_total")" "$(fmt_usd "$session_budget")"
+  elif [ "$percent" -ge 25 ] && [ "$loud_25" -eq 0 ]; then
+    loud_25=1; printf '*** 25%% of session budget spent (%s / %s) ***\n' "$(fmt_usd "$running_total")" "$(fmt_usd "$session_budget")"
+  fi
+
+  # pause conditions, checked in this order: budget, outlier cost, cadence.
+  reached_budget=$(awk -v a="$running_total" -v b="$session_budget" 'BEGIN { print (a >= b) ? 1 : 0 }')
+  prior_median=$(median "$costs")
+  outlier=$(awk -v c="$cost" -v m="$prior_median" 'BEGIN { print (m > 0 && c > 2 * m) ? 1 : 0 }')
+  costs="$costs $cost"
+
+  if [ "$reached_budget" -eq 1 ]; then
+    printf 'pause: session budget reached (%s / %s). %d item(s) processed this run.\n' \
+      "$(fmt_usd "$running_total")" "$(fmt_usd "$session_budget")" "$processed_this_run"
+    printf 'resume: %s\n' "$resume_cmd"
+    exit 0
+  fi
+  if [ "$outlier" -eq 1 ]; then
+    printf 'pause: %s cost %s, more than twice the running median (%s). %d item(s) processed this run.\n' \
+      "$ref" "$(fmt_usd "$cost")" "$(fmt_usd "$prior_median")" "$processed_this_run"
+    printf 'resume: %s\n' "$resume_cmd"
+    exit 0
+  fi
+  if [ "$processed_this_run" -ge "$pause_every" ]; then
+    printf 'pause: %d items processed this run (pause every %d). Running total %s / %s.\n' \
+      "$processed_this_run" "$pause_every" "$(fmt_usd "$running_total")" "$(fmt_usd "$session_budget")"
+    printf 'resume: %s\n' "$resume_cmd"
+    exit 0
+  fi
+done
+
+if [ "$dry_run" -eq 1 ]; then
+  exit 0
+fi
+
+printf 'done: Ready queue exhausted. Running total %s / %s.\n' "$(fmt_usd "$running_total")" "$(fmt_usd "$session_budget")"

--- a/.local/bin/grind
+++ b/.local/bin/grind
@@ -116,11 +116,22 @@ fi
 
 resume_cmd="grind --resume $session_id"
 
+# Worktrees are cut from the current directory's repository, so it must be
+# a checkout of $repo -- otherwise the worker is handed the wrong codebase.
+if [ "$dry_run" -eq 0 ]; then
+  here=$(cwd_repo) || here=""
+  [ "$here" = "$repo" ] \
+    || { printf 'grind: current directory is not a checkout of %s (found: %s); cd there first\n' \
+           "$repo" "${here:-no GitHub remote}" >&2; exit 1; }
+fi
+
 # refs (owner/repo#N) already accounted for from a prior run of this session,
 # delimited so a ref that is a prefix of another (e.g. #5 vs #50) can't
 # falsely match on a raw substring test.
+# Items recorded as failed keep their cost but are retried, so they are
+# excluded here.
 done_refs="|"
-[ -f "$state_file" ] && done_refs="|$(jq -r '.items[].ref' "$state_file" | tr '\n' '|')"
+[ -f "$state_file" ] && done_refs="|$(jq -r '.items[] | select(.status != "failed") | .ref' "$state_file" | tr '\n' '|')"
 
 is_done_ref() {
   case "$done_refs" in *"|$1|"*) return 0 ;; esac
@@ -224,21 +235,16 @@ while [ "$i" -lt "$count" ]; do
     || { printf 'grind: could not create worktree for %s -- skipping\n' "$ref" >&2; continue; }
 
   prompt=$(build_prompt "$(printf '%s' "$item" | jq -r '.body')")
-  claude_failed=0
+  claude_rc=0
   result_json=$( (cd "$wt_path" && printf '%s' "$prompt" | \
     claude -p --output-format json --max-budget-usd "$item_budget" --model "$model" --effort "$effort") ) \
-    || claude_failed=1
+    || claude_rc=$?
 
   git worktree remove -f "$wt_path" >/dev/null 2>&1 || true
 
-  # A non-zero exit or unparseable/empty JSON means the worker never
-  # produced a result -- distinct from a worker that ran and reported one.
-  # Don't record it as done: --resume must retry it, not skip it forever.
-  if [ "$claude_failed" -eq 0 ]; then
-    printf '%s' "$result_json" | jq -e . >/dev/null 2>&1 || claude_failed=1
-  fi
-
-  if [ "$claude_failed" -eq 1 ]; then
+  # Unparseable/empty JSON means the worker never produced a result, so its
+  # spend is unknown: don't record it, and let --resume retry it.
+  if ! printf '%s' "$result_json" | jq -e . >/dev/null 2>&1; then
     printf 'FAILED: %s -- %s -- claude invocation did not complete; not recorded, will retry on --resume\n' \
       "$ref" "$title" >&2
     continue
@@ -250,9 +256,14 @@ while [ "$i" -lt "$count" ]; do
      + (.usage.cache_creation_input_tokens // 0) + (.usage.cache_read_input_tokens // 0))' 2>/dev/null)
   tokens=${tokens:-0}
   text=$(printf '%s' "$result_json" | jq -r '.result // ""' 2>/dev/null)
+  is_error=$(printf '%s' "$result_json" | jq -r '.is_error // false' 2>/dev/null)
 
+  # A non-zero exit or an is_error result (e.g. the item cap was hit) still
+  # spent money: record the cost so the session budget stays honest, but mark
+  # it failed so --resume retries it instead of skipping it forever.
   status=done
   case "$text" in *"GRIND_STATUS: carded"*) status=carded ;; esac
+  if [ "$claude_rc" -ne 0 ] || [ "$is_error" = true ]; then status=failed; fi
 
   running_total=$(awk -v a="$running_total" -v b="$cost" 'BEGIN { printf "%.4f", a + b }')
   processed_this_run=$((processed_this_run + 1))
@@ -261,7 +272,10 @@ while [ "$i" -lt "$count" ]; do
      && mv "$state_file.tmp" "$state_file"
 
   percent=$(pct "$running_total" "$session_budget")
-  if [ "$status" = carded ]; then
+  if [ "$status" = failed ]; then
+    printf 'FAILED: %s -- %s -- worker reported an error (%s, %s tokens, running %s / %s -- %s%%); will retry on --resume\n' \
+      "$ref" "$title" "$(fmt_usd "$cost")" "$tokens" "$(fmt_usd "$running_total")" "$(fmt_usd "$session_budget")" "$percent" >&2
+  elif [ "$status" = carded ]; then
     printf 'carded: %s -- %s (%s, %s tokens, running %s / %s -- %s%%)\n' \
       "$ref" "$title" "$(fmt_usd "$cost")" "$tokens" "$(fmt_usd "$running_total")" "$(fmt_usd "$session_budget")" "$percent"
   else
@@ -269,12 +283,15 @@ while [ "$i" -lt "$count" ]; do
       "$ref" "$title" "$model" "$(fmt_usd "$cost")" "$tokens" "$(fmt_usd "$running_total")" "$(fmt_usd "$session_budget")" "$percent"
   fi
 
+  # Independent checks so one item that crosses two lines announces both.
+  if [ "$percent" -ge 25 ] && [ "$loud_25" -eq 0 ]; then
+    loud_25=1; printf '*** 25%% of session budget spent (%s / %s) ***\n' "$(fmt_usd "$running_total")" "$(fmt_usd "$session_budget")"
+  fi
+  if [ "$percent" -ge 50 ] && [ "$loud_50" -eq 0 ]; then
+    loud_50=1; printf '*** 50%% of session budget spent (%s / %s) ***\n' "$(fmt_usd "$running_total")" "$(fmt_usd "$session_budget")"
+  fi
   if [ "$percent" -ge 75 ] && [ "$loud_75" -eq 0 ]; then
     loud_75=1; printf '*** 75%% of session budget spent (%s / %s) ***\n' "$(fmt_usd "$running_total")" "$(fmt_usd "$session_budget")"
-  elif [ "$percent" -ge 50 ] && [ "$loud_50" -eq 0 ]; then
-    loud_50=1; printf '*** 50%% of session budget spent (%s / %s) ***\n' "$(fmt_usd "$running_total")" "$(fmt_usd "$session_budget")"
-  elif [ "$percent" -ge 25 ] && [ "$loud_25" -eq 0 ]; then
-    loud_25=1; printf '*** 25%% of session budget spent (%s / %s) ***\n' "$(fmt_usd "$running_total")" "$(fmt_usd "$session_budget")"
   fi
 
   # pause conditions, checked in this order: budget, outlier cost, cadence.

--- a/.local/bin/grind
+++ b/.local/bin/grind
@@ -116,9 +116,16 @@ fi
 
 resume_cmd="grind --resume $session_id"
 
-# refs (owner/repo#N) already accounted for from a prior run of this session
-done_refs=""
-[ -f "$state_file" ] && done_refs=$(jq -r '.items[].ref' "$state_file")
+# refs (owner/repo#N) already accounted for from a prior run of this session,
+# delimited so a ref that is a prefix of another (e.g. #5 vs #50) can't
+# falsely match on a raw substring test.
+done_refs="|"
+[ -f "$state_file" ] && done_refs="|$(jq -r '.items[].ref' "$state_file" | tr '\n' '|')"
+
+is_done_ref() {
+  case "$done_refs" in *"|$1|"*) return 0 ;; esac
+  return 1
+}
 
 # --- fetch the Ready queue, top (lowest number) first -------------------------
 ready_json=$(gh issue list --repo "$repo" --label ready --state open --limit 100 \
@@ -160,10 +167,22 @@ median() {
 pct() { awk -v a="$1" -v b="$2" 'BEGIN { if (b == 0) { print 0 } else { printf "%.0f", (a / b) * 100 } }'; }
 fmt_usd() { awk -v v="$1" 'BEGIN { printf "$%.2f", v }'; }
 
+# Seed running_total and costs from prior-run item costs already in
+# $state_file so a --resume honors the original --session-budget as a
+# cap on the whole session, not just on this invocation.
 running_total=0
-loud_25=0; loud_50=0; loud_75=0
-processed_this_run=0
 costs=""
+if [ -f "$state_file" ]; then
+  running_total=$(jq -r '[.items[].cost] | add // 0' "$state_file")
+  costs=$(jq -r '.items[].cost' "$state_file" | tr '\n' ' ')
+fi
+
+start_percent=$(pct "$running_total" "$session_budget")
+loud_25=0; loud_50=0; loud_75=0
+[ "$start_percent" -ge 25 ] && loud_25=1
+[ "$start_percent" -ge 50 ] && loud_50=1
+[ "$start_percent" -ge 75 ] && loud_75=1
+processed_this_run=0
 
 i=0
 while [ "$i" -lt "$count" ]; do
@@ -173,7 +192,17 @@ while [ "$i" -lt "$count" ]; do
   title=$(printf '%s' "$item" | jq -r '.title')
   ref="$repo#$number"
 
-  case "$done_refs" in *"$ref"*) continue ;; esac
+  is_done_ref "$ref" && continue
+
+  if [ "$dry_run" -eq 0 ]; then
+    already_reached=$(awk -v a="$running_total" -v b="$session_budget" 'BEGIN { print (a >= b) ? 1 : 0 }')
+    if [ "$already_reached" -eq 1 ]; then
+      printf 'pause: session budget reached (%s / %s). %d item(s) processed this run.\n' \
+        "$(fmt_usd "$running_total")" "$(fmt_usd "$session_budget")" "$processed_this_run"
+      printf 'resume: %s\n' "$resume_cmd"
+      exit 0
+    fi
+  fi
 
   branch="grind-$number"
   wt_path="$worktree_root/$number"
@@ -195,11 +224,25 @@ while [ "$i" -lt "$count" ]; do
     || { printf 'grind: could not create worktree for %s -- skipping\n' "$ref" >&2; continue; }
 
   prompt=$(build_prompt "$(printf '%s' "$item" | jq -r '.body')")
+  claude_failed=0
   result_json=$( (cd "$wt_path" && printf '%s' "$prompt" | \
     claude -p --output-format json --max-budget-usd "$item_budget" --model "$model" --effort "$effort") ) \
-    || result_json=""
+    || claude_failed=1
 
   git worktree remove -f "$wt_path" >/dev/null 2>&1 || true
+
+  # A non-zero exit or unparseable/empty JSON means the worker never
+  # produced a result -- distinct from a worker that ran and reported one.
+  # Don't record it as done: --resume must retry it, not skip it forever.
+  if [ "$claude_failed" -eq 0 ]; then
+    printf '%s' "$result_json" | jq -e . >/dev/null 2>&1 || claude_failed=1
+  fi
+
+  if [ "$claude_failed" -eq 1 ]; then
+    printf 'FAILED: %s -- %s -- claude invocation did not complete; not recorded, will retry on --resume\n' \
+      "$ref" "$title" >&2
+    continue
+  fi
 
   cost=$(printf '%s' "$result_json" | jq -r '.total_cost_usd // 0' 2>/dev/null); cost=${cost:-0}
   tokens=$(printf '%s' "$result_json" | jq -r '

--- a/.local/bin/grind.test.sh
+++ b/.local/bin/grind.test.sh
@@ -105,19 +105,18 @@ has 'queue exhausted, final tally' '^done: Ready queue exhausted\. Running total
 sess=$(latest_session)
 eq 'two items recorded in state' 2 "$(jq '.items | length' "$sess")"
 
-# --- threshold lines: crossed once fires the loudest one reached that turn ------
+# --- threshold lines: each fires once, even when one item crosses several ------
 # Only two Ready items exist, so item 1 crosses 25%, item 2 jumps straight to
-# 100% (and the budget-reached pause) -- confirms the loudest-crossed-this-turn
-# rule rather than every threshold firing on every item.
+# 100% (and the budget-reached pause): 50% and 75% both announce on item 2.
 rm -f "$S/state/grind"/*.json
 rm -f "$S/claude-replies"/*.json
 reply 5.00 "done" 1    # 25% of 20
-reply 15.00 "done" 2   # +75% = 100% -> budget reached, 75% line (not 50%) fires
+reply 15.00 "done" 2   # +75% = 100% -> budget reached, 50% and 75% lines fire
 : > "$CLAUDE_LOG"
 run --session-budget 20 --pause-every 10
 has '25% line on the first item' '\*\*\* 25% of session budget spent \(\$5\.00 / \$20\.00\) \*\*\*'
-has '75% line (loudest crossed) on the second, not 50%' '\*\*\* 75% of session budget spent \(\$20\.00 / \$20\.00\) \*\*\*'
-lacks '50% line skipped -- one line per item, loudest threshold reached' '50% of session budget'
+has '50% line also fires on the second item' '\*\*\* 50% of session budget spent \(\$20\.00 / \$20\.00\) \*\*\*'
+has '75% line on the second item' '\*\*\* 75% of session budget spent \(\$20\.00 / \$20\.00\) \*\*\*'
 eq 'no line printed twice' 1 "$(printf '%s\n' "$OUT" | grep -c '25% of session budget')"
 has 'pauses when the session budget is reached' '^pause: session budget reached \(\$20\.00 / \$20\.00\)\.'
 sess=$(latest_session)
@@ -273,6 +272,47 @@ run --resume "$session_id"
 eq 'the failed item retried on resume' 1 "$(calls_claude)"
 has 'retried item now succeeds' '^o/alpha#7: Flaky item --'
 eq 'now recorded in state' 1 "$(jq '.items | length' "$sess")"
+
+# --- a worker that exits non-zero WITH a JSON result: cost kept, item retried ------
+rm -f "$S/state/grind"/*.json
+cat > "$S/bin/claude" <<GH
+#!/bin/sh
+cat > /dev/null
+n=\$(cat "$S/claude-next" 2>/dev/null || echo 1)
+echo "\$n \$*" >> "$CLAUDE_LOG"
+echo \$((n + 1)) > "$S/claude-next"
+echo '{"is_error":true,"total_cost_usd":5.00,"usage":{"input_tokens":100,"output_tokens":50},"result":"Budget exceeded"}'
+exit 1
+GH
+chmod +x "$S/bin/claude"
+: > "$CLAUDE_LOG"
+run --session-budget 100 --pause-every 10
+has 'logged as a failure' '^FAILED: o/alpha#7 .*will retry on --resume'
+sess=$(latest_session)
+eq 'recorded in state as failed' failed "$(jq -r '.items[0].status' "$sess")"
+eq 'its cost is kept' 5.00 "$(jq -r '.items[0].cost' "$sess")"
+has 'running total includes the failed spend' 'running \$5\.00 / \$100\.00'
+session_id=$(basename "$sess" .json)
+: > "$CLAUDE_LOG"
+run --resume "$session_id"
+eq 'failed-with-cost item retried on resume' 1 "$(calls_claude)"
+
+# restore the real claude shim
+cat > "$S/bin/claude" <<GH
+#!/bin/sh
+cat > /dev/null
+n=\$(cat "$S/claude-next" 2>/dev/null || echo 1)
+echo "\$n \$*" >> "$CLAUDE_LOG"
+echo \$((n + 1)) > "$S/claude-next"
+reply="$S/claude-replies/\$n.json"
+if [ -f "\$reply" ]; then cat "\$reply"; else echo '{"total_cost_usd":0.10,"usage":{"input_tokens":100,"output_tokens":50},"result":"GRIND_STATUS: done"}'; fi
+GH
+chmod +x "$S/bin/claude"
+
+# --- --repo naming a repo the cwd is not a checkout of ---------------------------
+run --repo o/other
+eq 'exit 1 when cwd is not a checkout of --repo' 1 "$RC"
+has 'says which repo it found' 'not a checkout of o/other \(found: o/alpha\)'
 
 # --- empty queue -----------------------------------------------------------------
 cat > "$S/ready.json" <<'JSON'

--- a/.local/bin/grind.test.sh
+++ b/.local/bin/grind.test.sh
@@ -80,7 +80,6 @@ latest_session() { ls -t "$S/state/grind"/*.json 2>/dev/null | head -1; }
 run --dry-run
 eq 'exit 0' 0 "$RC"
 eq 'no claude call in dry-run' 0 "$(calls_claude)"
-first_line=$(printf '%s\n' "$OUT" | grep -m1 '^\[')
 has 'first item is the lower-numbered one' '^\[1/2\] o/alpha#5 -- First item$'
 has 'second item follows' '^\[2/2\] o/alpha#20 -- Second item$'
 lacks 'blocked item excluded' 'alpha#9'
@@ -94,8 +93,8 @@ has 'overrides reach the command line' -- '--max-budget-usd 2 --model opus --eff
 
 # --- a real run: cost/tokens parsed, running total and percent printed ----------
 rm -f "$S/claude-replies"/*.json
-reply 1.00 done 1
-reply 2.00 done 2
+reply 1.00 "done" 1
+reply 2.00 "done" 2
 : > "$CLAUDE_LOG"
 run --session-budget 20 --pause-every 5
 eq 'exit 0' 0 "$RC"
@@ -112,8 +111,8 @@ eq 'two items recorded in state' 2 "$(jq '.items | length' "$sess")"
 # rule rather than every threshold firing on every item.
 rm -f "$S/state/grind"/*.json
 rm -f "$S/claude-replies"/*.json
-reply 5.00 done 1    # 25% of 20
-reply 15.00 done 2   # +75% = 100% -> budget reached, 75% line (not 50%) fires
+reply 5.00 "done" 1    # 25% of 20
+reply 15.00 "done" 2   # +75% = 100% -> budget reached, 75% line (not 50%) fires
 : > "$CLAUDE_LOG"
 run --session-budget 20 --pause-every 10
 has '25% line on the first item' '\*\*\* 25% of session budget spent \(\$5\.00 / \$20\.00\) \*\*\*'
@@ -122,9 +121,7 @@ lacks '50% line skipped -- one line per item, loudest threshold reached' '50% of
 eq 'no line printed twice' 1 "$(printf '%s\n' "$OUT" | grep -c '25% of session budget')"
 has 'pauses when the session budget is reached' '^pause: session budget reached \(\$20\.00 / \$20\.00\)\.'
 sess=$(latest_session)
-resume_line=$(printf '%s\n' "$OUT" | grep '^resume: ')
 has 'exact resume command printed' '^resume: grind --resume grind-'
-resume_cmd=${resume_line#resume: }
 
 # --- --resume skips already-processed items and keeps the same session file -----
 session_id=$(basename "$sess" .json)
@@ -138,8 +135,8 @@ eq 'state file unchanged (still 2 items)' 2 "$(jq '.items | length' "$sess")"
 # --- outlier pause: one item costs more than twice the running median -----------
 rm -f "$S/state/grind"/*.json
 rm -f "$S/claude-replies"/*.json
-reply 1.00 done 1
-reply 3.00 done 2
+reply 1.00 "done" 1
+reply 3.00 "done" 2
 : > "$CLAUDE_LOG"
 run --session-budget 100 --pause-every 10
 has 'pauses on the outlier, not the budget' '^pause: o/alpha#20 cost \$3\.00, more than twice the running median \(\$1\.00\)'
@@ -148,8 +145,8 @@ eq 'only the second item ran before the pause' 2 "$(calls_claude)"
 # equal-to-twice-median is not an outlier -- confirms a strict >, not >=.
 rm -f "$S/state/grind"/*.json
 rm -f "$S/claude-replies"/*.json
-reply 1.00 done 1
-reply 2.00 done 2
+reply 1.00 "done" 1
+reply 2.00 "done" 2
 : > "$CLAUDE_LOG"
 run --session-budget 100 --pause-every 10
 lacks 'exactly 2x median does not trip the outlier pause' '^pause: o/alpha#20 cost'
@@ -158,8 +155,8 @@ has 'runs to completion instead' '^done: Ready queue exhausted'
 # --- carded: logged, not a failure, item still counted toward pause-every -------
 rm -f "$S/state/grind"/*.json
 rm -f "$S/claude-replies"/*.json
-reply 0.50 carded 1
-reply 0.50 done 2
+reply 0.50 "carded" 1
+reply 0.50 "done" 2
 : > "$CLAUDE_LOG"
 run --session-budget 100 --pause-every 2
 has 'carded item logged distinctly' '^carded: o/alpha#5 -- First item'
@@ -170,8 +167,8 @@ has 'pauses on cadence after two items (one carded)' '^pause: 2 items processed 
 # --- pause-every cadence, exact count ---------------------------------------------
 rm -f "$S/state/grind"/*.json
 rm -f "$S/claude-replies"/*.json
-reply 0.10 done 1
-reply 0.10 done 2
+reply 0.10 "done" 1
+reply 0.10 "done" 2
 : > "$CLAUDE_LOG"
 run --session-budget 100 --pause-every 1
 eq 'stops after exactly one item' 1 "$(calls_claude)"

--- a/.local/bin/grind.test.sh
+++ b/.local/bin/grind.test.sh
@@ -174,6 +174,106 @@ run --session-budget 100 --pause-every 1
 eq 'stops after exactly one item' 1 "$(calls_claude)"
 has 'pause names the cadence' 'pause every 1'
 
+# --- done-ref matching is whole-entry, not substring (issue #5 vs #50) ----------
+cat > "$S/ready.json" <<'JSON'
+[
+  {"number": 5, "title": "Item five", "body": "b", "url": "https://github.com/o/alpha/issues/5", "labels": [{"name": "ready"}]},
+  {"number": 50, "title": "Item fifty", "body": "b", "url": "https://github.com/o/alpha/issues/50", "labels": [{"name": "ready"}]}
+]
+JSON
+rm -f "$S/state/grind"/*.json
+rm -f "$S/claude-replies"/*.json
+reply 0.10 "done" 1
+: > "$CLAUDE_LOG"
+run --session-budget 100 --pause-every 1
+sess=$(latest_session)
+session_id=$(basename "$sess" .json)
+: > "$CLAUDE_LOG"
+rm -f "$S/claude-replies"/*.json
+reply 0.10 "done" 1
+run --resume "$session_id"
+eq 'item 50 is not skipped as a substring match of done #5' 1 "$(calls_claude)"
+has 'item 50 actually ran' '^o/alpha#50: Item fifty'
+
+# --- --resume seeds running_total/costs from prior-run item costs ----------------
+cat > "$S/ready.json" <<'JSON'
+[
+  {"number": 1, "title": "A", "body": "b", "url": "https://github.com/o/alpha/issues/1", "labels": [{"name": "ready"}]},
+  {"number": 2, "title": "B", "body": "b", "url": "https://github.com/o/alpha/issues/2", "labels": [{"name": "ready"}]}
+]
+JSON
+rm -f "$S/state/grind"/*.json
+rm -f "$S/claude-replies"/*.json
+reply 15.00 "done" 1
+: > "$CLAUDE_LOG"
+run --session-budget 20 --pause-every 1
+has 'first run spends $15 of a $20 session budget' 'running \$15\.00 / \$20\.00'
+sess=$(latest_session)
+session_id=$(basename "$sess" .json)
+rm -f "$S/claude-replies"/*.json
+reply 15.00 "done" 1
+: > "$CLAUDE_LOG"
+run --resume "$session_id"
+eq 'resume runs the one remaining item' 1 "$(calls_claude)"
+has 'running total continues from the seeded $15, not from $0' 'running \$30\.00 / \$20\.00'
+has 'pauses on budget once the seeded total plus this item crosses it' '^pause: session budget reached \(\$30\.00 / \$20\.00\)\.'
+
+# a session already at/over budget on resume pauses before spending anything
+rm -f "$S/state/grind"/*.json
+rm -f "$S/claude-replies"/*.json
+reply 25.00 "done" 1
+: > "$CLAUDE_LOG"
+run --session-budget 20 --pause-every 1
+sess=$(latest_session)
+session_id=$(basename "$sess" .json)
+rm -f "$S/claude-replies"/*.json
+: > "$CLAUDE_LOG"
+run --resume "$session_id"
+eq 'no further spend once already over budget from a prior run' 0 "$(calls_claude)"
+has 'pauses immediately using the seeded total' '^pause: session budget reached \(\$25\.00 / \$20\.00\)\.'
+
+# --- a failed claude invocation is not recorded as done; --resume retries it ------
+cat > "$S/ready.json" <<'JSON'
+[
+  {"number": 7, "title": "Flaky item", "body": "b", "url": "https://github.com/o/alpha/issues/7", "labels": [{"name": "ready"}]}
+]
+JSON
+rm -f "$S/state/grind"/*.json
+rm -f "$S/claude-replies"/*.json
+cat > "$S/bin/claude" <<GH
+#!/bin/sh
+cat > /dev/null
+n=\$(cat "$S/claude-next" 2>/dev/null || echo 1)
+echo "\$n \$*" >> "$CLAUDE_LOG"
+echo \$((n + 1)) > "$S/claude-next"
+exit 1
+GH
+chmod +x "$S/bin/claude"
+: > "$CLAUDE_LOG"
+run --session-budget 100 --pause-every 10
+has 'a failed invocation is logged as a failure, not a normal cost line' '^FAILED: o/alpha#7'
+lacks 'no cost line for the failed item' '^o/alpha#7: Flaky item --'
+sess=$(latest_session)
+eq 'failed item is not recorded in state' 0 "$(jq '.items | length' "$sess")"
+
+# restore the real claude shim and confirm --resume retries the failed item
+cat > "$S/bin/claude" <<GH
+#!/bin/sh
+cat > /dev/null
+n=\$(cat "$S/claude-next" 2>/dev/null || echo 1)
+echo "\$n \$*" >> "$CLAUDE_LOG"
+echo \$((n + 1)) > "$S/claude-next"
+reply="$S/claude-replies/\$n.json"
+if [ -f "\$reply" ]; then cat "\$reply"; else echo '{"total_cost_usd":0.10,"usage":{"input_tokens":100,"output_tokens":50},"result":"GRIND_STATUS: done"}'; fi
+GH
+chmod +x "$S/bin/claude"
+session_id=$(basename "$sess" .json)
+: > "$CLAUDE_LOG"
+run --resume "$session_id"
+eq 'the failed item retried on resume' 1 "$(calls_claude)"
+has 'retried item now succeeds' '^o/alpha#7: Flaky item --'
+eq 'now recorded in state' 1 "$(jq '.items | length' "$sess")"
+
 # --- empty queue -----------------------------------------------------------------
 cat > "$S/ready.json" <<'JSON'
 []

--- a/.local/bin/grind.test.sh
+++ b/.local/bin/grind.test.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# Tests for grind. Run: bash .local/bin/grind.test.sh
+#
+# What matters: --dry-run lists every Ready (non-blocked) item and the exact
+# command per item without spending anything; a real run parses cost/tokens
+# out of the worker's JSON, prints the running-total/percent line, and pauses
+# -- with the exact resume command -- on session budget, an outlier item cost,
+# or the pause-every cadence; a carded worker is logged and not treated as a
+# failure; --resume skips what a prior run already accounted for. gh and
+# claude are both faked; no real `claude -p` is ever invoked.
+set -uo pipefail
+
+GRIND="$(cd "$(dirname "$0")" && pwd)/grind"
+pass=0; fail=0
+S=$(mktemp -d); export S
+cleanup() { rm -rf "$S"; }
+trap cleanup EXIT
+
+mkdir -p "$S/bin" "$S/home" "$S/state" "$S/repo" "$S/nogit"
+export HOME="$S/home" XDG_STATE_HOME="$S/state" TMPDIR="$S/tmp"
+mkdir -p "$TMPDIR"
+export GH_LOG="$S/gh.log" CLAUDE_LOG="$S/claude.log"
+: > "$GH_LOG"; : > "$CLAUDE_LOG"
+export PATH="$S/bin:$PATH"
+
+git -C "$S/repo" init -q
+git -C "$S/repo" config user.email t@example.invalid
+git -C "$S/repo" config user.name t
+git -C "$S/repo" remote add origin https://github.com/o/alpha.git
+git -C "$S/repo" commit -q --allow-empty -m init
+cd "$S/repo" || exit 1
+
+# --- canned Ready queue --------------------------------------------------------
+cat > "$S/ready.json" <<'JSON'
+[
+  {"number": 20, "title": "Second item", "body": "do the second thing", "url": "https://github.com/o/alpha/issues/20", "labels": [{"name": "ready"}]},
+  {"number": 5, "title": "First item", "body": "do the first thing", "url": "https://github.com/o/alpha/issues/5", "labels": [{"name": "ready"}]},
+  {"number": 9, "title": "Blocked item", "body": "not yet", "url": "https://github.com/o/alpha/issues/9", "labels": [{"name": "ready"}, {"name": "blocked"}]}
+]
+JSON
+
+cat > "$S/bin/gh" <<GH
+#!/bin/sh
+echo "\$*" >> "$GH_LOG"
+case "\$1 \$2" in
+  "issue list") cat "$S/ready.json" ;;
+  *) echo "gh shim: unexpected \$*" >&2; exit 1 ;;
+esac
+GH
+chmod +x "$S/bin/gh"
+
+# fake claude -- reads the prompt from stdin (unused), writes a canned JSON
+# result read from $CLAUDE_MODE for the current item (matched by title in the
+# piped prompt) via $S/claude-replies/<n>.json, defaulting to a $1 flat reply.
+mkdir -p "$S/claude-replies"
+cat > "$S/bin/claude" <<GH
+#!/bin/sh
+cat > /dev/null
+n=\$(cat "$S/claude-next" 2>/dev/null || echo 1)
+echo "\$n \$*" >> "$CLAUDE_LOG"
+echo \$((n + 1)) > "$S/claude-next"
+reply="$S/claude-replies/\$n.json"
+if [ -f "\$reply" ]; then cat "\$reply"; else echo '{"total_cost_usd":0.10,"usage":{"input_tokens":100,"output_tokens":50},"result":"GRIND_STATUS: done"}'; fi
+GH
+chmod +x "$S/bin/claude"
+reply() { jq -nc --argjson cost "$1" --arg status "$2" '{total_cost_usd:$cost, usage:{input_tokens:100,output_tokens:50}, result:("done work\nGRIND_STATUS: " + $status)}' > "$S/claude-replies/$3.json"; }
+
+ok()   { pass=$((pass + 1)); }
+bad()  { fail=$((fail + 1)); printf 'FAIL: %s\n' "$1"; [ -n "${2:-}" ] && printf '%s\n' "$2" | sed 's/^/    /'; }
+has()  { if printf '%s\n' "$OUT" | grep -Eq -- "$2"; then ok; else bad "$1 (missing /$2/)" "$OUT"; fi; }
+lacks(){ if printf '%s\n' "$OUT" | grep -Eq -- "$2"; then bad "$1 (has /$2/)" "$OUT"; else ok; fi; }
+eq()   { if [ "$2" = "$3" ]; then ok; else bad "$1: want [$2] got [$3]"; fi; }
+assert() { local d=$1; shift; if "$@"; then ok; else bad "$d"; fi; }
+run() { rm -f "$S/claude-next"; OUT=$(sh "$GRIND" "$@" 2>&1); RC=$?; }
+calls_claude() { wc -l < "$CLAUDE_LOG" | tr -d ' '; }
+latest_session() { ls -t "$S/state/grind"/*.json 2>/dev/null | head -1; }
+
+# --- --dry-run: lists Ready items, top (lowest number) first, blocked excluded ---
+: > "$GH_LOG"
+run --dry-run
+eq 'exit 0' 0 "$RC"
+eq 'no claude call in dry-run' 0 "$(calls_claude)"
+first_line=$(printf '%s\n' "$OUT" | grep -m1 '^\[')
+has 'first item is the lower-numbered one' '^\[1/2\] o/alpha#5 -- First item$'
+has 'second item follows' '^\[2/2\] o/alpha#20 -- Second item$'
+lacks 'blocked item excluded' 'alpha#9'
+has 'a worktree command is shown' 'git worktree add -b grind-5'
+has 'the claude command is shown, with defaults' 'claude -p <issue o/alpha#5 body> --output-format json --max-budget-usd 5 --model sonnet --effort medium'
+assert 'dry-run wrote no state file' bash -c '! ls '"$S"'/state/grind/*.json >/dev/null 2>&1'
+
+# --- --dry-run respects override flags -----------------------------------------
+run --dry-run --model opus --effort high --item-budget 2
+has 'overrides reach the command line' -- '--max-budget-usd 2 --model opus --effort high'
+
+# --- a real run: cost/tokens parsed, running total and percent printed ----------
+rm -f "$S/claude-replies"/*.json
+reply 1.00 done 1
+reply 2.00 done 2
+: > "$CLAUDE_LOG"
+run --session-budget 20 --pause-every 5
+eq 'exit 0' 0 "$RC"
+eq 'two claude invocations' 2 "$(calls_claude)"
+has 'first item line: cost, tokens, running total, percent' '^o/alpha#5: First item -- sonnet, \$1\.00, 150 tokens -- running \$1\.00 / \$20\.00 -- 5%$'
+has 'second item line: running total accumulates' '^o/alpha#20: Second item -- sonnet, \$2\.00, 150 tokens -- running \$3\.00 / \$20\.00 -- 15%$'
+has 'queue exhausted, final tally' '^done: Ready queue exhausted\. Running total \$3\.00 / \$20\.00\.$'
+sess=$(latest_session)
+eq 'two items recorded in state' 2 "$(jq '.items | length' "$sess")"
+
+# --- threshold lines: crossed once fires the loudest one reached that turn ------
+# Only two Ready items exist, so item 1 crosses 25%, item 2 jumps straight to
+# 100% (and the budget-reached pause) -- confirms the loudest-crossed-this-turn
+# rule rather than every threshold firing on every item.
+rm -f "$S/state/grind"/*.json
+rm -f "$S/claude-replies"/*.json
+reply 5.00 done 1    # 25% of 20
+reply 15.00 done 2   # +75% = 100% -> budget reached, 75% line (not 50%) fires
+: > "$CLAUDE_LOG"
+run --session-budget 20 --pause-every 10
+has '25% line on the first item' '\*\*\* 25% of session budget spent \(\$5\.00 / \$20\.00\) \*\*\*'
+has '75% line (loudest crossed) on the second, not 50%' '\*\*\* 75% of session budget spent \(\$20\.00 / \$20\.00\) \*\*\*'
+lacks '50% line skipped -- one line per item, loudest threshold reached' '50% of session budget'
+eq 'no line printed twice' 1 "$(printf '%s\n' "$OUT" | grep -c '25% of session budget')"
+has 'pauses when the session budget is reached' '^pause: session budget reached \(\$20\.00 / \$20\.00\)\.'
+sess=$(latest_session)
+resume_line=$(printf '%s\n' "$OUT" | grep '^resume: ')
+has 'exact resume command printed' '^resume: grind --resume grind-'
+resume_cmd=${resume_line#resume: }
+
+# --- --resume skips already-processed items and keeps the same session file -----
+session_id=$(basename "$sess" .json)
+: > "$CLAUDE_LOG"
+run --resume "$session_id"
+eq 'exit 0' 0 "$RC"
+eq 'no more items to run -- queue already exhausted' 0 "$(calls_claude)"
+has 'says the queue is done' 'Ready queue exhausted'
+eq 'state file unchanged (still 2 items)' 2 "$(jq '.items | length' "$sess")"
+
+# --- outlier pause: one item costs more than twice the running median -----------
+rm -f "$S/state/grind"/*.json
+rm -f "$S/claude-replies"/*.json
+reply 1.00 done 1
+reply 3.00 done 2
+: > "$CLAUDE_LOG"
+run --session-budget 100 --pause-every 10
+has 'pauses on the outlier, not the budget' '^pause: o/alpha#20 cost \$3\.00, more than twice the running median \(\$1\.00\)'
+eq 'only the second item ran before the pause' 2 "$(calls_claude)"
+
+# equal-to-twice-median is not an outlier -- confirms a strict >, not >=.
+rm -f "$S/state/grind"/*.json
+rm -f "$S/claude-replies"/*.json
+reply 1.00 done 1
+reply 2.00 done 2
+: > "$CLAUDE_LOG"
+run --session-budget 100 --pause-every 10
+lacks 'exactly 2x median does not trip the outlier pause' '^pause: o/alpha#20 cost'
+has 'runs to completion instead' '^done: Ready queue exhausted'
+
+# --- carded: logged, not a failure, item still counted toward pause-every -------
+rm -f "$S/state/grind"/*.json
+rm -f "$S/claude-replies"/*.json
+reply 0.50 carded 1
+reply 0.50 done 2
+: > "$CLAUDE_LOG"
+run --session-budget 100 --pause-every 2
+has 'carded item logged distinctly' '^carded: o/alpha#5 -- First item'
+sess=$(latest_session)
+eq 'carded status recorded' 'carded' "$(jq -r '.items[0].status' "$sess")"
+has 'pauses on cadence after two items (one carded)' '^pause: 2 items processed this run'
+
+# --- pause-every cadence, exact count ---------------------------------------------
+rm -f "$S/state/grind"/*.json
+rm -f "$S/claude-replies"/*.json
+reply 0.10 done 1
+reply 0.10 done 2
+: > "$CLAUDE_LOG"
+run --session-budget 100 --pause-every 1
+eq 'stops after exactly one item' 1 "$(calls_claude)"
+has 'pause names the cadence' 'pause every 1'
+
+# --- empty queue -----------------------------------------------------------------
+cat > "$S/ready.json" <<'JSON'
+[]
+JSON
+run
+eq 'exit 0 on an empty queue' 0 "$RC"
+has 'says nothing is ready' '^grind: no Ready items on o/alpha$'
+
+# --- not in a repo, no --repo given -----------------------------------------------
+cd "$S/nogit" || exit 1
+run
+eq 'exit 1 outside a repo without --repo' 1 "$RC"
+has 'says so' 'not in a GitHub repo'
+cd "$S/repo" || exit 1
+
+printf '%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Closes #113.

## What

`.local/bin/grind`, POSIX sh like `worklist`. Per Ready item (lowest issue
number first, `blocked`-labeled items excluded):

1. A fresh worktree on a new branch (`grind-<number>`).
2. One `claude -p --output-format json --max-budget-usd <item cap> --model
   <m> --effort <e>` with the issue body, plus a short appended contract, as
   the prompt piped over stdin. That session does the work and opens the PR;
   merging stays the human's.
3. Parses the JSON result for cost and tokens, prints one line per item:
   item, model, cost, tokens, running total, percent of session budget.
   Crossing 25/50/75% prints a louder line (once each per session).
4. A worker that decides an item needs a ruling files the card itself and
   ends its final message with `GRIND_STATUS: carded` instead of guessing;
   grind matches that, logs "carded", and moves on without treating it as a
   failure.
5. Pauses -- tally plus the exact resume command, exit 0 -- on: session
   budget reached, one item costing more than twice the running median, or
   every N items. Nothing waits on a terminal.

Defaults, overridable by flag: Sonnet, medium effort, $5/item, $20/session,
pause every 3. `--dry-run` prints the plan and spends nothing.

Resume bookkeeping (which items are done/carded, and the session's options)
lives in a small JSON file under `$XDG_STATE_HOME/grind/<session>.json` --
never committed, same shape as `worklist`'s cache.

`sequence`'s description gets the one line the issue specifies: "Not for
doing the work; that is grind."

## Tests

`.local/bin/grind.test.sh`, house pattern from `worklist.test.sh`: `gh` and
`claude` are both faked, so no real `claude -p` is ever invoked and nothing
here spends money. Covers dry-run listing/command construction, cost/token
parsing, the running-total/percent math and threshold lines, all three
pause conditions (budget, outlier, cadence), carded handling, and
`--resume` skipping already-processed items. 38 assertions, passing under
both mawk and gawk.

## Verification

`grind --dry-run --repo mark-brannan/dotfiles` was run for real against
this repo's live Ready queue -- it listed all 8 current Ready items, top
(lowest number) first, with the worktree and `claude -p` command for each,
and made no `claude` call. A real `claude -p` run against a live Ready item
was not run in this automated session -- that would spend real money
without the repo owner's sign-off on which item and budget. The dry-run
above is the approximation; a real one-item run is worth doing by hand once
this merges.
