### PR TITLE
grind: INFO/WARN/ERR logging, heartbeat, permission mode; skips fail the run

### DIFF
--- a/.local/bin/grind
+++ b/.local/bin/grind
@@ -37,14 +37,30 @@
 #
 #   grind [--dry-run] [--repo owner/name] [--model <m>] [--effort <e>]
 #         [--item-budget <usd>] [--session-budget <usd>] [--pause-every <n>]
-#         [--resume <session-id>]
+#         [--resume <session-id>] [--heartbeat <seconds>] [--permission-mode <mode>]
+#
+# Output: one INFO line per unit of work started and finished, a heartbeat
+# every --heartbeat seconds (default 60, 0 disables) while a worker runs, WARN
+# for a skipped item, ERR when the run ends with skips (exit 1). The worker
+# gets --permission-mode (default acceptEdits) so it never waits on a
+# terminal; bypassPermissions is the caller's call, not the default.
 set -eu
 
 usage() {
   printf 'usage: grind [--dry-run] [--repo owner/name] [--model <m>] [--effort <e>]\n'
   printf '             [--item-budget <usd>] [--session-budget <usd>] [--pause-every <n>]\n'
-  printf '             [--resume <session-id>]\n'
+  printf '             [--resume <session-id>] [--heartbeat <seconds>] [--permission-mode <mode>]\n'
 }
+
+# Logging. INFO goes to stdout at a low rate: one line per unit of work
+# started or finished, plus a heartbeat while a worker runs. WARN and ERR go
+# to stderr. All three are always on; there is no quiet mode.
+pct() { awk -v a="$1" -v b="$2" 'BEGIN { if (b == 0) { print 0 } else { printf "%.0f", (a / b) * 100 } }'; }
+fmt_usd() { awk -v v="$1" 'BEGIN { printf "$%.2f", v }'; }
+ts()   { date -u +%H:%M:%SZ; }
+info() { printf '%s INFO  %s\n' "$(ts)" "$*"; }
+warn() { printf '%s WARN  %s\n' "$(ts)" "$*" >&2; }
+err()  { printf '%s ERR   %s\n' "$(ts)" "$*" >&2; }
 
 model=sonnet
 effort=medium
@@ -54,6 +70,8 @@ pause_every=3
 dry_run=0
 repo=""
 resume_id=""
+heartbeat=60
+permission_mode=acceptEdits
 
 while [ $# -gt 0 ]; do
   case $1 in
@@ -65,6 +83,8 @@ while [ $# -gt 0 ]; do
     --session-budget) shift; session_budget=${1:-} ;;
     --pause-every) shift; pause_every=${1:-} ;;
     --resume) shift; resume_id=${1:-} ;;
+    --heartbeat) shift; heartbeat=${1:-} ;;
+    --permission-mode) shift; permission_mode=${1:-} ;;
     -h|--help) usage; exit 0 ;;
     -*) printf 'grind: unknown option %s\n' "$1" >&2; usage >&2; exit 2 ;;
     *) printf 'grind: unexpected argument %s\n' "$1" >&2; usage >&2; exit 2 ;;
@@ -153,6 +173,12 @@ if [ "$count" -eq 0 ]; then
   exit 0
 fi
 
+if [ "$dry_run" -eq 0 ]; then
+  info "session $session_id on $repo: $count Ready item(s), $model/$effort, cap $(fmt_usd "$item_budget")/item $(fmt_usd "$session_budget")/session, pause every $pause_every"
+  info "state: $state_file"
+fi
+skipped=0
+
 # --- one worktree per item -----------------------------------------------------
 worktree_root=${TMPDIR:-/tmp}/grind-worktrees
 
@@ -175,8 +201,6 @@ median() {
       if (NR % 2) print a[(NR+1)/2]; else print (a[NR/2]+a[NR/2+1])/2 }'
 }
 
-pct() { awk -v a="$1" -v b="$2" 'BEGIN { if (b == 0) { print 0 } else { printf "%.0f", (a / b) * 100 } }'; }
-fmt_usd() { awk -v v="$1" 'BEGIN { printf "$%.2f", v }'; }
 
 # Seed running_total and costs from prior-run item costs already in
 # $state_file so a --resume honors the original --session-budget as a
@@ -227,18 +251,38 @@ while [ "$i" -lt "$count" ]; do
     continue
   fi
 
+  info "[$i/$count] starting $ref -- $title"
   mkdir -p "$worktree_root"
   git worktree prune >/dev/null 2>&1 || true
   rm -rf "$wt_path"
   git branch -D "$branch" >/dev/null 2>&1 || true
-  git worktree add -q -b "$branch" "$wt_path" >/dev/null 2>&1 \
-    || { printf 'grind: could not create worktree for %s -- skipping\n' "$ref" >&2; continue; }
+  if ! wt_err=$(git worktree add -q -b "$branch" "$wt_path" 2>&1 >/dev/null); then
+    warn "skipping $ref -- could not create worktree $wt_path on branch $branch: $wt_err"
+    skipped=$((skipped + 1))
+    continue
+  fi
+  info "worktree $wt_path on branch $branch"
 
   prompt=$(build_prompt "$(printf '%s' "$item" | jq -r '.body')")
