### PR TITLE
Resume: archive verdict, per-session resume blocks, /resume, wrap-up dedup

### DIFF
--- a/.claude/hooks/branch-home-gate.sh
+++ b/.claude/hooks/branch-home-gate.sh
@@ -32,11 +32,30 @@
 # GATE: no jq, no gh, gh failing or unauthenticated -> block once saying the
 # branch could not be verified. A guard that goes quiet when it cannot look is
 # indistinguishable from one that looked and found nothing.
+#
+#   branch-home-gate.sh --check [dir]
+#
+# Second entry point, read-only: answers "does this branch have a home" on
+# stdout and exits 0, without ever blocking and without touching the
+# once-per-session marker. stop-continuity.sh calls it for the archive verdict
+# (dotfiles#110) so the verdict and the gate can never disagree about what a
+# home is -- one implementation, two callers. Prints exactly one line:
+#   home: <why>          a PR, a card or an issue names it; or nothing to strand
+#   none                 ahead of the default branch with no home
+#   unverified: <why>    could not look (no gh, not authenticated, no jq)
 set -u
 
 HERE=$(cd "$(dirname "$0")" && pwd)
 # shellcheck source=lib-state.sh
 . "$HERE/lib-state.sh"
+
+CHECK=0; check_cwd=
+if [ "${1:-}" = "--check" ]; then CHECK=1; check_cwd=${2:-$PWD}; fi
+# In --check mode every path that would exit quietly (default branch, nothing
+# ahead, no origin, not a repo) is a pass: there is nothing to strand, so
+# nothing there blocks an archive. Silence would read as "no answer" to the
+# caller, so say it.
+quiet_exit() { [ "$CHECK" = 1 ] && printf 'home: %s\n' "${1:-nothing to strand}"; exit 0; }
 
 # json_str(), block() and names_branch() come from lib-state.sh, sourced above.
 
@@ -46,33 +65,40 @@ run_to() {
   if command -v timeout >/dev/null 2>&1; then timeout "$@"; else shift; "$@"; fi
 }
 
-payload=$(cat) || exit 0
-
-# stop_hook_active is the last-resort loop breaker.
-if command -v jq >/dev/null 2>&1; then
-  active=$(printf '%s' "$payload" | jq -r '.stop_hook_active // false' 2>/dev/null)
+if [ "$CHECK" = 1 ]; then
+  active=false; sid=; cwd=$check_cwd
+  if ! command -v jq >/dev/null 2>&1; then
+    printf 'unverified: jq is not installed here\n'; exit 0
+  fi
 else
-  active=false
-  printf '%s' "$payload" | grep -q '"stop_hook_active"[[:space:]]*:[[:space:]]*true' && active=true
-  [ "$active" = true ] && exit 0
-  block "branch-home-gate: jq is missing here, so this session's branch could not be checked for a PR or a pointer card. This is a gate and fails closed: open the PR, or file a pointer card naming the branch and what it holds (/card-write), then end the turn again."
-fi
+  payload=$(cat) || exit 0
 
-sid=$(printf '%s' "$payload" | jq -r '.session_id // empty' 2>/dev/null)
-cwd=$(printf '%s' "$payload" | jq -r '.cwd // empty' 2>/dev/null)
-[ -n "$sid" ] || exit 0
+  # stop_hook_active is the last-resort loop breaker.
+  if command -v jq >/dev/null 2>&1; then
+    active=$(printf '%s' "$payload" | jq -r '.stop_hook_active // false' 2>/dev/null)
+  else
+    active=false
+    printf '%s' "$payload" | grep -q '"stop_hook_active"[[:space:]]*:[[:space:]]*true' && active=true
+    [ "$active" = true ] && exit 0
+    block "branch-home-gate: jq is missing here, so this session's branch could not be checked for a PR or a pointer card. This is a gate and fails closed: open the PR, or file a pointer card naming the branch and what it holds (/card-write), then end the turn again."
+  fi
+
+  sid=$(printf '%s' "$payload" | jq -r '.session_id // empty' 2>/dev/null)
+  cwd=$(printf '%s' "$payload" | jq -r '.cwd // empty' 2>/dev/null)
+  [ -n "$sid" ] || exit 0
+fi
 [ -n "$cwd" ] || cwd=$PWD
 
 # ------------------------------------------------------------- quiet path
-work_root=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null) || exit 0
-[ -n "$work_root" ] || exit 0
-branch=$(git -C "$cwd" rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
+work_root=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null) || quiet_exit "not a git repo"
+[ -n "$work_root" ] || quiet_exit "not a git repo"
+branch=$(git -C "$cwd" rev-parse --abbrev-ref HEAD 2>/dev/null) || quiet_exit
 case "$branch" in
-  ''|HEAD|main|master) exit 0 ;;   # default branch or detached: nothing to strand
+  ''|HEAD|main|master) quiet_exit "on \`$branch\`" ;;   # default branch or detached
 esac
 # No origin means nothing was published and nothing can be: a purely local
 # repo has no orphan to leave behind.
-git -C "$work_root" remote get-url origin >/dev/null 2>&1 || exit 0
+git -C "$work_root" remote get-url origin >/dev/null 2>&1 || quiet_exit "no origin remote"
 
 # The base to measure "ahead" against: origin's default branch, however it is
 # named here.
@@ -82,19 +108,23 @@ for cand in "$(git -C "$work_root" symbolic-ref -q --short refs/remotes/origin/H
   [ -n "$cand" ] || continue
   if git -C "$work_root" rev-parse --verify -q "$cand" >/dev/null 2>&1; then base=$cand; break; fi
 done
-[ -n "$base" ] || exit 0
-[ "$base" = "origin/$branch" ] && exit 0
+[ -n "$base" ] || quiet_exit "no default branch to compare against"
+[ "$base" = "origin/$branch" ] && quiet_exit "is the default branch"
 ahead=$(git -C "$work_root" rev-list --count "$base..HEAD" 2>/dev/null || echo 0)
-[ "${ahead:-0}" -gt 0 ] 2>/dev/null || exit 0
+[ "${ahead:-0}" -gt 0 ] 2>/dev/null || quiet_exit "no commits ahead of $base"
 
-# One file per session: the once-per-session marker (a line beginning
-# "blocked") for the checkpoint.
-rec="${TMPDIR:-/tmp}/claude-branch-home.$(printf '%s' "$sid" | tr -c 'A-Za-z0-9_-' '_')"
-note() { printf '%s\n' "$1" >> "$rec" 2>/dev/null || true; }
+if [ "$CHECK" = 1 ]; then
+  note() { :; }
+else
+  # One file per session: the once-per-session marker (a line beginning
+  # "blocked") for the checkpoint.
+  rec="${TMPDIR:-/tmp}/claude-branch-home.$(printf '%s' "$sid" | tr -c 'A-Za-z0-9_-' '_')"
+  note() { printf '%s\n' "$1" >> "$rec" 2>/dev/null || true; }
 
-# --------------------------------------------------------- already blocked
-[ -f "$rec" ] && grep -q '^blocked' "$rec" 2>/dev/null && exit 0
-[ "$active" = true ] && exit 0
+  # ------------------------------------------------------- already blocked
+  [ -f "$rec" ] && grep -q '^blocked' "$rec" 2>/dev/null && exit 0
+  [ "$active" = true ] && exit 0
+fi
 
 # ------------------------------------------------------------ find a home
 # 0 found, 1 none, 2 could not verify. The board is a local file, so it is
@@ -135,6 +165,13 @@ if [ -z "$found" ] && [ -z "$unverified" ]; then
   else
     unverified="gh issue list failed (not authenticated here?)"
   fi
