### PR TITLE
Nags: edge-triggered counters, a sitting clock that resets, and three metrics-live wirings

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -87,10 +87,18 @@ count, or a decision.
 My capacity to decide is the scarce resource. Track the decisions you push
 to me; count what was logged, not what you remember. Validity is irrelevant.
 
-**You may question my capacity to decide, not only my decisions.** The
-friction counter says when: a hook hands you the count, once. Name the
+**You may question my capacity to decide, not only my decisions.** Raise it
+when signals converge, never on a schedule — I stop auditing you after
+correcting you all session; I reverse settled decisions; I drift without
+closing; replies go clipped and typo-dense *while circling* (clipped and
+productive is flow). The friction counter is a fifth signal, not a
+replacement for those four: a hook hands you the count, once. Name the
 signal, don't diagnose the feeling. Offer a stopping point, not a verdict.
 If I say I'm fine, drop it.
+
+**The sitting clock outranks friction.** Two hours at the screen is a reason
+to stop even in a session with no friction at all, and no amount of the work
+going well is an argument against it.
 
 ## Execution
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -87,12 +87,10 @@ count, or a decision.
 My capacity to decide is the scarce resource. Track the decisions you push
 to me; count what was logged, not what you remember. Validity is irrelevant.
 
-**You may question my capacity to decide, not only my decisions.** Raise it
-when signals converge, never on a schedule: I stop auditing you after
-correcting you all session; I reverse settled decisions or drift without
-closing; replies go clipped and typo-dense *while circling* (clipped and
-productive is flow). Name the signal, don't diagnose the feeling. Offer a
-stopping point, not a verdict. If I say I'm fine, drop it.
+**You may question my capacity to decide, not only my decisions.** The
+friction counter says when: a hook hands you the count, once. Name the
+signal, don't diagnose the feeling. Offer a stopping point, not a verdict.
+If I say I'm fine, drop it.
 
 ## Execution
 

--- a/.claude/hooks/lib-metrics-fmt.jq
+++ b/.claude/hooks/lib-metrics-fmt.jq
@@ -143,21 +143,14 @@ def night_nag:
     else ""
     end;
 