+  started=$(date +%s)
+  info "worker running: claude -p --model $model --effort $effort --max-budget-usd $item_budget --permission-mode $permission_mode (heartbeat every ${heartbeat}s)"
+  hb_pid=""
+  if [ "$heartbeat" -gt 0 ]; then
+    # The sleep child would otherwise outlive the kill and hold stdout open.
+    ( trap 'kill "$sp" 2>/dev/null; exit 0' TERM
+      while :; do
+        sleep "$heartbeat" & sp=$!; wait "$sp" || exit 0
+        info "still working on $ref ($(( ($(date +%s) - started) / 60 ))m elapsed)"
+      done ) &
+    hb_pid=$!
+  fi
   claude_rc=0
   result_json=$( (cd "$wt_path" && printf '%s' "$prompt" | \
-    claude -p --output-format json --max-budget-usd "$item_budget" --model "$model" --effort "$effort") ) \
+    claude -p --output-format json --max-budget-usd "$item_budget" --model "$model" --effort "$effort" \
+      --permission-mode "$permission_mode") ) \
     || claude_rc=$?
+  if [ -n "$hb_pid" ]; then kill "$hb_pid" 2>/dev/null; wait "$hb_pid" 2>/dev/null || true; fi
+  info "worker exited $claude_rc after $(( $(date +%s) - started ))s"
 
   git worktree remove -f "$wt_path" >/dev/null 2>&1 || true
 
@@ -324,4 +368,8 @@ if [ "$dry_run" -eq 1 ]; then
   exit 0
 fi
 
-printf 'done: Ready queue exhausted. Running total %s / %s.\n' "$(fmt_usd "$running_total")" "$(fmt_usd "$session_budget")"
+printf 'done: Ready queue exhausted. Running total %s / %s. %d skipped.\n' "$(fmt_usd "$running_total")" "$(fmt_usd "$session_budget")" "$skipped"
+if [ "$skipped" -gt 0 ]; then
+  err "$skipped item(s) skipped (worktree could not be created); see WARN lines above"
+  exit 1
+fi

--- a/.local/bin/grind
+++ b/.local/bin/grind
@@ -179,6 +179,16 @@ if [ "$dry_run" -eq 0 ]; then
 fi
 skipped=0
 
+# Every way out of the loop goes through here so a skipped item fails the
+# run whether it ended by pause or by exhausting the queue.
+finish() {
+  if [ "$skipped" -gt 0 ]; then
+    err "$skipped item(s) skipped (worktree could not be created); see WARN lines above"
+    exit 1
+  fi
+  exit 0
+}
+
 # --- one worktree per item -----------------------------------------------------
 worktree_root=${TMPDIR:-/tmp}/grind-worktrees
 
@@ -235,7 +245,7 @@ while [ "$i" -lt "$count" ]; do
       printf 'pause: session budget reached (%s / %s). %d item(s) processed this run.\n' \
         "$(fmt_usd "$running_total")" "$(fmt_usd "$session_budget")" "$processed_this_run"
       printf 'resume: %s\n' "$resume_cmd"
-      exit 0
+      finish
     fi
   fi
 
@@ -348,19 +358,19 @@ while [ "$i" -lt "$count" ]; do
     printf 'pause: session budget reached (%s / %s). %d item(s) processed this run.\n' \
       "$(fmt_usd "$running_total")" "$(fmt_usd "$session_budget")" "$processed_this_run"
     printf 'resume: %s\n' "$resume_cmd"
-    exit 0
+    finish
   fi
   if [ "$outlier" -eq 1 ]; then
     printf 'pause: %s cost %s, more than twice the running median (%s). %d item(s) processed this run.\n' \
       "$ref" "$(fmt_usd "$cost")" "$(fmt_usd "$prior_median")" "$processed_this_run"
     printf 'resume: %s\n' "$resume_cmd"
-    exit 0
+    finish
   fi
   if [ "$processed_this_run" -ge "$pause_every" ]; then
     printf 'pause: %d items processed this run (pause every %d). Running total %s / %s.\n' \
       "$processed_this_run" "$pause_every" "$(fmt_usd "$running_total")" "$(fmt_usd "$session_budget")"
     printf 'resume: %s\n' "$resume_cmd"
-    exit 0
+    finish
   fi
 done
 
@@ -369,7 +379,4 @@ if [ "$dry_run" -eq 1 ]; then
 fi
 
 printf 'done: Ready queue exhausted. Running total %s / %s. %d skipped.\n' "$(fmt_usd "$running_total")" "$(fmt_usd "$session_budget")" "$skipped"
-if [ "$skipped" -gt 0 ]; then
-  err "$skipped item(s) skipped (worktree could not be created); see WARN lines above"
-  exit 1
-fi
+finish

--- a/.local/bin/grind.test.sh
+++ b/.local/bin/grind.test.sh
@@ -148,6 +148,13 @@ has 'WARN line for the skip names the item and the branch' 'WARN  skipping o/alp
 has 'the other item still runs' '^o/alpha#20: Second item --'
 has 'tally counts the skip' 'Ready queue exhausted\. .* 1 skipped\.$'
 has 'ERR line at the end' 'ERR   1 item\(s\) skipped'