+fi
+
+if [ "$CHECK" = 1 ]; then
+  if [ -n "$found" ]; then printf 'home: %s\n' "$found"
+  elif [ -n "$unverified" ]; then printf 'unverified: %s\n' "$unverified"
+  else printf 'none\n'; fi
+  exit 0
 fi
 
 [ -n "$found" ] && exit 0

--- a/.claude/hooks/stop-continuity.sh
+++ b/.claude/hooks/stop-continuity.sh
@@ -82,13 +82,34 @@ bash "$HOOK_DIR/metrics-rollup.sh" 2>/dev/null || true
 # ---------------------------------------------------------------- checkpoint
 ckpt="$SD/log/auto/$today-$work_repo-${sid:0:8}.md"
 
+# The resume block (dotfiles#110) is the one part of this file a *model*
+# writes, and this hook rewrites the whole file on every Stop -- so it has to
+# be lifted out of the old copy and put back, or the next Stop silently eats
+# the hand-off the model was told to write. Everything from the `## Resume`
+# heading to the next `## ` heading is carried verbatim, including the
+# `- consumed:` marker a resuming session appends.
+resume_block=""
+[ -f "$ckpt" ] && resume_block=$(awk '
+  /^## Resume[[:space:]]*$/ { f = 1; print; next }
+  f && /^## / { exit }
+  f { print }
+' "$ckpt" 2>/dev/null)
+
 {
   echo "# Auto-checkpoint — $work_repo @ \`$work_branch\`"
+  echo
+  # The verdict is the first thing in the file because it is the one line a
+  # reader needs: archivable means archive, no wrap-up. It cannot be computed
+  # yet -- the salvage commit and the state-repo push have not happened -- so
+  # it starts as a refusal and set_verdict() substitutes it below. A Stop that
+  # dies in between leaves this line, which is the truth: nothing was decided.
+  echo "**Verdict:** not archivable: the Stop hook did not finish"
   echo
   echo "Machine-written by \`stop-continuity.sh\`; rewritten on every Stop, so"
   echo "this is the session's current state, not a history. Narrative entries"
   echo "belong in \`log/\` proper."
   echo
+  [ -n "$work_root" ] && echo "- worktree \`$work_root\`"
   printf '%s' "$metrics" | jq -r '.session |
     "- session `\(.session_id)` · \(.model // "?") · started \(.started_at // "?")",
     "- \(.user_turns) prompts, \(.assistant_turns) turns, \(.tool_calls) tool calls",
@@ -96,6 +117,11 @@ ckpt="$SD/log/auto/$today-$work_repo-${sid:0:8}.md"
     "- decisions: \(.decisions.total) total (\(.decisions.scoping) scoping, \(.decisions.inline) inline, \(.decisions.gate) gate)",
     "- friction: \(.friction.total) total (\(.friction.correction) correction, \(.friction.override) override, \(.friction.rebuke) rebuke, \(.friction.pushback) pushback)",
     "- blocked: \(.blocked.total // 0) tool calls refused (\(.blocked.classifier // 0) classifier, \(.blocked.rule // 0) rule, \(.blocked.user // 0) user-declined)"'
+
+  if [ -n "$resume_block" ]; then
+    echo
+    printf '%s\n' "$resume_block"
+  fi
 
   if [ -n "$work_root" ]; then
     echo
@@ -146,6 +172,62 @@ flock -w 90 9 2>/dev/null || exit 0
 # do; every refusal after that is named in the checkpoint so it can carry
 # whatever detail turns out to be useful.
 sc_note() { printf '\n## Stop-commit\n\n%s\n' "$1" >> "$ckpt"; }
+
+# ------------------------------------------------------------ the verdict
+# set_verdict [extra reason] -- computes the archive verdict (dotfiles#110)
+# and writes it into the checkpoint's placeholder line and into the session's
+# metrics record. Idempotent: it rewrites whatever verdict line is already
+# there, so it can be called again once the state-repo push has been tried.
+#
+# "wrap up" is expensive and was being paid every session, including sessions
+# whose work already had a home. Archivable means archive; wrap up only when
+# the session holds something no issue, PR or card carries. Four conditions,
+# reasons named in this order:
+#   1. the branch has a home -- an open PR, or a pointer card/issue (#108).
+#      branch-home-gate.sh --check answers it, so this verdict and that gate
+#      can never disagree about what counts as a home;
+#   2. the worktree is clean;
+#   3. nothing is unpushed;
+#   4. the state-repo push succeeded (passed in by the caller, because it is
+#      not known until the bottom of this script).
+# "Could not verify" is never a pass, here as in the gate.
+verdict=""
+set_verdict() {
+  reasons=""
+  add_reason() { reasons="${reasons:+$reasons, }$1"; }
+
+  # Cached across calls: the check costs a `gh` round trip and the branch's
+  # home does not change between the salvage and the state-repo push.
+  [ -n "${home:-}" ] || home=$(sh "$HOOK_DIR/branch-home-gate.sh" --check "$cwd" 2>/dev/null)
+  case "$home" in
+    home:*)       : ;;
+    unverified:*) add_reason "branch home unverified (${home#unverified: })" ;;
+    *)            add_reason "no PR and no pointer for \`$work_branch\`" ;;
+  esac
+  if [ -n "$work_root" ]; then
+    [ -n "$(git -C "$work_root" status --porcelain 2>/dev/null)" ] && add_reason "worktree dirty"
+    unpushed=$(git -C "$work_root" rev-list --count "@{u}..HEAD" 2>/dev/null || echo 0)
+    case "${unpushed:-0}" in 0|"") ;; *) add_reason "$unpushed commit(s) unpushed" ;; esac
+  fi
+  [ -n "${1:-}" ] && add_reason "$1"
+
+  if [ -n "$reasons" ]; then verdict="not archivable: $reasons"; else verdict="archivable"; fi
+
+  # Substitute rather than append: the line is at a known place and a second
+  # verdict line would be a second answer.
+  tmpc="$ckpt.verdict.$$"
+  if awk -v v="**Verdict:** $verdict" '
+       !done && /^\*\*Verdict:\*\* / { print v; done = 1; next } { print }
+     ' "$ckpt" > "$tmpc" 2>/dev/null; then mv -f "$tmpc" "$ckpt" 2>/dev/null; else rm -f "$tmpc"; fi
+
+  sf="$SD/metrics/sessions/$sid.json"
+  if [ -f "$sf" ]; then
+    tmpj="$sf.$$"
+    if jq -c --arg v "$verdict" '. + {verdict: $v}' "$sf" > "$tmpj" 2>/dev/null; then
+      mv -f "$tmpj" "$sf" 2>/dev/null
+    else rm -f "$tmpj"; fi
+  fi
+}
 sc_salvage() {
   # --- silent exits: the normal case for most sessions ---------------------
   # Not inside a git repo at all.
@@ -206,6 +288,9 @@ sc_salvage() {
   fi
 }
 sc_salvage
+# After the salvage, not before: a session whose work this hook just committed
+# and pushed is not "dirty, unpushed".
+set_verdict
 
 # ------------------------------------------------------------ state repo
 state_is_repo || exit 0
@@ -223,6 +308,7 @@ if [ -f .gitattributes ] && grep -qE '(^|[[:space:]])filter=' .gitattributes; th
       printf '\n**NOT COMMITTED** — git filter `%s` is declared in .gitattributes\n' "$f" >> "$ckpt"
       printf 'but not configured in this clone, so committing would mangle content.\n' >> "$ckpt"
       printf 'Run the repo'"'"'s filter setup, or commit by hand from a real machine.\n' >> "$ckpt"
+      set_verdict "state repo not committed (git filter \`$f\` unconfigured)"
       exit 0
     fi
   done
@@ -272,4 +358,8 @@ for attempt in 1 2; do
   fi
   sleep $((attempt * 3))
 done
+# The optimistic verdict is now known to be wrong. Correcting it leaves the
+# checkpoint one commit behind the state repo -- the next Stop carries both
+# the correction and this commit.
+set_verdict "state-repo push failed"
 exit 0

--- a/.claude/hooks/stop-continuity.sh
+++ b/.claude/hooks/stop-continuity.sh
@@ -206,8 +206,22 @@ set_verdict() {
   esac
   if [ -n "$work_root" ]; then
     [ -n "$(git -C "$work_root" status --porcelain 2>/dev/null)" ] && add_reason "worktree dirty"
-    unpushed=$(git -C "$work_root" rev-list --count "@{u}..HEAD" 2>/dev/null || echo 0)
-    case "${unpushed:-0}" in 0|"") ;; *) add_reason "$unpushed commit(s) unpushed" ;; esac
+    # An unconfigured upstream makes `rev-list @{u}..HEAD` fail, and a failure
+    # that falls back to 0 is indistinguishable from a fully-pushed branch --
+    # the "lost work" failure mode one step earlier than #108/#110. Ask about
+    # the upstream first, so a never-pushed branch gets its own reason.
+    if git -C "$work_root" rev-parse --verify -q --symbolic-full-name '@{u}' >/dev/null 2>&1; then
+      unpushed=$(git -C "$work_root" rev-list --count "@{u}..HEAD" 2>/dev/null || printf '')
+      case "${unpushed:-}" in
+        0)  ;;
+        '') add_reason "could not count unpushed commits" ;;
+        *)  add_reason "$unpushed commit(s) unpushed" ;;
+      esac
+    elif [ "$work_branch" = HEAD ] || [ -z "$work_branch" ]; then
+      add_reason "detached HEAD, no upstream to compare against"
+    else
+      add_reason "\`$work_branch\` has no upstream (never pushed)"
+    fi
   fi
   [ -n "${1:-}" ] && add_reason "$1"
 