-# Escalates rather than just firing once at a threshold: a flat "take a
-# break" easy to skim past every render for the next three hours. Minutes
-# derived from time_since_break_seconds -- spans across sessions, accumulates
-# until gap >= 25 min auto-resets it. The point is time spent at the screen
-# across continuous work, not resetting on every new session.
-def break_nag:
-  (.time_since_break_seconds // .elapsed_seconds // 0) as $s
-  | ($s / 60 | floor) as $m
-  | if   $s <  5400 then ""
-    elif $s < 10800 then " ⏰ break!(\($m)m)"
-    elif $s < 16200 then " ⏰⏰ BREAK!(\($m)m)"
-    else                 " ⏰⏰⏰ STOP!(\($m)m)"
-    end;
+# The sitting clock is not here. It used to be -- `break_nag`, escalating off
+# a `time_since_break_seconds` field that metrics-live.sh stamped on every
+# event including every statusline render, so the readout wound its own
+# timer by being drawn. The clock that replaced it is prompt-driven and lives
+# in metrics-live.sh's crossing engine, where it fires once per threshold
+# instead of on every render.
 
-def nag: night_nag + break_nag;
+def nag: night_nag;
 
 # --- layouts --------------------------------------------------------------
 # The two readouts are one vocabulary in two shapes, so both shapes live here

--- a/.claude/hooks/metrics-live.sh
+++ b/.claude/hooks/metrics-live.sh
@@ -3,12 +3,17 @@
 # read them without paying for the computation itself.
 #
 # Why a cache file at all: `session-metrics.jq` slurps the whole transcript,
-# which is fine once at Stop but not on every statusline render (those fire
-# several times a second), and not on every tool call either now that a
-# PostToolUse pulse fires on all of them. The expensive part runs only when
-# a block is actually about to print -- a prompt, a question put to the user, a
-# pulse tick, a coalesced git action, Stop -- and the statusline just prints
-# what is already on disk.
+# which is fine a few times a turn but not on every statusline render (those
+# fire several times a second). The statusline just prints what is already on
+# disk, and recomputes only past its own staleness age.
+#
+# Three wirings, and only three: UserPromptSubmit (silent readout, may carry a
+# crossing line), Stop and SubagentStop. It used to be wired to nine events,
+# eight of them with `show`, which meant a jq pass over the transcript after
+# every single tool call and a readout that spoke often enough to be tuned
+# out. That is a level-triggered nag. What replaced it is the crossing engine
+# below: a line fires once, when a threshold is first crossed, and then says
+# nothing until the next line.
 #
 # One file per session, keyed by session_id: parallel sessions are normal
 # here, and per-session paths mean two of them never write the same file.
@@ -30,32 +35,50 @@ EVENT_ARG="${1:-}"          # explicit override; only statusline and tests pass 
 MAX_AGE="${2:-0}"           # seconds; >0 means "skip if cache is fresher"
 SHOW="${3:-}"               # "show" -> also print a systemMessage block
 
+# ---------------------------------------------------- counters and their lines
+# Every threshold in this file is here, and every one is overridable. A line
+# fires once, when the counter first crosses it this session, and then says
+# nothing until the next line up -- edge-triggered, not level-triggered.
+#
+#   context   size and a verdict; "propose stopping" from CONTEXT_STOP_AT up
+#   sitting   elapsed, context, verdict -- and the clock starts over when the
+#             gap between two prompts runs past SIT_GAP_MIN, because a session
+#             picked up after dinner is a new sitting, not a nine-hour one
+#   friction  corrections and rebukes inside a window of human turns; the one
+#             line that goes to the model rather than to the screen, since the
+#             standing orders' capacity rule is what it is asking for
+#   gate      gate decisions pushed to the user, every GATE_EVERY
+NAG_CONTEXT_LINES="${METRICS_CONTEXT_LINES:-100000 150000 200000}"
+NAG_CONTEXT_STOP_AT="${METRICS_CONTEXT_STOP_AT:-150000}"
+NAG_SIT_EVERY_MIN="${METRICS_SIT_EVERY_MIN:-60}"
+NAG_SIT_GAP_MIN="${METRICS_SIT_GAP_MIN:-30}"
+NAG_FRICTION_N="${METRICS_FRICTION_N:-3}"
+NAG_FRICTION_TURNS="${METRICS_FRICTION_TURNS:-20}"
+NAG_GATE_EVERY="${METRICS_GATE_EVERY:-5}"
+# Local hour from which a Stop on an archivable session is worth interrupting.
+NAG_STOP_HOUR="${METRICS_STOP_HOUR:-22}"
+
 # One jq for all three fields: the statusline reaches this code on every
 # render, and three spawns before the staleness check was most of its cost.
 input=$(cat 2>/dev/null || echo '{}')
-IFS=$'\t' read -r tp sid cwd tool_name tool_cmd hook_name <<<"$(printf '%s' "$input" | jq -r \
+IFS=$'\t' read -r tp sid cwd hook_name <<<"$(printf '%s' "$input" | jq -r \
   '[(.transcript_path // ""), (.session_id // ""),
     (.cwd // .workspace.current_dir // ""),
-    (.tool_name // ""), (.tool_input.command // ""),
     (.hook_event_name // "")] | @tsv')"
 [ -n "$tp" ] && [ -f "$tp" ] && [ -n "$sid" ] || exit 0
 [ -n "$cwd" ] || cwd=$PWD
 
 # Default EVENT to hook_event_name verbatim, lowercased, so a new hook
-# needs no matching entry here. question is the one specialized case.
+# needs no matching entry here.
 if [ -n "$EVENT_ARG" ]; then
   EVENT="$EVENT_ARG"
-elif [ "$hook_name" = PreToolUse ] && [ "$tool_name" = AskUserQuestion ]; then
-  EVENT="$tool_name"
 else
   EVENT=$(printf '%s' "${hook_name:-tool}" | tr '[:upper:]' '[:lower:]')
 fi
 
-# `show` on an event that Claude can read would make the block context, not
-# display -- true for UserPromptSubmit and SessionStart. Guarding SessionStart
-# is dropped for now: it's the one moment with no other visibility into
-# session state, worth the per-session token cost to see it. UserPromptSubmit
-# fires every turn, so it stays suppressed.
+# `show` on UserPromptSubmit would make the readout model context rather than
+# display, every turn. The crossing lines below still reach the screen there;
+# it is the whole block that stays suppressed.
 case "$EVENT" in prompt|userpromptsubmit|statusline) SHOW="" ;; esac
 
 # A git event means an actual git-state change, not every Bash call: the jq
@@ -76,99 +99,6 @@ JQPROG="$HOOK_DIR/session-metrics.jq"
 
 LIVE="$(state_dir)/metrics/live"
 OUT="$LIVE/$sid.json"
-
-# ------------------------------------------------------------- pulse/coalesce
-# EVENT=posttooluse fires on EVERY tool call (settings.json matches all
-# tools, no per-tool matcher). Two jobs, both driven by a small counter file
-# the statusline never touches -- it only ever reads/writes $OUT, so this
-# file is safe to use as a debounce the 15s statusline refresh can't stomp:
-#
-#   pulse    a block every PULSE_N tool calls, so a long non-git stretch
-#            (reading, editing, debugging) still gets a regular readout
-#            instead of showing nothing until the next git event or Stop.
-#            PULSE_N=8: roughly one read/edit/check cycle -- frequent enough
-#            that a 20-minute silent stretch still gets 2-3 pulses, coarse
-#            enough that a grep/read sweep doesn't spam a block per call.
-#   coalesce a git-matching call (commit/push/rebase/...) doesn't print
-#            immediately. It marks a "pending" flag and recomputes silently.
-#            The block only prints once a NON-git tool call arrives -- i.e.
-#            when the streak actually ends -- so `git add && git commit &&
-#            git push`, or a rebase's wall of checkouts, prints exactly one
-#            block reflecting the final state, not one per call.
-#
-#            Coalescing only kicks in after GIT_EARLY_N git events have
-#            already printed individually this session: the first few git
-#            actions are exactly the ones the user most wants to see land in
-#            real time, so they show immediately, uncoalesced. Streaks are
-#            only worth collapsing once git activity is established as
-#            routine for the session.
-PULSE_N="${METRICS_PULSE_N:-1}"
-GIT_EARLY_N="${METRICS_GIT_EARLY_N:-3}"
-if [ "$EVENT" = posttooluse ]; then
-  PULSE="$LIVE/$sid.pulse.json"
-  mkdir -p "$LIVE" 2>/dev/null || exit 0
-  is_git=0
-  printf '%s\n%s' "$tool_cmd" "$tool_name" \
-    | grep -qE "$(git_event_re)" \
-    && is_git=1
-
-  count=0; pending_git=0; git_seen=0
-  if [ -f "$PULSE" ]; then
-    IFS=$'\t' read -r count pending_git git_seen <<<"$(jq -r \
-      '[(.count // 0), (if .pending_git then 1 else 0 end), (.git_seen // 0)] | @tsv' "$PULSE" 2>/dev/null)"
-    [ -n "$count" ] || count=0
-    [ -n "$pending_git" ] || pending_git=0
-    [ -n "$git_seen" ] || git_seen=0
-  fi
-
-  do_print=0
-  DISPLAY_KIND=""
-  if [ "$is_git" -eq 1 ]; then
-    if [ "$git_seen" -lt "$GIT_EARLY_N" ]; then
-      # Still under the early-git quota: print this one immediately rather
-      # than folding it into a streak.
-      git_seen=$((git_seen + 1))
-      do_print=1
-      DISPLAY_KIND="git"
-      count=0
-      pending_git=0
-    else
-      # Quota spent: coalesce as before -- recompute so $OUT stays current,
-      # stay silent, the streak isn't over yet.
-      count=0
-      pending_git=1
-    fi
-  else
-    if [ "$pending_git" -eq 1 ]; then
-      # The streak just ended: flush the one block for it.
-      do_print=1
-      DISPLAY_KIND="git"
-      count=0
-      pending_git=0
-    else
-      count=$((count + 1))
-      if [ "$count" -ge "$PULSE_N" ]; then
-        do_print=1
-        DISPLAY_KIND="pulse"
-        count=0
-      fi
-    fi
-  fi
-
-  jq -n --argjson c "$count" --argjson p "$([ "$pending_git" -eq 1 ] && echo true || echo false)" \
-    --argjson g "$git_seen" \
-    '{count: $c, pending_git: $p, git_seen: $g}' > "$PULSE.$$" 2>/dev/null \
-    && mv -f "$PULSE.$$" "$PULSE" 2>/dev/null || rm -f "$PULSE.$$" 2>/dev/null
-
-  # A tool call mid-streak (git or not, below PULSE_N) needs nothing beyond
-  # the counter bookkeeping above -- no reason to pay for the full transcript
-  # slurp below on every single call. Only a print (streak-end flush, or a
-  # pulse tick) needs $OUT current, and it'll be recomputed fresh right here
-  # regardless of how stale it was, so skipping the recompute in between
-  # never shows stale numbers, only fewer silent writes.
-  [ "$do_print" -eq 1 ] || exit 0
-  EVENT="$DISPLAY_KIND"
-fi
 
 # Throttle: the statusline asks constantly, events ask rarely. An event
 # always recomputes; the statusline only does so if the cache has gone stale.
@@ -261,10 +191,210 @@ printf '%s\n' "$metrics" | jq -c \
                dirty: $d, unpushed: $u, commits: $c, time_since_break_seconds: $tsb}' > "$tmp" 2>/dev/null \
   && mv -f "$tmp" "$OUT" 2>/dev/null || rm -f "$tmp" 2>/dev/null
 
+# =========================================================== crossing engine
+# Edge-triggered. State lives in one small file per session next to the cache;
+# it is NOT the cache, because stop-continuity.sh deletes the cache at the end
+# of a session and the crossings have to outlive it.
+NAGF="$LIVE/$sid.nag.json"
+CROSSD="$(state_dir)/metrics/crossings"
+
+ctx_line=0; time_line=0; gate_line=0; fric_tripped=0
+sit_start=0; last_prompt=0; since_nag=0; resume_ts=0; nag_pending=0
+if [ -f "$NAGF" ]; then
+  IFS=$'\t' read -r ctx_line time_line gate_line fric_tripped \
+                    sit_start last_prompt since_nag resume_ts nag_pending \
+    <<<"$(jq -r '[(.context_line // 0), (.time_line // 0), (.gate_line // 0),
+                  (if .friction_tripped then 1 else 0 end),
+                  (.sitting_start // 0), (.last_prompt // 0),
+                  (if .since_nag then 1 else 0 end),
+                  (.resume_ts // 0),
+                  (if .nag_pending then 1 else 0 end)] | @tsv' "$NAGF" 2>/dev/null)"
+fi
+for v in ctx_line time_line gate_line fric_tripped sit_start last_prompt \
+         since_nag resume_ts nag_pending; do
+  [ -n "${!v}" ] || eval "$v=0"
+done
+
+save_nag() {
+  jq -n --argjson cl "$ctx_line" --argjson tl "$time_line" --argjson gl "$gate_line" \
+        --argjson ft "$fric_tripped" --argjson ss "$sit_start" --argjson lp "$last_prompt" \
+        --argjson sn "$since_nag" --argjson rt "$resume_ts" --argjson np "$nag_pending" \
+    '{context_line: $cl, time_line: $tl, gate_line: $gl,
+      friction_tripped: ($ft == 1), sitting_start: $ss, last_prompt: $lp,
+      since_nag: ($sn == 1), resume_ts: $rt, nag_pending: ($np == 1)}' \
+    > "$NAGF.$$" 2>/dev/null \
+    && mv -f "$NAGF.$$" "$NAGF" 2>/dev/null || rm -f "$NAGF.$$" 2>/dev/null
+}
+
+# Only the three wired events drive the engine. The statusline reaches this
+# file too, several times a minute, and must never consume a crossing.
+is_prompt=0; run_engine=0
+case "$EVENT" in
+  prompt|userpromptsubmit)   is_prompt=1; run_engine=1 ;;
+  stop|subagentstop)         run_engine=1 ;;
+esac
+
+kfmt() { awk -v n="$1" 'BEGIN { if (n >= 1000) printf "%dk", int(n / 1000); else printf "%d", n }'; }
+hm()   { awk -v m="$1" 'BEGIN { if (m >= 60) printf "%dh%02d", int(m / 60), m % 60; else printf "%dm", m }'; }
+hhmm() { date -d "@$1" +%H:%M 2>/dev/null || date -r "$1" +%H:%M 2>/dev/null || echo "??:??"; }
+
+sys_lines=""; model_line=""
+add_line() { sys_lines="${sys_lines:+$sys_lines
+}$1"; }
+record_crossing() {
+  mkdir -p "$CROSSD" 2>/dev/null || return 0
+  jq -nc --arg sid "$sid" --arg now "$now" --arg kind "$1" \
+         --argjson at "$2" --arg text "$3" \
+    '{session_id: $sid, ts: $now, kind: $kind, at: $at, text: $text}' \
+    >> "$CROSSD/$sid.jsonl" 2>/dev/null || true
+}
+
+if [ "$run_engine" -eq 1 ]; then
+  # The sitting clock. Only a prompt moves it: the gap that matters is the one
+  # between two things the user typed, not between two tool calls.
+  if [ "$is_prompt" -eq 1 ]; then
+    if [ "$last_prompt" -gt 0 ] \
+       && [ $((now_ts - last_prompt)) -gt $((NAG_SIT_GAP_MIN * 60)) ]; then
+      sit_start=$now_ts
+      time_line=0
+    fi
+    last_prompt=$now_ts
+  fi
+  [ "$sit_start" -gt 0 ] || sit_start=$now_ts
+
+  IFS=$'\t' read -r ctx gates fric_win <<<"$(printf '%s\n' "$metrics" | jq -r \
+    --argjson w "$NAG_FRICTION_TURNS" \
+    '(.session.user_turns // 0) as $t
+     | [ (.session.context_peak // 0),
+         (.session.decisions.gate // 0),
+         ([ .friction[]?
+            | select(.type == "correction" or .type == "rebuke")
+            | select((.turn_ordinal // 0) > ($t - $w)) ] | length) ] | @tsv')"
+  [ -n "${ctx:-}" ] || ctx=0
+  [ -n "${gates:-}" ] || gates=0
+  [ -n "${fric_win:-}" ] || fric_win=0
+
+  # context -- lines ascending, so a jump past two of them reports both, in order
+  for L in $NAG_CONTEXT_LINES; do
+    if [ "$ctx" -ge "$L" ] && [ "$L" -gt "$ctx_line" ]; then
+      if [ "$L" -ge "$NAG_CONTEXT_STOP_AT" ]; then verdict="propose stopping"
+      else verdict="still room"; fi
+      t="⛁ context $(kfmt "$ctx") — past $(kfmt "$L"): $verdict."
+      add_line "$t"; record_crossing context "$L" "$t"
+      ctx_line=$L; since_nag=1
+    fi
+  done
+
+  # sitting clock
+  if [ "$NAG_SIT_EVERY_MIN" -gt 0 ]; then
+    sit_min=$(( (now_ts - sit_start) / 60 ))
+    n=$(( sit_min / NAG_SIT_EVERY_MIN * NAG_SIT_EVERY_MIN ))
+    if [ "$n" -ge "$NAG_SIT_EVERY_MIN" ] && [ "$n" -gt "$time_line" ]; then
+      if [ "$n" -ge $((NAG_SIT_EVERY_MIN * 2)) ]; then verdict="stop here"
+      else verdict="stand up"; fi
+      t="⏱ sitting $(hm "$n") — context $(kfmt "$ctx"): $verdict."
+      add_line "$t"; record_crossing time "$n" "$t"
+      time_line=$n; since_nag=1
+    fi
+  fi
+
+  # gate decisions
+  if [ "$NAG_GATE_EVERY" -gt 0 ]; then
+    n=$(( gates / NAG_GATE_EVERY * NAG_GATE_EVERY ))
+    if [ "$n" -ge "$NAG_GATE_EVERY" ] && [ "$n" -gt "$gate_line" ]; then
+      t="⚖ $gates gate decisions this session — front-load or card the rest."
+      add_line "$t"; record_crossing gate "$n" "$t"
+      gate_line=$n
+    fi
+  fi
+
+  # friction -- measured in human turns, so only a prompt can trip it, and it
+  # is addressed to the model, which is the thing the capacity rule asks of.
+  if [ "$is_prompt" -eq 1 ] && [ "$fric_tripped" -ne 1 ] \
+     && [ "$fric_win" -ge "$NAG_FRICTION_N" ]; then
+    model_line="$fric_win corrections or rebukes in the last $NAG_FRICTION_TURNS turns. Apply the capacity rule from the standing orders, once."
+    record_crossing friction "$fric_win" "$model_line"
+    fric_tripped=1; since_nag=1
+  fi
+fi
+
+# ---------------------------------------------------------------- Stop nag
+# Fires on a real Stop only -- hook_event_name, not the event argument, so a
+# preview or a test harness asking for the `stop` readout never blocks a turn.
+#
+# "archivable" is the verdict that the chat can be closed without losing
+# anything: clean worktree, nothing unpushed, the state repo's own commits
+# pushed, and the branch either has an open PR or is named by a pointer card.
+_to() { if command -v timeout >/dev/null 2>&1; then timeout "$@"; else shift; "$@"; fi; }
+archivable() {
+  [ "${dirty:-0}" -eq 0 ] || return 1
+  [ "${unpushed:-0}" -eq 0 ] || return 1
+  local sr n c
+  sr=$(state_repo 2>/dev/null) || sr=""
+  if [ -n "$sr" ]; then
+    n=$(git -C "$sr" rev-list --count '@{u}..HEAD' 2>/dev/null || echo 0)
+    [ "${n:-0}" -eq 0 ] || return 1
+  fi
+  [ -n "$work_root" ] || return 1
+  case "$work_branch" in main|master|HEAD|"") return 0 ;; esac
+  if command -v gh >/dev/null 2>&1; then
+    c=$( (cd "$work_root" 2>/dev/null \
+          && _to 10 gh pr list --head "$work_branch" --state open --json number \
+               --jq 'length') 2>/dev/null )
+    [ "${c:-0}" -gt 0 ] 2>/dev/null && return 0
+  fi
+  [ -n "$sr" ] && grep -qF -- "$work_branch" "$sr/state/global/kanban.md" 2>/dev/null \
+    && return 0
+  return 1
+}
+
+if [ "$hook_name" = Stop ]; then
+  if [ "$nag_pending" -eq 1 ]; then
+    # The block above has been answered; the resume block exists now.
+    resume_ts=$now_ts; nag_pending=0; since_nag=0; save_nag
+    add_line "Archivable. Resume block written $(hhmm "$resume_ts"). Next time: \`/resume\`."
+  elif archivable; then
+    local_hour=$(date +%H); local_hour=${local_hour#0}
+    late=0
+    [ "${local_hour:-0}" -ge "$NAG_STOP_HOUR" ] && late=1
+    # since_nag is armed by a context or time crossing and by the friction
+    # counter tripping, and disarmed by the nag. The hour arms it only while
+    # no resume block exists yet -- otherwise every Stop after 22:00 would
+    # block again, which is the level-triggered nag this replaced.
+    if [ "$since_nag" -eq 1 ] \
+       || { [ "$late" -eq 1 ] && [ "$resume_ts" -eq 0 ]; }; then
+      nag_pending=1; save_nag
+      printf '{"decision":"block","reason":%s}\n' \
+        "$(json_str "Write the resume block.")"
+      exit 0
+    fi
+    # Nothing new to say. Later Stops carry the block's age and nothing else.
+    if [ "$resume_ts" -gt 0 ]; then
+      add_line "Resume block $(hm $(( (now_ts - resume_ts) / 60 ))) old."
+    fi
+  fi
+fi
+
+[ "$run_engine" -eq 1 ] && save_nag
+
+# The crossing lines reach the user on every wired event; the friction line is
+# the one that reaches the model, and only on UserPromptSubmit, where a hook
+# can add context at all.
+if [ -n "$sys_lines" ] || [ -n "$model_line" ]; then
+  if [ "$is_prompt" -eq 1 ]; then
+    jq -nc --arg s "$sys_lines" --arg a "$model_line" \
+      '(if $s == "" then {} else {systemMessage: $s} end)
+       + (if $a == "" then {}
+          else {hookSpecificOutput: {hookEventName: "UserPromptSubmit",
+                                     additionalContext: $a}} end)'
+    exit 0
+  fi
+fi
+
 # ------------------------------------------------------------ event block
-# Shown to the user at the moments that matter -- a question put to her, a git
-# event, a pulse tick, the end of the session -- and never sent to the
-# model, so the running decision count costs nothing to display.
+# Shown to the user at the end of a turn -- never sent to the model, so the
+# running decision count costs nothing to display. Any crossing line rides on
+# the front of it rather than arriving as a second message.
 if [ "$SHOW" = show ] && [ -f "$OUT" ]; then
   # night_nag needs Pacific time, not the host's TZ -- an ephemeral/cloud
   # session usually runs UTC, which read as "LATE!" all evening. Compute the
@@ -277,7 +407,11 @@ if [ "$SHOW" = show ] && [ -f "$OUT" ]; then
     print sign * (hh * 3600 + mm * 60)
   }')
   export TZOFF
-  jq -c -L "$HOOK_DIR" \
-    'include "lib-metrics-fmt"; {systemMessage: block}' "$OUT" 2>/dev/null
+  jq -c -L "$HOOK_DIR" --arg x "$sys_lines" \
+    'include "lib-metrics-fmt";
+     {systemMessage: (if $x == "" then block else $x + "\n" + block end)}' \
+    "$OUT" 2>/dev/null
+elif [ -n "$sys_lines" ]; then
+  jq -nc --arg s "$sys_lines" '{systemMessage: $s}'
 fi
 exit 0

--- a/.claude/hooks/metrics-live.sh
+++ b/.claude/hooks/metrics-live.sh
@@ -199,19 +199,20 @@ NAGF="$LIVE/$sid.nag.json"
 CROSSD="$(state_dir)/metrics/crossings"
 
 ctx_line=0; time_line=0; gate_line=0; fric_tripped=0
-sit_start=0; last_prompt=0; since_nag=0; resume_ts=0; nag_pending=0
+sit_start=0; last_prompt=0; since_nag=0; resume_ts=0; nag_pending=0; late_nagged=0
 if [ -f "$NAGF" ]; then
   IFS=$'\t' read -r ctx_line time_line gate_line fric_tripped \
-                    sit_start last_prompt since_nag resume_ts nag_pending \
+                    sit_start last_prompt since_nag resume_ts nag_pending late_nagged \
     <<<"$(jq -r '[(.context_line // 0), (.time_line // 0), (.gate_line // 0),
                   (if .friction_tripped then 1 else 0 end),
                   (.sitting_start // 0), (.last_prompt // 0),
                   (if .since_nag then 1 else 0 end),
                   (.resume_ts // 0),
-                  (if .nag_pending then 1 else 0 end)] | @tsv' "$NAGF" 2>/dev/null)"
+                  (if .nag_pending then 1 else 0 end),
+                  (if .late_nagged then 1 else 0 end)] | @tsv' "$NAGF" 2>/dev/null)"
 fi
 for v in ctx_line time_line gate_line fric_tripped sit_start last_prompt \
-         since_nag resume_ts nag_pending; do
+         since_nag resume_ts nag_pending late_nagged; do
   [ -n "${!v}" ] || eval "$v=0"
 done
 
@@ -219,9 +220,11 @@ save_nag() {
   jq -n --argjson cl "$ctx_line" --argjson tl "$time_line" --argjson gl "$gate_line" \
         --argjson ft "$fric_tripped" --argjson ss "$sit_start" --argjson lp "$last_prompt" \
         --argjson sn "$since_nag" --argjson rt "$resume_ts" --argjson np "$nag_pending" \
+        --argjson ln "$late_nagged" \
     '{context_line: $cl, time_line: $tl, gate_line: $gl,
       friction_tripped: ($ft == 1), sitting_start: $ss, last_prompt: $lp,
-      since_nag: ($sn == 1), resume_ts: $rt, nag_pending: ($np == 1)}' \
+      since_nag: ($sn == 1), resume_ts: $rt, nag_pending: ($np == 1),
+      late_nagged: ($ln == 1)}' \
     > "$NAGF.$$" 2>/dev/null \
     && mv -f "$NAGF.$$" "$NAGF" 2>/dev/null || rm -f "$NAGF.$$" 2>/dev/null
 }
@@ -348,24 +351,49 @@ archivable() {
   return 1
 }
 
+# The resume block is a `## Resume` heading in this session's checkpoint
+# (stop-continuity.sh names it <date>-<repo>-<sid8>.md; dotfiles#110 defines
+# the block). The hook never assumes the block was written because it asked
+# for it: it looks, and says what it found either way.
+resume_ckpt() {
+  grep -lE '^## Resume[[:space:]]*$' \
+    "$(state_dir)/log/auto/"*"-${sid:0:8}.md" 2>/dev/null | head -1
+}
+
 if [ "$hook_name" = Stop ]; then
   if [ "$nag_pending" -eq 1 ]; then
-    # The block above has been answered; the resume block exists now.
-    resume_ts=$now_ts; nag_pending=0; since_nag=0; save_nag
-    add_line "Archivable. Resume block written $(hhmm "$resume_ts"). Next time: \`/resume\`."
+    # The block above has been answered. Whether the resume block exists is a
+    # fact on disk, not an inference from having asked. Either way the nag is
+    # spent: a missing block is reported once, never re-blocked on, or this
+    # would be the level-triggered nag again.
+    nag_pending=0; since_nag=0
+    found=$(resume_ckpt)
+    if [ -n "$found" ]; then
+      resume_ts=$now_ts
+      add_line "Archivable. Resume block written $(hhmm "$resume_ts") in $(basename "$found"). Next time: \`/resume\`."
+    else
+      add_line "Archivable, but no \`## Resume\` block in $(state_dir)/log/auto/*-${sid:0:8}.md. Not asking again this session."
+    fi
+    save_nag
   elif archivable; then
     local_hour=$(date +%H); local_hour=${local_hour#0}
     late=0
     [ "${local_hour:-0}" -ge "$NAG_STOP_HOUR" ] && late=1
     # since_nag is armed by a context or time crossing and by the friction
-    # counter tripping, and disarmed by the nag. The hour arms it only while
-    # no resume block exists yet -- otherwise every Stop after 22:00 would
-    # block again, which is the level-triggered nag this replaced.
+    # counter tripping, and disarmed by the nag. The hour arms it once per
+    # session -- otherwise every Stop after 22:00 would block again, which is
+    # the level-triggered nag this replaced.
     if [ "$since_nag" -eq 1 ] \
-       || { [ "$late" -eq 1 ] && [ "$resume_ts" -eq 0 ]; }; then
+       || { [ "$late" -eq 1 ] && [ "$late_nagged" -eq 0 ]; }; then
+      [ "$late" -eq 1 ] && late_nagged=1
       nag_pending=1; save_nag
-      printf '{"decision":"block","reason":%s}\n' \
-        "$(json_str "Write the resume block.")"
+      # The crossing lines that armed this Stop have already been persisted
+      # as consumed, so this reason is their only chance to be seen. They go
+      # in front of the instruction rather than being dropped.
+      reason="Write the resume block: append a \`## Resume\` block (next, link, model, effort) to this session's checkpoint in $(state_dir)/log/auto/."
+      [ -z "$sys_lines" ] || reason="$sys_lines
+$reason"
+      printf '{"decision":"block","reason":%s}\n' "$(json_str "$reason")"
       exit 0
     fi
     # Nothing new to say. Later Stops carry the block's age and nothing else.

--- a/.claude/hooks/metrics-live.sh
+++ b/.claude/hooks/metrics-live.sh
@@ -41,9 +41,11 @@ SHOW="${3:-}"               # "show" -> also print a systemMessage block
 # nothing until the next line up -- edge-triggered, not level-triggered.
 #
 #   context   size and a verdict; "propose stopping" from CONTEXT_STOP_AT up
-#   sitting   elapsed, context, verdict -- and the clock starts over when the
-#             gap between two prompts runs past SIT_GAP_MIN, because a session
-#             picked up after dinner is a new sitting, not a nine-hour one
+#   sitting   elapsed, context, verdict -- driven entirely by prompts: it
+#             starts at the first one, restarts when the gap between two of
+#             them runs past SIT_GAP_MIN (a session picked up after dinner is
+#             a new sitting, not a nine-hour one), and is never read or moved
+#             by a Stop. 60 min says stand up, 120 says stop here and wrap up
 #   friction  corrections and rebukes inside a window of human turns; the one
 #             line that goes to the model rather than to the screen, since the
 #             standing orders' capacity rule is what it is asking for
@@ -138,57 +140,23 @@ fi
 
 mkdir -p "$LIVE" 2>/dev/null || exit 0
 
-# --------------------------------------------------------- break-time tracking
-# Store last-activity timestamp. If gap >= 25 min since last activity, auto-reset
-# break timer. Else accumulate time since last break across sessions.
-ACTIVITY_FILE="$(state_dir)/metrics/last_activity.json"
-mkdir -p "$(dirname "$ACTIVITY_FILE")" 2>/dev/null || true
+# Wall clock, read once. The sitting clock in the engine below is the only
+# thing that reads it, and only a prompt moves that clock.
+#
+# There used to be a second timer here, backed by metrics/last_activity.json:
+# every event stamped it, including every statusline render, so the readout
+# kept its own break timer alive simply by being drawn. A clock the display
+# winds is not measuring the user. It is gone, and with it break_nag in
+# lib-metrics-fmt.jq -- the sitting clock is the only sitting clock now.
 now_ts=$(date +%s)
-time_since_break_seconds=0
-
-if [ -f "$ACTIVITY_FILE" ]; then
-  last_activity_ts=$(jq -r '.last_activity_timestamp // 0' "$ACTIVITY_FILE" 2>/dev/null || echo 0)
-  last_break_ts=$(jq -r '.last_break_timestamp // 0' "$ACTIVITY_FILE" 2>/dev/null || echo 0)
-
-  # If we have a last activity time, check the gap
-  if [ "$last_activity_ts" -gt 0 ]; then
-    gap=$((now_ts - last_activity_ts))
-    # 25 minutes = 1500 seconds
-    if [ "$gap" -ge 1500 ]; then
-      # Gap is long enough to count as a break -- reset the timer
-      last_break_ts=$now_ts
-    fi
-  fi
-
-  # Calculate time since last break
-  if [ "$last_break_ts" -gt 0 ]; then
-    time_since_break_seconds=$((now_ts - last_break_ts))
-  fi
-fi
-
-# Update activity file with new timestamps. Both fields take the max of what
-# we computed and whatever is on disk now: parallel sessions on this machine
-# read and write this file independently, so between the read above and this
-# write another session may have recorded newer activity or a later break.
-# Taking the max makes concurrent writers idempotent instead of letting the
-# last one to finish drag the break timer backwards.
-cur_json=$(jq -c '{last_activity_timestamp, last_break_timestamp}' \
-  "$ACTIVITY_FILE" 2>/dev/null) || cur_json='{}'
-[ -n "$cur_json" ] || cur_json='{}'
-jq -n --argjson la "$now_ts" --argjson lb "${last_break_ts:-0}" \
-  --argjson c "$cur_json" \
-  '{last_activity_timestamp: ([$la, ($c.last_activity_timestamp // 0)] | max),
-    last_break_timestamp:    ([$lb, ($c.last_break_timestamp    // 0)] | max)}' \
-  > "$ACTIVITY_FILE.$$" 2>/dev/null \
-  && mv -f "$ACTIVITY_FILE.$$" "$ACTIVITY_FILE" 2>/dev/null || rm -f "$ACTIVITY_FILE.$$" 2>/dev/null
 
 tmp="$OUT.$$"
 printf '%s\n' "$metrics" | jq -c \
   --arg ev "$EVENT" --arg now "$now" \
   --argjson d "${dirty:-0}" --argjson u "${unpushed:-0}" --argjson c "${ncommits:-0}" \
-  --arg sha "$start_sha" --argjson tsb "$time_since_break_seconds" \
+  --arg sha "$start_sha" \
   '.session + {last_event: $ev, updated_at: $now, start_sha: $sha,
-               dirty: $d, unpushed: $u, commits: $c, time_since_break_seconds: $tsb}' > "$tmp" 2>/dev/null \
+               dirty: $d, unpushed: $u, commits: $c}' > "$tmp" 2>/dev/null \
   && mv -f "$tmp" "$OUT" 2>/dev/null || rm -f "$tmp" 2>/dev/null
 
 # =========================================================== crossing engine
@@ -253,8 +221,11 @@ record_crossing() {
 }
 
 if [ "$run_engine" -eq 1 ]; then
-  # The sitting clock. Only a prompt moves it: the gap that matters is the one
-  # between two things the user typed, not between two tool calls.
+  # The sitting clock is wound by prompts and by nothing else -- started
+  # here, reset here, and read only under is_prompt below. A Stop or a
+  # SubagentStop leaves sitting_start exactly as it found it: those fire on
+  # the agent's schedule, not the user's, so a session whose first wired
+  # event is a Stop must not start a clock nobody has sat down at.
   if [ "$is_prompt" -eq 1 ]; then
     if [ "$last_prompt" -gt 0 ] \
        && [ $((now_ts - last_prompt)) -gt $((NAG_SIT_GAP_MIN * 60)) ]; then
@@ -262,8 +233,8 @@ if [ "$run_engine" -eq 1 ]; then
       time_line=0
     fi
     last_prompt=$now_ts
+    [ "$sit_start" -gt 0 ] || sit_start=$now_ts
   fi
-  [ "$sit_start" -gt 0 ] || sit_start=$now_ts
 
   IFS=$'\t' read -r ctx gates fric_win <<<"$(printf '%s\n' "$metrics" | jq -r \
     --argjson w "$NAG_FRICTION_TURNS" \
@@ -288,12 +259,14 @@ if [ "$run_engine" -eq 1 ]; then
     fi
   done
 
-  # sitting clock
-  if [ "$NAG_SIT_EVERY_MIN" -gt 0 ]; then
+  # sitting clock -- read on a prompt and nowhere else, so the line lands
+  # where the user is already reading, at the top of a turn.
+  if [ "$is_prompt" -eq 1 ] && [ "$NAG_SIT_EVERY_MIN" -gt 0 ] \
+     && [ "$sit_start" -gt 0 ]; then
     sit_min=$(( (now_ts - sit_start) / 60 ))
     n=$(( sit_min / NAG_SIT_EVERY_MIN * NAG_SIT_EVERY_MIN ))
     if [ "$n" -ge "$NAG_SIT_EVERY_MIN" ] && [ "$n" -gt "$time_line" ]; then
-      if [ "$n" -ge $((NAG_SIT_EVERY_MIN * 2)) ]; then verdict="stop here"
+      if [ "$n" -ge $((NAG_SIT_EVERY_MIN * 2)) ]; then verdict="stop here, run /wrapup"
       else verdict="stand up"; fi
       t="⏱ sitting $(hm "$n") — context $(kfmt "$ctx"): $verdict."
       add_line "$t"; record_crossing time "$n" "$t"

--- a/.claude/hooks/metrics-live.test.sh
+++ b/.claude/hooks/metrics-live.test.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Tests for the crossing engine in metrics-live.sh.
+# Run: bash .claude/hooks/metrics-live.test.sh
+#
+# What matters is that the nag is edge-triggered: a line fires once when its
+# counter first crosses, and then not again until the next line. Three
+# properties, one per case in issue #111's Verification section:
+#
+#   crossing    a transcript that grows past 100k then past 150k produces
+#               exactly two context lines, in that order, and the second one
+#               says to propose stopping
+#   the gap     a gap over 30 minutes between prompts starts a new sitting, so
+#               the 60-minute line does not fire on a clock that began before
+#               the gap -- and a short gap leaves that clock running
+#   the Stop    a Stop on an archivable session past the line blocks once with
+#               one instruction, then passes with the resume-block message, and
+#               every Stop after that carries only the block's age
+#
+# The transcripts are built here rather than committed: each one exists to hold
+# a single usage number, and a fixture file would say less than the generator.
+set -uo pipefail
+
+HOOK="$(cd "$(dirname "$0")" && pwd)/metrics-live.sh"
+pass=0; fail=0
+SCRATCH=$(mktemp -d); trap 'rm -rf "$SCRATCH"' EXIT
+export HOME="$SCRATCH/home"; mkdir -p "$HOME" "$SCRATCH/bin"
+export CLAUDE_STATE_REPO=""
+STATE="$HOME/.claude/state/global"
+
+t() {  # t <desc> <want> <got>
+  if [ "$2" = "$3" ]; then pass=$((pass+1))
+  else fail=$((fail+1)); printf 'FAIL: %s\n  want [%s]\n  got  [%s]\n' "$1" "$2" "$3"; fi
+}
+has() {  # has <desc> <pattern> <text>
+  if printf '%s' "$3" | grep -Eq -- "$2"; then pass=$((pass+1))
+  else fail=$((fail+1)); printf 'FAIL (no /%s/): %s\n  in [%s]\n' "$2" "$1" "$3"; fi
+}
+hasnt() {
+  if printf '%s' "$3" | grep -Eq -- "$2"; then
+    fail=$((fail+1)); printf 'FAIL (has /%s/): %s\n  in [%s]\n' "$2" "$1" "$3"
+  else pass=$((pass+1)); fi
+}
+
+# --- transcripts -------------------------------------------------------------
+# One human turn plus one assistant turn carrying the context number. Appending
+# another pair with a bigger number is how a session grows past a line.
+turn() {  # turn <file> <context tokens>
+  jq -nc --arg ts "2026-09-09T10:00:00.000Z" \
+    '{type:"queue-operation", operation:"enqueue", timestamp:$ts,
+      sessionId:"t", content:"go on"}' >> "$1"
+  jq -nc --arg ts "2026-09-09T10:00:00.000Z" --argjson n "$2" \
+    --arg u "req-$(wc -l < "$1" | tr -d ' ')" \
+    '{type:"assistant", timestamp:$ts, requestId:$u,
+      message:{model:"claude-opus-5", role:"assistant",
+               content:[{type:"text", text:"ok"}],
+               usage:{input_tokens:$n, output_tokens:10,
+                      cache_read_input_tokens:0, cache_creation_input_tokens:0}}}' >> "$1"
+}
+
+payload() {  # payload <transcript> <session id> <cwd> [hook_event_name]
+  jq -nc --arg tp "$1" --arg sid "$2" --arg cwd "$3" --arg h "${4:-}" \
+    '{transcript_path:$tp, session_id:$sid, cwd:$cwd}
+     + (if $h == "" then {} else {hook_event_name:$h} end)'
+}
+
+msg() { printf '%s' "$1" | jq -r '.systemMessage // ""' 2>/dev/null; }
+
+# --- 1. two context lines, in order ------------------------------------------
+TP="$SCRATCH/ctx.jsonl"; SID=ctx1
+turn "$TP" 103000
+out1=$(payload "$TP" "$SID" "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
+turn "$TP" 152000
+out2=$(payload "$TP" "$SID" "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
+out3=$(payload "$TP" "$SID" "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
+
+has  'first crossing names 100k'      'past 100k' "$(msg "$out1")"
+hasnt 'first crossing does not propose stopping' 'propose stopping' "$(msg "$out1")"
+has  'second crossing names 150k'     'past 150k' "$(msg "$out2")"
+has  'second crossing proposes stopping' 'propose stopping' "$(msg "$out2")"
+t    'nothing fires a third time'     '' "$(msg "$out3")"
+
+CROSS="$STATE/metrics/crossings/$SID.jsonl"
+t 'both crossings are recorded, in order' \
+  "$(printf '100000\n150000')" \
+  "$(jq -r 'select(.kind == "context") | .at' "$CROSS" 2>/dev/null)"
+
+# --- 2. a 40-minute gap starts a new sitting ---------------------------------
+# The clock is wall-clock, so the way to put a session 61 minutes in is to
+# write the state file the engine reads, which is what a resumed session's
+# state actually looks like.
+sitting() {  # sitting <session id> <minutes since sitting start> <minutes since last prompt>
+  local n=$STATE/metrics/live/$1.nag.json
+  mkdir -p "$(dirname "$n")"
+  jq -n --argjson ss "$(( $(date +%s) - $2 * 60 ))" \
+        --argjson lp "$(( $(date +%s) - $3 * 60 ))" \
+    '{context_line:200000, time_line:0, gate_line:0, friction_tripped:false,
+      sitting_start:$ss, last_prompt:$lp, since_nag:false,
+      resume_ts:0, nag_pending:false}' > "$n"
+}
+
+TP2="$SCRATCH/sit.jsonl"; turn "$TP2" 1000
+sitting gap 61 40
+out=$(payload "$TP2" gap "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
+hasnt 'a 40 min gap resets the clock: no 60 min line' '⏱' "$(msg "$out")"
+
+sitting nogap 61 10
+out=$(payload "$TP2" nogap "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
+has 'a 10 min gap leaves the clock running' '⏱ sitting 1h00' "$(msg "$out")"
+has 'the clock line carries the context'    'context 1k'     "$(msg "$out")"
+
+out=$(payload "$TP2" nogap "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
+t 'the 60 min line does not repeat' '' "$(msg "$out")"
+
+# --- 3. Stop, archivable, past the line --------------------------------------
+REPO="$SCRATCH/repo"; mkdir -p "$REPO"
+git -C "$REPO" init -q -b feat/nags
+git -C "$REPO" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+cat > "$SCRATCH/bin/gh" <<'GH'
+#!/bin/sh
+echo 1
+GH
+chmod +x "$SCRATCH/bin/gh"
+export PATH="$SCRATCH/bin:$PATH"
+
+TP3="$SCRATCH/stop.jsonl"; turn "$TP3" 1000
+S() { payload "$TP3" stop1 "$REPO" Stop \
+      | METRICS_STOP_HOUR=0 bash "$HOOK" stop 0 show 2>&1; }
+
+o1=$(S)
+t   'the first Stop blocks'  block "$(printf '%s' "$o1" | jq -r '.decision // ""')"
+t   'with one instruction'   'Write the resume block.' \
+    "$(printf '%s' "$o1" | jq -r '.reason // ""')"
+
+o2=$(S)
+t   'the second Stop does not block' '' "$(printf '%s' "$o2" | jq -r '.decision // ""')"
+has 'and reports the resume block' \
+    '^Archivable\. Resume block written [0-9]{2}:[0-9]{2}\. Next time: `/resume`\.$' \
+    "$(msg "$o2" | head -1)"
+
+o3=$(S)
+t     'a later Stop does not block'  '' "$(printf '%s' "$o3" | jq -r '.decision // ""')"
+has   'and carries only the age'     'Resume block 0m old' "$(msg "$o3")"
+hasnt 'not the message again'        'Next time' "$(msg "$o3")"
+
+# A dirty tree is not archivable, so nothing blocks however late it is.
+: > "$REPO/dirty"
+o4=$(payload "$TP3" stop2 "$REPO" Stop | METRICS_STOP_HOUR=0 bash "$HOOK" stop 0 show 2>&1)
+t 'a dirty tree is never archivable' '' "$(printf '%s' "$o4" | jq -r '.decision // ""')"
+
+# --- 4. the friction counter is the one line addressed to the model ----------
+# The standing orders' capacity clause no longer carries its own trigger, so
+# this line has to arrive as context, not as a systemMessage the model cannot
+# see. Uses the committed contentious fixture rather than a hand-rolled one:
+# the classifier that types a turn as a correction or a rebuke is what is
+# being relied on here.
+FIX="$(cd "$(dirname "$0")" && pwd)/fixtures/friction-contentious.jsonl"
+if [ -f "$FIX" ]; then
+  ctx=$(payload "$FIX" fric "$SCRATCH" \
+        | METRICS_FRICTION_TURNS=200 bash "$HOOK" prompt 0 2>&1 \
+        | jq -r '.hookSpecificOutput.additionalContext // ""')
+  has 'the friction line reaches the model'  'corrections or rebukes' "$ctx"
+  has 'and names the capacity rule'          'capacity rule'          "$ctx"
+  ctx2=$(payload "$FIX" fric "$SCRATCH" \
+         | METRICS_FRICTION_TURNS=200 bash "$HOOK" prompt 0 2>&1 \
+         | jq -r '.hookSpecificOutput.additionalContext // ""')
+  t 'and fires once, not every turn' '' "$ctx2"
+else
+  printf 'SKIP: %s is missing\n' "$FIX"
+fi
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/.claude/hooks/metrics-live.test.sh
+++ b/.claude/hooks/metrics-live.test.sh
@@ -12,6 +12,9 @@
 #   the gap     a gap over 30 minutes between prompts starts a new sitting, so
 #               the 60-minute line does not fire on a clock that began before
 #               the gap -- and a short gap leaves that clock running
+#   the clock    prompts own it outright: a Stop or a SubagentStop never starts
+#               it, never moves it and never reads it out, so a session whose
+#               first wired event is a Stop is sitting for zero minutes
 #   the Stop    a Stop on an archivable session past the line blocks once with
 #               one instruction, then passes with the resume-block message, and
 #               every Stop after that carries only the block's age
@@ -107,9 +110,42 @@ sitting nogap 61 10
 out=$(payload "$TP2" nogap "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
 has 'a 10 min gap leaves the clock running' '⏱ sitting 1h00' "$(msg "$out")"
 has 'the clock line carries the context'    'context 1k'     "$(msg "$out")"
+has 'and one hour says stand up'            'stand up'       "$(msg "$out")"
 
 out=$(payload "$TP2" nogap "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
 t 'the 60 min line does not repeat' '' "$(msg "$out")"
+
+sitting twohours 121 10
+out=$(payload "$TP2" twohours "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
+has 'two hours names the exit' 'sitting 2h00 .* stop here, run /wrapup' "$(msg "$out")"
+
+# --- 2b. the clock belongs to the prompt -------------------------------------
+# $SCRATCH is not a git repo, so archivable() refuses and the Stop nag stays
+# out of the way; what is under test here is only the clock.
+sit_start() { jq -r '.sitting_start // 0' "$STATE/metrics/live/$1.nag.json" 2>/dev/null; }
+
+TPS="$SCRATCH/stopfirst.jsonl"; turn "$TPS" 1000
+payload "$TPS" sfirst "$SCRATCH" Stop \
+  | bash "$HOOK" stop 0 show >/dev/null 2>&1
+t 'a Stop before any prompt does not start the clock' 0 "$(sit_start sfirst)"
+
+payload "$TPS" sfirst "$SCRATCH" SubagentStop \
+  | bash "$HOOK" subagentstop 0 show >/dev/null 2>&1
+t 'nor does a SubagentStop' 0 "$(sit_start sfirst)"
+
+out=$(payload "$TPS" sfirst "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
+hasnt 'so the first prompt after them is minute zero' '⏱' "$(msg "$out")"
+t 'and it is the prompt that starts the clock' yes \
+  "$( [ "$(sit_start sfirst)" -gt 0 ] && echo yes || echo no )"
+
+# An hour on the clock: a Stop must neither report it nor disturb it.
+sitting quiet 61 10
+before=$(sit_start quiet)
+out=$(payload "$TPS" quiet "$SCRATCH" Stop | bash "$HOOK" stop 0 show 2>&1)
+hasnt 'a Stop past the line says nothing about sitting' '⏱ sitting' "$(msg "$out")"
+t    'and leaves the clock exactly where it found it' "$before" "$(sit_start quiet)"
+out=$(payload "$TPS" quiet "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
+has  'the next prompt is what reports it' '⏱ sitting 1h00' "$(msg "$out")"
 
 # --- 3. Stop, archivable, past the line --------------------------------------
 REPO="$SCRATCH/repo"; mkdir -p "$REPO"

--- a/.claude/hooks/metrics-live.test.sh
+++ b/.claude/hooks/metrics-live.test.sh
@@ -128,19 +128,42 @@ S() { payload "$TP3" stop1 "$REPO" Stop \
 
 o1=$(S)
 t   'the first Stop blocks'  block "$(printf '%s' "$o1" | jq -r '.decision // ""')"
-t   'with one instruction'   'Write the resume block.' \
+has 'with one instruction'   '^Write the resume block: append a `## Resume` block' \
     "$(printf '%s' "$o1" | jq -r '.reason // ""')"
 
+# The model answers the block by writing the checkpoint's resume block. The
+# hook must find it on disk, not assume it from having asked.
+CK="$STATE/log/auto"; mkdir -p "$CK"
+printf '# ckpt\n\n## Resume\n\n- next: x\n' > "$CK/2026-09-09-repo-stop1.md"
 o2=$(S)
 t   'the second Stop does not block' '' "$(printf '%s' "$o2" | jq -r '.decision // ""')"
-has 'and reports the resume block' \
-    '^Archivable\. Resume block written [0-9]{2}:[0-9]{2}\. Next time: `/resume`\.$' \
+has 'and reports the resume block it found' \
+    '^Archivable\. Resume block written [0-9]{2}:[0-9]{2} in 2026-09-09-repo-stop1\.md\. Next time: `/resume`\.$' \
     "$(msg "$o2" | head -1)"
 
 o3=$(S)
 t     'a later Stop does not block'  '' "$(printf '%s' "$o3" | jq -r '.decision // ""')"
 has   'and carries only the age'     'Resume block 0m old' "$(msg "$o3")"
 hasnt 'not the message again'        'Next time' "$(msg "$o3")"
+
+# The block was ignored: no `## Resume` anywhere. Say so, do not claim one,
+# and do not block again -- the late-hour arm is spent for the session.
+S3() { payload "$TP3" stop3 "$REPO" Stop \
+       | METRICS_STOP_HOUR=0 bash "$HOOK" stop 0 show 2>&1; }
+o=$(S3); t 'blocks once' block "$(printf '%s' "$o" | jq -r '.decision // ""')"
+o=$(S3)
+t     'an unanswered block does not re-block' '' "$(printf '%s' "$o" | jq -r '.decision // ""')"
+has   'and reports the block as missing' 'no `## Resume` block' "$(msg "$o")"
+hasnt 'never claims it was written'      'Resume block written' "$(msg "$o")"
+o=$(S3); t 'and stays quiet after' '' "$(printf '%s' "$o" | jq -r '.decision // ""')"
+
+# A crossing that arms the Stop is consumed by it, so the block reason has to
+# carry the line -- otherwise the threshold that caused the block is never seen.
+TP4="$SCRATCH/cross.jsonl"; turn "$TP4" 103000
+o=$(payload "$TP4" stop4 "$REPO" Stop | METRICS_STOP_HOUR=23 bash "$HOOK" stop 0 show 2>&1)
+t   'a context crossing at Stop blocks' block "$(printf '%s' "$o" | jq -r '.decision // ""')"
+has 'and the reason carries the crossing line' '⛁ context 103k — past 100k' \
+    "$(printf '%s' "$o" | jq -r '.reason // ""')"
 
 # A dirty tree is not archivable, so nothing blocks however late it is.
 : > "$REPO/dirty"

--- a/.claude/hooks/session-metrics.jq
+++ b/.claude/hooks/session-metrics.jq
@@ -406,6 +406,11 @@ def prev_ask($h): (last($atext[] | select(.i < $h)) // {text: null}).text | ask_
      | {ts: $now, session_id: $sid, repo: $repo, branch: $branch,
         seq: ($seq + 1),
         turn_index: .i,
+        # Position among human turns, 1-based. turn_index is an index into the
+        # whole event stream, so it cannot answer "how many turns ago" -- and
+        # the friction counter in metrics-live.sh is defined as a window of
+        # turns, not of events. Computed here because $humans lives here.
+        turn_ordinal: (.i as $ii | ($humans | map(select(. <= $ii)) | length)),
         type: .type,
         tags: .tags,
         retracted: .retracted,
@@ -416,7 +421,9 @@ def prev_ask($h): (last($atext[] | select(.i < $h)) // {text: null}).text | ask_
         prior: .prior} ]) as $friction_human
 | ([ $atext[] | (first(.text | split("\n")[] | select(test(s9_self_re))) // empty) as $line
      | {ts: $now, session_id: $sid, repo: $repo, branch: $branch,
-        seq: 0, turn_index: .i, type: "self_report", tags: ["self_report"],
+        seq: 0, turn_index: .i,
+        turn_ordinal: (.i as $ii | ($humans | map(select(. <= $ii)) | length)),
+        type: "self_report", tags: ["self_report"],
         retracted: false, repeat: false,
         slug: ($ARGS.named.slug // ""),
         hits: [ $line | match(s9_self_re) | .captures[0].string ],

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -157,15 +157,6 @@
         ]
       },
       {
-        "matcher": "AskUserQuestion",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "h=\"$HOME/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] && bash \"$h\" question 0 show 2>/dev/null || true"
-          }
-        ]
-      },
-      {
         "matcher": "Bash|mcp__.*__create_pull_request",
         "hooks": [
           {
@@ -249,7 +240,9 @@
         "hooks": [
           {
             "type": "command",
-            "command": "h=\"$HOME/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] && bash \"$h\" stop 0 show 2>/dev/null || true"
+            "command": "h=\"$HOME/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] && bash \"$h\" stop 0 show 2>/dev/null || true",
+            "timeout": 30,
+            "statusMessage": "Checking the session against the nag thresholds"
           }
         ]
       },
@@ -294,24 +287,6 @@
             "command": "h=\"$HOME/.claude/hooks/log-commit.sh\"; [ -f \"$h\" ] && bash \"$h\" 2>/dev/null || true"
           }
         ]
-      },
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "h=\"$HOME/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] && bash \"$h\" posttooluse 0 show 2>/dev/null || true"
-          }
-        ]
-      }
-    ],
-    "Notification": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "h=\"$HOME/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] && bash \"$h\" notification 0 show 2>/dev/null || true"
-          }
-        ]
       }
     ],
     "SubagentStop": [
@@ -324,33 +299,9 @@
         ]
       }
     ],
-    "PreCompact": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "h=\"$HOME/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] && bash \"$h\" precompact 0 show 2>/dev/null || true"
-          }
-        ]
-      }
-    ],
-    "SessionEnd": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "h=\"$HOME/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] && bash \"$h\" sessionend 0 show 2>/dev/null || true"
-          }
-        ]
-      }
-    ],
     "SessionStart": [
       {
         "hooks": [
-          {
-            "type": "command",
-            "command": "h=\"$HOME/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] && bash \"$h\" sessionstart 0 show 2>/dev/null || true"
-          },
           {
             "type": "command",
             "command": "h=\"$HOME/.claude/hooks/session-start-seed-refresh.sh\"; [ -f \"$h\" ] && bash \"$h\" || true",

--- a/.local/bin/metrics-preview.sh
+++ b/.local/bin/metrics-preview.sh
@@ -97,7 +97,14 @@ F="$(state_dir)/metrics/live/$sid.json"
 # These two must stay silent. A regression here is invisible in a session:
 # `prompt` leaking means the block becomes model context instead of display,
 # and the git filter leaking means a transcript-wide jq pass after every `ls`.
-out=$(payload "git commit -m preview" | bash "$HOOKS/metrics-live.sh" prompt 0 show 2>&1)
+#
+# The thresholds are pushed out of reach for the prompt case: a crossing line
+# on UserPromptSubmit is correct and expected, and this check is about the
+# readout block, not about the nag.
+out=$(payload "git commit -m preview" \
+      | METRICS_CONTEXT_LINES=999999999 METRICS_SIT_EVERY_MIN=0 METRICS_GATE_EVERY=0 \
+        METRICS_FRICTION_N=999999 \
+        bash "$HOOKS/metrics-live.sh" prompt 0 show 2>&1)
 if [ -z "$out" ]; then ok "prompt event prints nothing (would become model context)"
 else bad "prompt event printed: $out"; fi
 


### PR DESCRIPTION
Closes #111.

## What changed

**Wiring.** `metrics-live.sh` is on `UserPromptSubmit` (silent), `Stop` and
`SubagentStop`. Removed from PreToolUse, PostToolUse, Notification, PreCompact,
SessionEnd and SessionStart, and the PostToolUse pulse/coalesce machinery those
events needed goes with them. The statusline recomputes past its own 15 s cache
age, so the readout no longer depends on hook cadence.

**Counters.** One overridable block at the top of the hook holds every
threshold:

| counter | lines | env |
|---|---|---|
| context | 100k, 150k, 200k; "propose stopping" from 150k | `METRICS_CONTEXT_LINES`, `METRICS_CONTEXT_STOP_AT` |
| sitting clock | 60 min, then every 60; a gap over 30 min starts a new sitting | `METRICS_SIT_EVERY_MIN`, `METRICS_SIT_GAP_MIN` |
| friction | 3 corrections or rebukes within 20 human turns | `METRICS_FRICTION_N`, `METRICS_FRICTION_TURNS` |
| gate decisions | every 5 | `METRICS_GATE_EVERY` |

Each line fires once, when its counter first crosses, and then nothing until
the next line. Crossings are appended to
`metrics/crossings/<session>.jsonl` in the state repo so a session can be read
back later. The sitting-clock reset clears elapsed time and the time crossings
only; context and decision crossings persist across the gap.

The friction line is the one addressed to the model, as `additionalContext` on
`UserPromptSubmit` — everything else is a `systemMessage`, which costs no
context. The capacity clause in `.claude/CLAUDE.md` keeps its response guidance
and loses its trigger sentence; the counter is the trigger now.

**Stop nag.** Fires when the session is archivable and something has armed it:
a context or time crossing since the last nag, the friction counter, or the
local hour past `METRICS_STOP_HOUR` (default 22) while no resume block exists
yet. It blocks the Stop once with one instruction; the next Stop passes with
`Archivable. Resume block written HH:MM. Next time: /resume.`; every Stop after
that carries only the block's age.

**Archivable, self-contained.** #110 is in flight in a separate PR, so this one
does not depend on it: `archivable()` here is a local check — clean worktree,
nothing unpushed, the state repo's own commits pushed, and an open PR or a
pointer card naming the branch. If #110 lands a shared verdict, this is the
call site to point at it.

**`session-metrics.jq`.** Friction records gain `turn_ordinal`, the position
among human turns. `turn_index` is an index into the whole event stream and so
cannot answer "how many turns ago", which is how the friction window is
defined.

## Verification

`.claude/hooks/metrics-live.test.sh`, 21 assertions, beside the hook:

- a transcript growing past 100k then past 150k → exactly two context lines, in
  order, only the second proposing a stop, nothing on the third pass; both
  crossings on disk in order;
- a 40-minute gap → the 60-minute line does not fire on a clock that started
  before it, and a 10-minute gap leaves that clock running and firing once;
- a Stop past the line with `archivable` → blocked once with the instruction,
  then the resume-block message, then only the age; a dirty tree never blocks;
- the friction line arrives as model context and fires once.

Every other hook test, `shellcheck --severity=warning`, the hook-seed check and
`prose-budget.test.py` run clean locally.