+
+# same skip, but the run ends on the cadence pause instead of the queue: still exit 1
+rm -f "$S/state/grind"/*.json
+run --session-budget 100 --pause-every 1
+eq 'exit 1 when a skip precedes a pause' 1 "$RC"
+has 'the pause line still prints' '^pause: 1 items processed this run'
+has 'ERR line after the pause' 'ERR   1 item\(s\) skipped'
 git -C "$S/repo" worktree remove -f "$S/wt5" >/dev/null 2>&1; git -C "$S/repo" branch -D grind-5 >/dev/null 2>&1
 
 # --- outlier pause: one item costs more than twice the running median -----------

--- a/.local/bin/grind.test.sh
+++ b/.local/bin/grind.test.sh
@@ -101,7 +101,12 @@ eq 'exit 0' 0 "$RC"
 eq 'two claude invocations' 2 "$(calls_claude)"
 has 'first item line: cost, tokens, running total, percent' '^o/alpha#5: First item -- sonnet, \$1\.00, 150 tokens -- running \$1\.00 / \$20\.00 -- 5%$'
 has 'second item line: running total accumulates' '^o/alpha#20: Second item -- sonnet, \$2\.00, 150 tokens -- running \$3\.00 / \$20\.00 -- 15%$'
-has 'queue exhausted, final tally' '^done: Ready queue exhausted\. Running total \$3\.00 / \$20\.00\.$'
+has 'queue exhausted, final tally' '^done: Ready queue exhausted\. Running total \$3\.00 / \$20\.00\. 0 skipped\.$'
+has 'INFO: session line names repo, count, model, caps' 'INFO  session grind-.* on o/alpha: 2 Ready item\(s\), sonnet/medium, cap \$5\.00/item \$20\.00/session'
+has 'INFO: item start line' 'INFO  \[1/2\] starting o/alpha#5 -- First item'
+has 'INFO: worker line names the permission mode' 'INFO  worker running: .*--permission-mode acceptEdits'
+has 'INFO: worker exit line' 'INFO  worker exited 0 after [0-9]+s'
+has 'worker gets --permission-mode' '--permission-mode acceptEdits' 
 sess=$(latest_session)
 eq 'two items recorded in state' 2 "$(jq '.items | length' "$sess")"
 
@@ -130,6 +135,20 @@ eq 'exit 0' 0 "$RC"
 eq 'no more items to run -- queue already exhausted' 0 "$(calls_claude)"
 has 'says the queue is done' 'Ready queue exhausted'
 eq 'state file unchanged (still 2 items)' 2 "$(jq '.items | length' "$sess")"
+
+# --- a worktree that cannot be created is a WARN, counted, and fails the run ----
+# grind-5 already exists from earlier runs; checking it out elsewhere makes
+# grind's branch -D and worktree add -b both fail for #5.
+git -C "$S/repo" worktree add -q "$S/wt5" grind-5 >/dev/null 2>&1 \
+  || git -C "$S/repo" worktree add -q -b grind-5 "$S/wt5" >/dev/null 2>&1
+rm -f "$S/state/grind"/*.json
+run --session-budget 100 --pause-every 10
+eq 'exit 1 when an item was skipped' 1 "$RC"
+has 'WARN line for the skip names the item and the branch' 'WARN  skipping o/alpha#5 -- could not create worktree .* on branch grind-5'
+has 'the other item still runs' '^o/alpha#20: Second item --'
+has 'tally counts the skip' 'Ready queue exhausted\. .* 1 skipped\.$'
+has 'ERR line at the end' 'ERR   1 item\(s\) skipped'
+git -C "$S/repo" worktree remove -f "$S/wt5" >/dev/null 2>&1; git -C "$S/repo" branch -D grind-5 >/dev/null 2>&1
 
 # --- outlier pause: one item costs more than twice the running median -----------
 rm -f "$S/state/grind"/*.json


### PR DESCRIPTION
First real run of `grind` after #122 looked stalled: one skip line, then silence while the worker sat on an interactive Claude Code prompt.

## What

- **Logging, always on.** INFO to stdout at a low rate: a session line (repo, item count, model, caps), one line per item started, the worktree path and branch, the worker command and its exit, and a heartbeat every `--heartbeat` seconds (default 60, `0` disables) while a worker runs. WARN and ERR go to stderr.
- **No terminal waits.** The worker gets `--permission-mode` (default `acceptEdits`). `bypassPermissions` is available by flag; it is not the default.
- **Skips are failures.** A worktree that cannot be created is a WARN carrying git's reason, is counted, appears in the final tally, and makes the run exit 1 instead of `done ... exit 0`.

## Tests

`grind.test.sh`: 69 pass. New cases cover the INFO lines, the permission-mode flag reaching the worker, and a skipped item (branch checked out elsewhere) producing WARN, the tally count, ERR and exit 1. The heartbeat subshell kills its own `sleep` on TERM so the suite no longer hangs on the captured pipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)