--- a/.claude/hooks/stop-continuity.sh
+++ b/.claude/hooks/stop-continuity.sh
@@ -353,6 +353,8 @@ if [ -n "$(git status --porcelain -- "$board" 2>/dev/null)" ]; then
   [ "$board_ok" = 1 ] || printf '\n## Board NOT committed\n\n`%s` failed kanban-lint; its edits stay uncommitted in the working tree (anything you had already staged for it is left staged). Fix or delete the lines, then commit by hand or let the next Stop try again.\n\n```\n%s\n```\n' "$board" "$lint_out" >> "$ckpt"
 fi
 
+# Before the add, so the correction is what gets committed.
+[ "$board_ok" = 1 ] || set_verdict "board not committed (kanban-lint failed)"
 git add state/ >/dev/null 2>&1
 if [ "$board_ok" != 1 ]; then
   git reset -q -- "$board" >/dev/null 2>&1
@@ -363,7 +365,7 @@ git diff --cached --quiet 2>/dev/null && exit 0   # nothing changed
 git -c user.name="${GIT_AUTHOR_NAME:-Claude}" \
     -c user.email="${GIT_AUTHOR_EMAIL:-noreply@anthropic.com}" \
     -c commit.gpgsign=false \
-    commit -q -m "State: $work_repo session ${sid:0:8} ($today)" >/dev/null 2>&1 || exit 0
+    commit -q -m "State: $work_repo session ${sid:0:8} ($today)" >/dev/null 2>&1 || { set_verdict "state-repo commit failed"; exit 0; }
 
 for attempt in 1 2; do
   timeout 120 git pull --rebase --autostash -q >/dev/null 2>&1

--- a/.claude/hooks/stop-continuity.test.sh
+++ b/.claude/hooks/stop-continuity.test.sh
@@ -93,6 +93,17 @@ eq 'dirty before unpushed' 'not archivable: worktree dirty, 1 commit(s) unpushed
 gitq "$WORK" checkout -- f
 gitq "$WORK" push
 
+# --- a branch that was never pushed at all -------------------------------------
+# No upstream means `rev-list @{u}..HEAD` fails rather than answering 0, so a
+# fallback of 0 would call a clean, home-having branch archivable while every
+# commit still lives only on local disk.
+gitq "$WORK" checkout -b claude/never-pushed
+echo five >> "$WORK/f"; gitq "$WORK" add f; gitq "$WORK" commit -m local-only
+GH_PRS='[{"url":"https://github.com/o/r/pull/7"}]' stop
+eq 'never pushed is not archivable' \
+  'not archivable: `claude/never-pushed` has no upstream (never pushed)' "$(verdict)"
+gitq "$WORK" checkout claude/work
+
 # --- "cannot verify" is never a pass ------------------------------------------------
 GH_FAIL=1 stop
 has 'unverified is not archivable' '^\*\*Verdict:\*\* not archivable: branch home unverified' "$CKPT"

--- a/.claude/hooks/stop-continuity.test.sh
+++ b/.claude/hooks/stop-continuity.test.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Tests for the parts of stop-continuity.sh that dotfiles#110 added: the
+# archive verdict line, the same verdict in the metrics record, and carrying a
+# model-written resume block through the rewrite.
+# Run: bash .claude/hooks/stop-continuity.test.sh
+#
+# What matters: `archivable` is said only when every condition holds; each
+# reason is named, in the contract's order; a resume block survives a Stop,
+# because the hook rewrites the whole checkpoint and eating the hand-off the
+# model was told to write would be silent and total.
+#
+# The rest of the hook (metrics shape, the salvage commit, the state-repo
+# push) is not covered here.
+set -uo pipefail
+[ -n "${AWK_PATH:-}" ] && PATH="$AWK_PATH:$PATH"
+
+HOOKS="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$HOOKS/stop-continuity.sh"
+pass=0; fail=0
+S=$(mktemp -d); trap 'rm -rf "$S"' EXIT
+export HOME="$S/home"; mkdir -p "$HOME"
+export TMPDIR="$S/tmp"; mkdir -p "$TMPDIR"
+export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1
+export CLAUDE_STOP_COMMIT=off          # the salvage commit is not under test
+
+gitq() { git -C "$1" -c user.name=t -c user.email=t@example.invalid -c commit.gpgsign=false "${@:2}" >/dev/null 2>&1; }
+
+# A state dir that is deliberately NOT a git repo: state_is_repo is false, so
+# the hook stops before the commit-and-push section and the verdict written by
+# the salvage step is the one under test.
+SD="$S/state"; mkdir -p "$SD/state/global"
+export CLAUDE_STATE_REPO=""
+export HOME="$S/home"
+AUTO="$HOME/.claude/state/global/log/auto"
+
+# --- a fake gh: GH_PRS is what `gh pr list` answers ---------------------------
+BIN="$S/bin"; mkdir -p "$BIN"
+cat > "$BIN/gh" <<'EOF'
+#!/bin/sh
+[ "${GH_FAIL:-0}" = 1 ] && { echo "gh: not logged in" >&2; exit 1; }
+case "$1 ${2:-}" in
+  "pr list")    printf '%s\n' "${GH_PRS:-[]}" ;;
+  "issue list") printf '%s\n' "${GH_ISSUES:-[]}" ;;
+  *) exit 1 ;;
+esac
+EOF
+chmod +x "$BIN/gh"
+export PATH="$BIN:$PATH"
+
+# --- the repo the session worked ----------------------------------------------
+ORIGIN="$S/origin.git"; WORK="$S/work"
+git init -q --bare "$ORIGIN"
+git init -q -b main "$WORK"
+gitq "$WORK" remote add origin "$ORIGIN"
+echo one > "$WORK/f"; gitq "$WORK" add f; gitq "$WORK" commit -m base
+gitq "$WORK" push -u origin main
+gitq "$WORK" checkout -b claude/work
+echo two >> "$WORK/f"; gitq "$WORK" add f; gitq "$WORK" commit -m work
+gitq "$WORK" push -u origin claude/work
+
+TP="$HOOKS/fixtures/friction-calm.jsonl"
+SID=stopcont-0000-1111-2222
+CKPT=""
+stop() {  # stop -- run the hook and set $CKPT to the checkpoint it wrote
+  printf '{"transcript_path":"%s","session_id":"%s","cwd":"%s"}' "$TP" "$SID" "$WORK" \
+    | bash "$HOOK" >/dev/null 2>&1
+  CKPT=$(ls "$AUTO"/*"${SID:0:8}".md 2>/dev/null | head -1)
+}
+verdict() { sed -n 's/^\*\*Verdict:\*\* //p' "$CKPT" | head -1; }
+
+assert() { local m=$1; shift; if "$@"; then pass=$((pass + 1)); else fail=$((fail + 1)); echo "FAIL: $m"; fi; }
+eq() { assert "$1: expected [$2], got [$3]" test "$2" = "$3"; }
+has() { assert "$1: /$2/ in $3" grep -qE "$2" "$3"; }
+
+# --- everything in order: archivable --------------------------------------------
+GH_PRS='[{"url":"https://github.com/o/r/pull/7"}]' stop
+assert 'a checkpoint was written' test -n "$CKPT"
+eq 'clean, pushed, PR: archivable' 'archivable' "$(verdict)"
+eq 'the metrics record says the same' 'archivable' \
+  "$(jq -r .verdict "$HOME/.claude/state/global/metrics/sessions/$SID.json")"
+has 'the worktree is recorded for resume-list' "^- worktree .$WORK.$" "$CKPT"
+
+# --- no PR and no pointer --------------------------------------------------------
+stop
+has 'no home is named' '^\*\*Verdict:\*\* not archivable: no PR and no pointer' "$CKPT"
+
+# --- a dirty worktree, and unpushed commits, named in the contract's order ---------
+echo three >> "$WORK/f"
+gitq "$WORK" add f; gitq "$WORK" commit -m unpushed
+echo four >> "$WORK/f"
+GH_PRS='[{"url":"https://github.com/o/r/pull/7"}]' stop
+eq 'dirty before unpushed' 'not archivable: worktree dirty, 1 commit(s) unpushed' "$(verdict)"
+gitq "$WORK" checkout -- f
+gitq "$WORK" push
+
+# --- "cannot verify" is never a pass ------------------------------------------------
+GH_FAIL=1 stop
+has 'unverified is not archivable' '^\*\*Verdict:\*\* not archivable: branch home unverified' "$CKPT"
+
+# --- a resume block survives the rewrite ---------------------------------------------
+GH_PRS='[{"url":"https://github.com/o/r/pull/7"}]' stop
+printf '\n## Resume\n\n- next: Finish the resume-list fixtures\n- link: o/r#7\n- model: opus\n- effort: high\n' >> "$CKPT"
+GH_PRS='[{"url":"https://github.com/o/r/pull/7"}]' stop
+has 'the heading survives' '^## Resume$' "$CKPT"
+has 'next survives' '^- next: Finish the resume-list fixtures$' "$CKPT"
+has 'effort survives' '^- effort: high$' "$CKPT"
+eq 'exactly one resume block' 1 "$(grep -c '^## Resume$' "$CKPT")"
+eq 'exactly one verdict line' 1 "$(grep -c '^\*\*Verdict:\*\* ' "$CKPT")"
+assert 'the block did not swallow the rest of the file' grep -q '^## Commits this session$' "$CKPT"
+
+# --- and so does a consumed marker, so the record of who took it stays --------------
+sed -i 's/^- effort: high$/&\n- consumed: session abcd1234 at 2026-09-09T13:00:00Z/' "$CKPT"
+GH_PRS='[{"url":"https://github.com/o/r/pull/7"}]' stop
+has 'consumed marker survives' '^- consumed: session abcd1234' "$CKPT"
+
+printf '%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/.claude/skills/resume/SKILL.md
+++ b/.claude/skills/resume/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: resume
+description: Pick up a session where an earlier one left it, from the resume block that session wrote into its own checkpoint. Use when Solace says "resume", "/resume", "/resume <branch>", "pick up where we left off", or opens a session meaning to continue work rather than choose new work.
+---
+
+# Resume
+
+Thin by design. `resume-list` holds the parsing, the drop rules and the
+table; this skill picks a row and starts.
+
+A session opened this way starts **from the block, not from `worklist`**.
+Don't run `worklist`, don't survey the project, don't re-derive what to do:
+the previous session already decided, and re-deciding is the cost this exists
+to avoid.
+
+## 1. Read the list
+
+Run `~/.local/bin/resume-list`.
+
+- **No rows** — say so in one line and stop. There is nothing to resume;
+  `worklist` is the tool for choosing new work, and Solace will ask for it.
+- **One row** — take it.
+- **Several** — if Solace named a branch (`/resume <branch>`), take that row.
+  Otherwise print the table and ask for a one-line pick. That is the one
+  question this skill is allowed to ask.
+
+## 2. Restate it, in three lines
+
+Before touching anything, three lines and no more:
+
+```
+Resuming <branch> (<repo>) — <the block's next step, verbatim>
+<the link the block names>
+Model: <model> · Effort: <effort>
+```
+
+The block's `model` and `effort` are the *previous* session's
+recommendation for this work. If the running session is on something else,
+say so in one line — never silently.
+
+Then read the link — the PR, issue or card — for live state. The block
+names where the work is; it does not carry its state, which is stale the
+moment it is written.
+
+## 3. Mark it consumed
+
+Do this **as you start**, not at the end: a session that dies mid-work
+should not hand the same block to the next one as if nothing happened, and a
+block still listed after two sessions took it is worse than none.
+
+`resume-list --files` prints `<branch><TAB><checkpoint path>`. In the chosen
+branch's checkpoint, append one line inside the `## Resume` block:
+
+```
+- consumed: session <this session id, 8 chars> at <UTC timestamp>
+```
+
+`resume-list` drops it from then on. The Stop hook carries the whole block,
+consumed line included, into every later rewrite of that checkpoint, so it
+stays as a record of who took it.
+
+## 4. Then work
+
+Nothing else belongs to this skill. Blocks are dropped on their own when the
+branch goes level with the default branch or its PR merges, so there is no
+tidying to do.
+
+## Writing a block
+
+The other half, for a session that is *leaving* work: write the block into
+**your own** checkpoint — `state/global/log/auto/<date>-<repo>-<id>.md` — when
+the Stop nag blocks once, or when Solace says "update resume". Four lines,
+house hand-off spec, under a `## Resume` heading:
+
+```
+## Resume
+
+- next: <one sentence, imperative, what the next session does first>
+- link: <the branch, PR, issue or card it acts on>
+- model: <opus | sonnet | haiku>
+- effort: <low | medium | high>
+```
+
+One block per checkpoint; the newest replaces. `next` is a step, not a
+status — "add the fixture for a consumed block", never "resume-list is
+half done". No state adjectives: the link carries state, live, at the other
+end.
+
+This is not a wrap-up. A block costs four lines; `/wrapup` costs a log, a
+sweep and a prompt, and is for a session holding something no issue, PR or
+card carries. If the checkpoint's verdict line says `archivable`, a block is
+usually all that is wanted, and often not even that.

--- a/.claude/skills/worklist/SKILL.md
+++ b/.claude/skills/worklist/SKILL.md
@@ -36,6 +36,9 @@ otherwise, with a `+N more` row past the cap. Needs ruling and Board stay
 plain bullets — they're prose cards, not tabular data:
 
 ```
+Resume                    unconsumed resume blocks, newest first, from
+                          `resume-list` — a session with one starts there
+                          and reads no further
 Solace's turn             PRs ready for her: not draft, mergeable, checks
                           green, no unresolved threads, no auto-merge
                           (failing check names printed in Notes, never a

--- a/.claude/skills/wrapup/SKILL.md
+++ b/.claude/skills/wrapup/SKILL.md
@@ -11,6 +11,26 @@ repo — every Stop, unprompted. Don't redo any of that by hand and don't wait
 to be asked. This skill covers what only you can write: what the session
 meant, what is still open, and how the next one starts.
 
+## 0. Should this session wrap up at all
+
+Check first, every time. A wrap-up costs a log, a sweep and a prompt, and it
+was being paid every session — including sessions whose work already had a
+home, where all it produced was a second copy of what GitHub held.
+
+Read the verdict line at the top of this session's auto-checkpoint
+(`state/global/log/auto/<date>-<repo>-<id>.md`, written by the Stop hook):
+
+- **`archivable`** — the branch has a PR or a pointer, the worktree is clean,
+  nothing is unpushed, the state repo pushed — **and** every open loop has a
+  home (an issue, a PR or a card): say so in one line, name where the work
+  lives, and **stop**. No log, no hand-off prompt. Archivable means archive.
+- **`not archivable: <reasons>`**, or a loop with no home: continue below.
+  The reasons name what to fix; fixing them is usually cheaper than the
+  wrap-up and sometimes turns it into an archive.
+
+If the session's only remaining need is "the next session should start here",
+that is a resume block (`/resume`, four lines), not a wrap-up.
+
 ## 1. Where state lands
 
 Session state lives in the private repo `~/claude_prompts_scratch`, under
@@ -51,8 +71,23 @@ format: `/card-write`.
 
 ## 4. Hand-off prompt
 
-When the session ends with work still to do, write the prompt that starts
-the next one. It must:
+**Look for the home first.** Before writing anything, find the PR or issue
+that already carries this work — the PR on the branch, the issue the session
+was working, the card that pointed at it. If there is one:
+
+- the hand-off is one line, `continue <link>`, and nothing else. A fresh
+  prompt restating what the PR body and the issue already say is a second
+  copy of both, and the copies drift;
+- what the session *learned* — what was tried and abandoned, what the next
+  reader would otherwise redo — goes as a **comment on that PR or issue**,
+  where the person who picks it up is already looking. Not in a prompt they
+  would have to be handed separately.
+
+A fresh prompt is for work with **no home**: nothing on GitHub carries it. If
+that is the case, ask why not first — a pointer card or an issue is usually
+the right artefact, and then the hand-off is `continue <link>` again.
+
+When you do write one, it must:
 
 - be **ready to paste** — no "as discussed", no context the reader has to
   supply;

--- a/.local/bin/cloud-session-setup.sh
+++ b/.local/bin/cloud-session-setup.sh
@@ -58,6 +58,7 @@ INSTALL="
 .claude/skills/wrapup/SKILL.md
 .claude/skills/worklist/SKILL.md
 .claude/skills/sweep/SKILL.md
+.claude/skills/resume/SKILL.md
 .claude/hooks/lib-state.sh
 .claude/hooks/session-metrics.jq
 .claude/hooks/lib-metrics-fmt.jq
@@ -91,6 +92,7 @@ INSTALL="
 .local/bin/metrics-preview.sh
 .local/bin/prose-budget
 .local/bin/worklist
+.local/bin/resume-list
 "
 
 # --- what is wholly owned by this installer -------------------------------

--- a/.local/bin/resume-list
+++ b/.local/bin/resume-list
@@ -93,8 +93,10 @@ cut80() { if [ "$brief" = 1 ]; then printf '%s' "$1" | cut -c1-77; else printf '
 
 # --- collect ---------------------------------------------------------------
 # One record per line: mtime<TAB>path<TAB>branch<TAB>next<TAB>model<TAB>effort
-#   <TAB>repo<TAB>worktree<TAB>note
-tab=$(printf '\t')
+# One record per line, US-separated: mtime path branch next model effort
+#   repo worktree note
+# two adjacent separators into one and shift every later column.
+sep=$(printf '\037')
 recs=""
 for f in "$auto"/*.md; do
   [ -f "$f" ] || continue
@@ -140,7 +142,7 @@ for f in "$auto"/*.md; do
   fi
   [ "$drop" = 1 ] && continue
 
-  recs="$recs$(mtime "$f")$tab$f$tab$branch$tab$next$tab$(field "$f" model)$tab$(field "$f" effort)$tab$repo$tab${work:-?}$tab$note
+  recs="$recs$(mtime "$f")$sep$f$sep$branch$sep$next$sep$(field "$f" model)$sep$(field "$f" effort)$sep$repo$sep${work:-?}$sep$note
 "
 done
 
@@ -153,7 +155,7 @@ if [ -z "$recs" ]; then
 fi
 
 if [ "$files" = 1 ]; then
-  printf '%s\n' "$recs" | awk -F'\t' -v OFS='\t' '{print $3, $2}'
+  printf '%s\n' "$recs" | awk -F "$sep" -v OFS='\t' '{print $3, $2}'
   exit 0
 fi
 
@@ -161,7 +163,7 @@ total=$(printf '%s\n' "$recs" | grep -c '^')
 limit=8; [ "$brief" = 1 ] && limit=5
 printf 'Resume, showing %s of %s\n\n' "$( [ "$total" -gt "$limit" ] && echo "$limit" || echo "$total" )" "$total"
 printf '| Branch | Next step | Age | Model | Notes |\n|---|---|---|---|---|\n'
-printf '%s\n' "$recs" | head -n "$limit" | while IFS="$tab" read -r mt _path branch next model effort repo work note; do
+printf '%s\n' "$recs" | head -n "$limit" | while IFS="$sep" read -r mt _path branch next model effort repo work note; do
   m=$model
   [ -n "$effort" ] && m="${m:+$m · }$effort"
   notes="$repo"

--- a/.local/bin/resume-list
+++ b/.local/bin/resume-list
@@ -1,0 +1,174 @@
+#!/bin/sh
+# resume-list -- the unconsumed resume blocks across every session's
+# auto-checkpoint, newest first.
+#
+# Why: sessions were being wrapped up every time, because a hand-off prompt in
+# a chat is gone the moment the chat is. The Stop hook already writes one
+# checkpoint per session; a resume block is four lines the *model* writes into
+# its own checkpoint saying what the next session should do. This is the view
+# over them. Ruled 2026-09-09 (Solace): resume from a per-session block, never
+# a single pointer file, because parallel sessions in one repo are normal --
+# one file per session is also why two of them never conflict on push.
+#
+#   resume-list [--brief] [--files]
+#
+# Read-only, always. Marking a block consumed is an edit to the checkpoint and
+# belongs to /resume, not here; --files prints the paths so it can do that.
+#
+# A block is shown until one of three things is true:
+#   - a session resumed it (a `- consumed:` line in the block);
+#   - its branch has no commits ahead of the default branch;
+#   - its PR is merged.
+# Anything that cannot be checked -- the worktree is gone, gh is absent or
+# unauthenticated -- keeps its row and says so in Notes. Dropping a block
+# because we could not look is how work gets lost, which is the thing this
+# exists to stop.
+#
+# CONVENIENCE: exit 0 always.
+set -u
+
+usage() { printf 'usage: resume-list [--brief] [--files]\n'; }
+
+brief=0; files=0
+while [ $# -gt 0 ]; do
+  case $1 in
+    --brief) brief=1 ;;
+    --files) files=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) printf 'resume-list: unknown option %s\n' "$1" >&2; usage >&2; exit 2 ;;
+  esac
+  shift
+done
+
+self=$0
+case $self in */*) ;; *) self=$(command -v "$self" 2>/dev/null || printf '%s' "$self") ;; esac
+self_dir=$(cd "$(dirname "$self")" 2>/dev/null && pwd)
+
+# The state dir is lib-state.sh's answer, never a guess: every hook that
+# writes a checkpoint asks the same function, so a machine without the private
+# repo degrades identically here.
+lib=""
+for c in "$self_dir/../../.claude/hooks/lib-state.sh" "$HOME/.claude/hooks/lib-state.sh"; do
+  [ -f "$c" ] && { lib=$c; break; }
+done
+if [ -z "$lib" ]; then
+  [ "$files" = 1 ] || printf 'Resume: unavailable (lib-state.sh not found)\n'
+  exit 0
+fi
+# shellcheck disable=SC1090
+. "$lib"
+auto="$(state_dir)/log/auto"
+if [ ! -d "$auto" ]; then
+  [ "$files" = 1 ] || printf 'Resume: none\n'
+  exit 0
+fi
+
+have_gh=1; command -v gh >/dev/null 2>&1 || have_gh=0
+now=$(date +%s)
+
+# Portable mtime: GNU stat, then BSD stat. A machine with neither prints the
+# row with an unknown age rather than losing it.
+mtime() { stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null || printf ''; }
+
+# Age as one short token: 4m, 3h, 6d.
+age_of() {
+  [ -n "$1" ] || { printf '?'; return; }
+  s=$((now - $1))
+  [ "$s" -lt 0 ] && s=0
+  if [ "$s" -lt 3600 ]; then printf '%dm' $((s / 60))
+  elif [ "$s" -lt 172800 ]; then printf '%dh' $((s / 3600))
+  else printf '%dd' $((s / 86400)); fi
+}
+
+field() {  # field <file> <name> -- the value of "- <name>: ..." inside ## Resume
+  awk -v k="$2" '
+    /^## Resume[[:space:]]*$/ { f = 1; next }
+    f && /^## / { exit }
+    f && index($0, "- " k ":") == 1 { print substr($0, length(k) + 4); exit }
+  ' "$1" 2>/dev/null | sed 's/^[[:space:]]*//; s/[[:space:]]*$//'
+}
+
+esc() { printf '%s' "$1" | sed 's/|/\\|/g'; }
+cut80() { if [ "$brief" = 1 ]; then printf '%s' "$1" | cut -c1-77; else printf '%s' "$1"; fi; }
+
+# --- collect ---------------------------------------------------------------
+# One record per line: mtime<TAB>path<TAB>branch<TAB>next<TAB>model<TAB>effort
+#   <TAB>repo<TAB>worktree<TAB>note
+tab=$(printf '\t')
+recs=""
+for f in "$auto"/*.md; do
+  [ -f "$f" ] || continue
+  next=$(field "$f" next)
+  [ -n "$next" ] || continue                       # no block in this checkpoint
+  [ -n "$(field "$f" consumed)" ] && continue      # a session already took it
+
+  branch=$(sed -n '1s/.*@ `\(.*\)`.*/\1/p' "$f" 2>/dev/null)
+  repo=$(sed -n '1s/^# Auto-checkpoint — \(.*\) @ .*/\1/p' "$f" 2>/dev/null)
+  [ -n "$branch" ] || branch="?"
+  [ -n "$repo" ] || repo="?"
+  work=$(sed -n 's/^- worktree `\(.*\)`$/\1/p' "$f" 2>/dev/null | head -1)
+
+  note=""
+  drop=0
+  if [ -n "$work" ] && [ -d "$work" ]; then
+    base=""
+    for cand in "$(git -C "$work" symbolic-ref -q --short refs/remotes/origin/HEAD 2>/dev/null)" \
+                origin/main origin/master; do
+      [ -n "$cand" ] || continue
+      git -C "$work" rev-parse --verify -q "$cand" >/dev/null 2>&1 && { base=$cand; break; }
+    done
+    if [ -n "$base" ]; then
+      ahead=$(git -C "$work" rev-list --count "$base..$branch" 2>/dev/null || printf '')
+      case "${ahead:-}" in
+        0) drop=1 ;;                               # nothing ahead: landed or empty
+        '') note="branch not found in the worktree" ;;
+      esac
+    else
+      note="no default branch to compare against"
+    fi
+    if [ "$drop" = 0 ] && [ "$have_gh" = 1 ]; then
+      if st=$( (cd "$work" && gh pr list --head "$branch" --state merged --limit 1 --json number) 2>/dev/null ); then
+        case "$st" in ''|'[]') ;; *) drop=1 ;; esac   # its PR merged
+      else
+        note="${note:+$note; }PR state unverified (gh)"
+      fi
+    elif [ "$drop" = 0 ]; then
+      note="${note:+$note; }PR state unverified (no gh)"
+    fi
+  else
+    note="worktree gone"
+  fi
+  [ "$drop" = 1 ] && continue
+
+  recs="$recs$(mtime "$f")$tab$f$tab$branch$tab$next$tab$(field "$f" model)$tab$(field "$f" effort)$tab$repo$tab${work:-?}$tab$note
+"
+done
+
+recs=$(printf '%s' "$recs" | grep -v '^$' | sort -rn)
+
+# --- render ----------------------------------------------------------------
+if [ -z "$recs" ]; then
+  [ "$files" = 1 ] || printf 'Resume: none\n'
+  exit 0
+fi
+
+if [ "$files" = 1 ]; then
+  printf '%s\n' "$recs" | awk -F'\t' -v OFS='\t' '{print $3, $2}'
+  exit 0
+fi
+
+total=$(printf '%s\n' "$recs" | grep -c '^')
+limit=8; [ "$brief" = 1 ] && limit=5
+printf 'Resume, showing %s of %s\n\n' "$( [ "$total" -gt "$limit" ] && echo "$limit" || echo "$total" )" "$total"
+printf '| Branch | Next step | Age | Model | Notes |\n|---|---|---|---|---|\n'
+printf '%s\n' "$recs" | head -n "$limit" | while IFS="$tab" read -r mt _path branch next model effort repo work note; do
+  m=$model
+  [ -n "$effort" ] && m="${m:+$m · }$effort"
+  notes="$repo"
+  [ "$work" != "?" ] && notes="$notes · $work"
+  [ -n "$note" ] && notes="$notes · $note"
+  printf '| `%s` | %s | %s | %s | %s |\n' \
+    "$(esc "$branch")" "$(esc "$(cut80 "$next")")" "$(age_of "$mt")" "$(esc "${m:-?}")" "$(esc "$notes")"
+done
+[ "$total" -gt "$limit" ] && printf '| +%s more | | | | run `resume-list` |\n' $((total - limit))
+exit 0

--- a/.local/bin/resume-list
+++ b/.local/bin/resume-list
@@ -92,10 +92,10 @@ esc() { printf '%s' "$1" | sed 's/|/\\|/g'; }
 cut80() { if [ "$brief" = 1 ]; then printf '%s' "$1" | cut -c1-77; else printf '%s' "$1"; fi; }
 
 # --- collect ---------------------------------------------------------------
-# One record per line: mtime<TAB>path<TAB>branch<TAB>next<TAB>model<TAB>effort
-# One record per line, US-separated: mtime path branch next model effort
-#   repo worktree note
-# two adjacent separators into one and shift every later column.
+# One record per line, unit-separator (\037) delimited: mtime path branch
+# next model effort repo worktree note. Not a tab: tab is IFS whitespace, so
+# `read` would collapse an empty field's two adjacent separators into one and
+# shift every later column.
 sep=$(printf '\037')
 recs=""
 for f in "$auto"/*.md; do

--- a/.local/bin/resume-list.test.sh
+++ b/.local/bin/resume-list.test.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Tests for resume-list. Run: bash .local/bin/resume-list.test.sh
+# Set AWK_PATH to a directory whose `awk` is another implementation to run the
+# same cases under it; CI does this for each.
+#
+# What matters: zero, one and two blocks each render right; a consumed block is
+# gone; a block whose branch is level with main or whose PR merged is dropped;
+# a block that cannot be checked is KEPT and says why, because dropping what we
+# could not look at is exactly how work gets lost; newest first; --files gives
+# /resume the paths it needs to mark one consumed.
+set -uo pipefail
+[ -n "${AWK_PATH:-}" ] && PATH="$AWK_PATH:$PATH"
+
+RL="$(cd "$(dirname "$0")" && pwd)/resume-list"
+pass=0; fail=0
+S=$(mktemp -d); trap 'rm -rf "$S"' EXIT
+export HOME="$S/home"; mkdir -p "$HOME"
+export TMPDIR="$S/tmp"; mkdir -p "$TMPDIR"
+export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1
+
+SR="$S/state"; AUTO="$SR/state/global/log/auto"
+mkdir -p "$AUTO" "$SR/.git"
+export CLAUDE_STATE_REPO="$SR"
+
+gitq() { git -C "$1" -c user.name=t -c user.email=t@example.invalid -c commit.gpgsign=false "${@:2}" >/dev/null 2>&1; }
+
+# --- a fake gh: GH_MERGED lists the branches whose PR is merged --------------
+BIN="$S/bin"; mkdir -p "$BIN"
+cat > "$BIN/gh" <<'EOF'
+#!/bin/sh
+[ "${GH_FAIL:-0}" = 1 ] && { echo "gh: not logged in" >&2; exit 1; }
+b=""
+while [ $# -gt 0 ]; do [ "$1" = --head ] && { shift; b=$1; }; shift; done
+for m in ${GH_MERGED:-}; do [ "$m" = "$b" ] && { echo '[{"number":1}]'; exit 0; }; done
+echo '[]'
+EOF
+chmod +x "$BIN/gh"
+export PATH="$BIN:$PATH"
+
+# --- a work repo with a main and some branches -------------------------------
+ORIGIN="$S/origin.git"; WORK="$S/work"
+git init -q --bare "$ORIGIN"
+git init -q -b main "$WORK"
+gitq "$WORK" remote add origin "$ORIGIN"
+echo one > "$WORK/f"; gitq "$WORK" add f; gitq "$WORK" commit -m base
+gitq "$WORK" push -u origin main
+for b in claude/alpha claude/beta claude/merged; do
+  gitq "$WORK" checkout -b "$b" main
+  echo "$b" >> "$WORK/f"; gitq "$WORK" add f; gitq "$WORK" commit -m "$b"
+done
+gitq "$WORK" checkout -b claude/level main        # level with main: nothing ahead
+gitq "$WORK" checkout main
+
+# --- fixtures ----------------------------------------------------------------
+# ckpt <slug> <branch> <worktree> <next> [consumed]
+ckpt() {
+  local f="$AUTO/2026-09-09-demo-$1.md"
+  {
+    printf '# Auto-checkpoint — demo @ `%s`\n\n' "$2"
+    printf '**Verdict:** not archivable: worktree dirty\n\n'
+    printf -- '- worktree `%s`\n' "$3"
+    printf -- '- session `%s` · opus · started 2026-09-09T00:00:00Z\n\n' "$1"
+    printf '## Resume\n\n'
+    printf -- '- next: %s\n' "$4"
+    printf -- '- link: https://github.com/o/demo/pull/1\n'
+    printf -- '- model: opus\n'
+    printf -- '- effort: high\n'
+    [ -n "${5:-}" ] && printf -- '- consumed: %s\n' "$5"
+    printf '\n## Commits this session\n\n- none\n'
+  } > "$f"
+  printf '%s' "$f"
+}
+# A checkpoint with no resume block at all: must never appear.
+printf '# Auto-checkpoint — demo @ `claude/nothing`\n\n**Verdict:** archivable\n\n- worktree `%s`\n' \
+  "$WORK" > "$AUTO/2026-09-09-demo-none.md"
+
+run() { OUT=$("$RL" "$@" 2>&1); RC=$?; }
+assert() { local m=$1; shift; if "$@"; then pass=$((pass + 1)); else fail=$((fail + 1)); echo "FAIL: $m"; fi; }
+has()  { assert "$1: /$2/ in output" grep -qE "$2" <<<"$OUT" || printf '%s\n' "$OUT" | sed 's/^/    /'; }
+hasnt() { assert "$1: /$2/ absent" bash -c '! grep -qE "$1" <<<"$2"' _ "$2" "$OUT"; }
+eq()   { assert "$1: expected $2, got $3" test "$2" = "$3"; }
+
+# --- zero blocks --------------------------------------------------------------
+run
+eq 'exit 0' 0 "$RC"
+eq 'zero blocks prints none' 'Resume: none' "$OUT"
+
+# --- one block ----------------------------------------------------------------
+A=$(ckpt alpha claude/alpha "$WORK" "Wire the verdict into the checkpoint")
+touch -t 202609090800 "$A"
+run
+has 'one row counted' '^Resume, showing 1 of 1$'
+has 'table header' '^\| Branch \| Next step \| Age \| Model \| Notes \|$'
+has 'branch cell' '\| `claude/alpha` \|'
+has 'next step' 'Wire the verdict into the checkpoint'
+has 'model and effort' 'opus · high'
+has 'repo and worktree in notes' "demo · $WORK"
+
+# --- two blocks, newest first --------------------------------------------------
+B=$(ckpt beta claude/beta "$WORK" "Write the resume-list fixtures")
+touch -t 202609091200 "$B"
+run
+has 'two rows counted' '^Resume, showing 2 of 2$'
+eq 'newest first' 'claude/beta' \
+  "$(grep -o '`claude/[a-z]*`' <<<"$OUT" | head -1 | tr -d '`')"
+
+# --- a consumed block is gone ----------------------------------------------------
+ckpt beta claude/beta "$WORK" "Write the resume-list fixtures" \
+  "session abcd1234 at 2026-09-09T13:00:00Z" >/dev/null
+run
+has 'consumed block dropped' '^Resume, showing 1 of 1$'
+hasnt 'consumed branch absent' 'claude/beta'
+
+# --- level with main, and a merged PR, are both dropped ---------------------------
+L=$(ckpt level claude/level "$WORK" "Nothing left ahead of main")
+M=$(ckpt merged claude/merged "$WORK" "Its PR already merged")
+GH_MERGED="claude/merged" run
+hasnt 'branch level with main dropped' 'claude/level'
+hasnt 'merged PR dropped' 'claude/merged'
+has 'the live one survives' 'claude/alpha'
+rm -f "$L" "$M"
+
+# --- what cannot be checked is kept, and says so -----------------------------------
+G=$(ckpt gone claude/gone "$S/not-here" "Worktree was thrown away")
+run
+has 'missing worktree kept' 'claude/gone'
+has 'and named' 'worktree gone'
+rm -f "$G"
+
+GH_FAIL=1 run
+has 'gh failure keeps the row' 'claude/alpha'
+has 'and names it' 'PR state unverified \(gh\)'
+
+# --- --brief caps and cuts ----------------------------------------------------------
+long="A next step written well past the eighty character mark so that brief output has to cut it somewhere sensible"
+P=$(ckpt long claude/alpha "$WORK" "$long")
+run --brief
+assert 'brief cuts the next step' test "$(grep -c "$long" <<<"$OUT")" -eq 0
+run
+has 'full output does not cut' "$long"
+rm -f "$P"
+
+# --- --files gives /resume the path --------------------------------------------------
+run --files
+eq 'files: one line per block' 1 "$(grep -c '^' <<<"$OUT")"
+has 'files: branch then path' "^claude/alpha	$AUTO/"
+eq 'files: silent when empty' '' "$(rm -f "$A"; "$RL" --files)"
+
+printf '%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/.local/bin/worklist
+++ b/.local/bin/worklist
@@ -323,6 +323,19 @@ board_path() {
 
 count_lines() { [ -n "$1" ] || { echo 0; return; }; printf '%s\n' "$1" | grep -c '^'; }
 
+# resume_section -- the unconsumed resume blocks, printed first because a
+# session that has one starts from it and never reads the rest of this view
+# (dotfiles#110). The table is resume-list's, not rebuilt here: one home for
+# the parsing and the drop rules.
+resume_section() {
+  rl=""
+  for c in "$self_dir/resume-list" "$HOME/.local/bin/resume-list"; do
+    [ -x "$c" ] && { rl=$c; break; }
+  done
+  [ -n "$rl" ] || { printf 'Resume: unavailable (resume-list not found)\n'; return 0; }
+  if [ "$brief" = 1 ]; then sh "$rl" --brief; else sh "$rl"; fi
+}
+
 # Pushed branches with no open PR, one repo object per record, each carrying
 # its candidate branch names and its open issues' title+body (for the
 # pointer check below).
@@ -442,6 +455,9 @@ render() {
     fi
     echo "$stamp"
     [ -n "$3" ] && echo "$3"
+    echo
+    resume_section
+    echo
     if [ -n "$1" ]; then
       # The buckets come out of jq in one piece with a @@RULINGS@@ marker in
       # them; the rulings are spliced in here rather than by awk, because a

--- a/.local/bin/worklist.test.sh
+++ b/.local/bin/worklist.test.sh
@@ -335,5 +335,18 @@ cd "$S/repo" || exit 1
 # --- board edge: no kanban ------------------------------------------------------------------
 mv "$S/state/state/global/kanban.md" "$S/kb.bak"; run; has 'missing board named' '^Board: no kanban.md at'; mv "$S/kb.bak" "$S/state/state/global/kanban.md"
 
+# --- the resume bucket is first (dotfiles#110) ------------------------------------
+run
+has 'resume bucket present' '^Resume: none$'
+eq 'resume is the first bucket' 'Resume: none' \
+  "$(printf '%s\n' "$OUT" | grep -nE '^(Resume|Needs ruling|Solace|Queued|Ready|Blocked|Untriaged|Stranded)' | head -1 | cut -d: -f2-)"
+mkdir -p "$S/state/state/global/log/auto"
+{ printf '# Auto-checkpoint — alpha @ `claude/x`\n\n**Verdict:** archivable\n\n- worktree `%s`\n\n' "$S/repo"
+  printf '## Resume\n\n- next: Finish the thing\n- link: o/alpha#10\n- model: opus\n- effort: high\n'
+} > "$S/state/state/global/log/auto/2026-09-09-alpha-abcd1234.md"
+run
+has 'a real block shows in worklist' '\| `claude/x` \| Finish the thing \|'
+rm -rf "$S/state/state/global/log"
+
 printf '%d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
Closes #110

## What landed

**Verdict.** `stop-continuity.sh` writes `**Verdict:** archivable` or
`**Verdict:** not archivable: <reasons>` as the first line of every
auto-checkpoint, and the same string as `.verdict` in the session's metrics
record. Reasons are comma-separated in the contract's order: no PR/pointer,
worktree dirty, N unpushed, state-repo push failed.

Two implementation notes worth a reviewer's eye:

- The "has a home" test is not reimplemented here. `branch-home-gate.sh` gets
  a second, read-only entry point — `branch-home-gate.sh --check [dir]` —
  which prints `home: <why>` / `none` / `unverified: <why>` and never blocks.
  The verdict and the #108 gate therefore cannot drift apart on what counts
  as a home, and "could not verify" is not a pass in either.
- The verdict is computed *after* the salvage commit (so a session this hook
  just committed and pushed does not read as "dirty, unpushed") and rewritten
  once more if the state-repo push fails. It goes into the file as a refusal
  first, so a Stop that dies midway leaves the truth rather than a stale
  `archivable`.

**Resume blocks.** The hook rewrites the whole checkpoint on every Stop, so
the block a *model* writes is now lifted out of the old copy and put back
verbatim — including the `- consumed:` marker. Without this the next Stop
silently ate the hand-off, which is the one failure mode that would have made
the whole feature look like it worked.

**`resume-list`.** New POSIX-sh script in `.local/bin`, read-only, shaped
like `worklist`. Prints unconsumed blocks newest first as
`Branch | Next step | Age | Model | Notes`, repo and worktree in Notes. A
block is dropped when a session consumed it, its branch is level with the
default branch, or its PR merged. Anything that cannot be checked (worktree
gone, `gh` missing or unauthenticated) **keeps its row and says why** —
dropping what we could not look at is how work gets lost. `--files` gives
`/resume` the checkpoint paths; `worklist` prints the table as its first
bucket by calling the script.

**`/resume`** and **`/wrapup` steps 0 and 4** as specified.

`.claude/skills/resume/SKILL.md` and `.local/bin/resume-list` are both in the
`INSTALL` list of `cloud-session-setup.sh`. No new hook script, so
hook-seed-check is unaffected — the two hooks touched were already seeded.

## Verification

Automated (`.local/bin/resume-list.test.sh`, 24 assertions;
`.claude/hooks/stop-continuity.test.sh`, 14; plus 3 new in
`worklist.test.sh`), run under mawk and gawk locally, all three awks in CI:

- zero / one / two blocks, and a consumed one — the fixtures the issue names;
- newest-first ordering; a checkpoint with no block never appears;
- a branch level with main, and a branch whose PR is merged, are both dropped;
- a missing worktree and a failing `gh` each keep the row and name the reason;
- `archivable` only when clean, pushed, and a PR exists; each reason named, in
  order; "cannot verify" is not a pass;
- a resume block and its consumed marker survive a Stop rewrite, exactly one
  of each, with the rest of the checkpoint intact.

Not automated — these need live multi-session behaviour, and are the issue's
Verification section proper:

- two real sessions in one repo on two branches, both past the Stop nag,
  showing two rows in `resume-list`;
- `/resume <branch>` in a fresh session restating the right one and the row
  disappearing from the next `resume-list` (the mechanism it relies on — the
  consumed marker, and its survival across a Stop — is covered above);
- `/wrapup` actually stopping at step 0 on an `archivable` session. `/wrapup`
  is a prose skill; nothing in this repo executes it.

Also not covered here: the Stop *nag* that triggers writing a block. Per the
issue that belongs to the nags issue, not this one.
