### PR TITLE
Metrics: one sitting clock for the machine, and only 'stop here' blocks

### DIFF
--- a/.claude/hooks/metrics-live.sh
+++ b/.claude/hooks/metrics-live.sh
@@ -45,7 +45,10 @@ SHOW="${3:-}"               # "show" -> also print a systemMessage block
 #             starts at the first one, restarts when the gap between two of
 #             them runs past SIT_GAP_MIN (a session picked up after dinner is
 #             a new sitting, not a nine-hour one), and is never read or moved
-#             by a Stop. 60 min says stand up, 120 says stop here and wrap up
+#             by a Stop. 60 min says stand up, 120 says stop here and wrap up.
+#             The clock itself is machine-wide, not per session -- three open
+#             chats are still one chair -- while the line is reported once per
+#             session, so each chat says it where its user is reading
 #   friction  corrections and rebukes inside a window of human turns; the one
 #             line that goes to the model rather than to the screen, since the
 #             standing orders' capacity rule is what it is asking for
@@ -166,31 +169,74 @@ printf '%s\n' "$metrics" | jq -c \
 NAGF="$LIVE/$sid.nag.json"
 CROSSD="$(state_dir)/metrics/crossings"
 
-ctx_line=0; time_line=0; gate_line=0; fric_tripped=0
-sit_start=0; last_prompt=0; since_nag=0; resume_ts=0; nag_pending=0; late_nagged=0
+# The sitting clock is the one piece of this state that is NOT per session.
+# A person with three chats open is one person in one chair: when the clock
+# lived in the per-session file, every new session started its own clock at
+# zero and a four-hour afternoon spread over four chats never reached the
+# 60-minute line once. So sitting_start and last_prompt live in a single
+# machine-wide file that any session's UserPromptSubmit advances.
+#
+# Per machine, and never a record: it answers "how long has this body been at
+# this box", which does not survive being synced to another host. It is
+# gitignored in the state repo for the same reason last_activity.json was.
+#
+# Two sessions prompting in the same second can clobber each other's write.
+# The loss is bounded by the write being whole-file and atomic -- the reader
+# sees one session's clock or the other's, never a torn one -- and both are
+# writing near-identical values, so it is not worth a lock file that would
+# have to work on a machine without flock.
+SITF="$(state_dir)/metrics/sitting.json"
+
+sit_start=0; last_prompt=0
+if [ -f "$SITF" ]; then
+  IFS=$'\t' read -r sit_start last_prompt \
+    <<<"$(jq -r '[(.sitting_start // 0), (.last_prompt // 0)] | @tsv' "$SITF" 2>/dev/null)"
+fi
+[ -n "$sit_start" ] || sit_start=0
+[ -n "$last_prompt" ] || last_prompt=0
+
+save_sitting() {
+  mkdir -p "$(dirname "$SITF")" 2>/dev/null || return 0
+  jq -n --argjson ss "$sit_start" --argjson lp "$last_prompt" \
+    '{sitting_start: $ss, last_prompt: $lp}' \
+    > "$SITF.$$" 2>/dev/null \
+    && mv -f "$SITF.$$" "$SITF" 2>/dev/null || rm -f "$SITF.$$" 2>/dev/null
+}
+
+# time_line stays per session: the clock is shared, but the report of it is
+# each session's own, so a threshold is spoken once in every chat that is
+# open when it is crossed rather than once on the machine. tl_sitting is the
+# sitting_start that time_line was recorded against -- when the shared clock
+# restarts, every session's line is stale, including the ones that were not
+# the prompt that restarted it, and they must be free to speak again.
+ctx_line=0; time_line=0; tl_sitting=0; gate_line=0; fric_tripped=0
+since_nag=0; resume_ts=0; nag_pending=0; late_nagged=0
 if [ -f "$NAGF" ]; then
-  IFS=$'\t' read -r ctx_line time_line gate_line fric_tripped \
-                    sit_start last_prompt since_nag resume_ts nag_pending late_nagged \
-    <<<"$(jq -r '[(.context_line // 0), (.time_line // 0), (.gate_line // 0),
+  IFS=$'\t' read -r ctx_line time_line tl_sitting gate_line fric_tripped \
+                    since_nag resume_ts nag_pending late_nagged \
+    <<<"$(jq -r '[(.context_line // 0), (.time_line // 0), (.time_line_sitting // -1),
+                  (.gate_line // 0),
                   (if .friction_tripped then 1 else 0 end),
-                  (.sitting_start // 0), (.last_prompt // 0),
                   (if .since_nag then 1 else 0 end),
                   (.resume_ts // 0),
                   (if .nag_pending then 1 else 0 end),
                   (if .late_nagged then 1 else 0 end)] | @tsv' "$NAGF" 2>/dev/null)"
 fi
-for v in ctx_line time_line gate_line fric_tripped sit_start last_prompt \
+for v in ctx_line time_line tl_sitting gate_line fric_tripped \
          since_nag resume_ts nag_pending late_nagged; do
   [ -n "${!v}" ] || eval "$v=0"
 done
+# -1 is a nag file written before the clock moved out of it: its time_line
+# belongs to a sitting nobody can name, so it is spent rather than trusted.
+[ "$tl_sitting" -eq "$sit_start" ] || { time_line=0; tl_sitting=$sit_start; }
 
 save_nag() {
-  jq -n --argjson cl "$ctx_line" --argjson tl "$time_line" --argjson gl "$gate_line" \
-        --argjson ft "$fric_tripped" --argjson ss "$sit_start" --argjson lp "$last_prompt" \
+  jq -n --argjson cl "$ctx_line" --argjson tl "$time_line" --argjson ts "$tl_sitting" \
+        --argjson gl "$gate_line" --argjson ft "$fric_tripped" \
         --argjson sn "$since_nag" --argjson rt "$resume_ts" --argjson np "$nag_pending" \
         --argjson ln "$late_nagged" \
-    '{context_line: $cl, time_line: $tl, gate_line: $gl,
-      friction_tripped: ($ft == 1), sitting_start: $ss, last_prompt: $lp,
+    '{context_line: $cl, time_line: $tl, time_line_sitting: $ts, gate_line: $gl,
+      friction_tripped: ($ft == 1),
       since_nag: ($sn == 1), resume_ts: $rt, nag_pending: ($np == 1),
       late_nagged: ($ln == 1)}' \
     > "$NAGF.$$" 2>/dev/null \
@@ -226,6 +272,11 @@ if [ "$run_engine" -eq 1 ]; then
   # SubagentStop leaves sitting_start exactly as it found it: those fire on
   # the agent's schedule, not the user's, so a session whose first wired
   # event is a Stop must not start a clock nobody has sat down at.
+  #
+  # The gap that resets it is the gap between prompts anywhere on the
+  # machine, not in this chat: a session left idle for an hour while its
+  # neighbour was worked in has not earned a fresh clock, because the person
+  # never left the chair.
   if [ "$is_prompt" -eq 1 ]; then
     if [ "$last_prompt" -gt 0 ] \
        && [ $((now_ts - last_prompt)) -gt $((NAG_SIT_GAP_MIN * 60)) ]; then
@@ -234,6 +285,8 @@ if [ "$run_engine" -eq 1 ]; then
     fi
     last_prompt=$now_ts
     [ "$sit_start" -gt 0 ] || sit_start=$now_ts
+    tl_sitting=$sit_start
+    save_sitting
   fi
 
   IFS=$'\t' read -r ctx gates fric_win <<<"$(printf '%s\n' "$metrics" | jq -r \
@@ -266,11 +319,16 @@ if [ "$run_engine" -eq 1 ]; then
     sit_min=$(( (now_ts - sit_start) / 60 ))
     n=$(( sit_min / NAG_SIT_EVERY_MIN * NAG_SIT_EVERY_MIN ))
     if [ "$n" -ge "$NAG_SIT_EVERY_MIN" ] && [ "$n" -gt "$time_line" ]; then
-      if [ "$n" -ge $((NAG_SIT_EVERY_MIN * 2)) ]; then verdict="stop here, run /wrapup"
+      # Only "stop here" arms the Stop block. "Stand up" is a nudge to leave
+      # the chair for five minutes and come back to the same session; making
+      # it demand a resume block turned the one-hour mark into a wrap-up
+      # every hour. Two hours is the sitting clock's actual verdict.
+      if [ "$n" -ge $((NAG_SIT_EVERY_MIN * 2)) ]; then
+        verdict="stop here, run /wrapup"; since_nag=1
       else verdict="stand up"; fi
       t="⏱ sitting $(hm "$n") — context $(kfmt "$ctx"): $verdict."
       add_line "$t"; record_crossing time "$n" "$t"
-      time_line=$n; since_nag=1
+      time_line=$n
     fi
   fi
 

--- a/.claude/hooks/metrics-live.test.sh
+++ b/.claude/hooks/metrics-live.test.sh
@@ -91,14 +91,24 @@ t 'both crossings are recorded, in order' \
 # The clock is wall-clock, so the way to put a session 61 minutes in is to
 # write the state file the engine reads, which is what a resumed session's
 # state actually looks like.
+# The clock is machine-wide now, so putting a session 61 minutes in means
+# writing the one shared file plus that session's own per-session state --
+# the second only to keep the context line out of the way of the assertions.
+SITF=$STATE/metrics/sitting.json
+clock() {  # clock <minutes since sitting start> <minutes since last prompt>
+  mkdir -p "$(dirname "$SITF")"
+  jq -n --argjson ss "$(( $(date +%s) - $1 * 60 ))" \
+        --argjson lp "$(( $(date +%s) - $2 * 60 ))" \
+    '{sitting_start:$ss, last_prompt:$lp}' > "$SITF"
+}
+clock_clear() { rm -f "$SITF"; }
 sitting() {  # sitting <session id> <minutes since sitting start> <minutes since last prompt>
   local n=$STATE/metrics/live/$1.nag.json
   mkdir -p "$(dirname "$n")"
-  jq -n --argjson ss "$(( $(date +%s) - $2 * 60 ))" \
-        --argjson lp "$(( $(date +%s) - $3 * 60 ))" \
-    '{context_line:200000, time_line:0, gate_line:0, friction_tripped:false,
-      sitting_start:$ss, last_prompt:$lp, since_nag:false,
-      resume_ts:0, nag_pending:false}' > "$n"
+  jq -n '{context_line:200000, time_line:0, time_line_sitting:0, gate_line:0,
+          friction_tripped:false, since_nag:false,
+          resume_ts:0, nag_pending:false}' > "$n"
+  clock "$2" "$3"
 }
 
 TP2="$SCRATCH/sit.jsonl"; turn "$TP2" 1000
@@ -122,30 +132,108 @@ has 'two hours names the exit' 'sitting 2h00 .* stop here, run /wrapup' "$(msg "
 # --- 2b. the clock belongs to the prompt -------------------------------------
 # $SCRATCH is not a git repo, so archivable() refuses and the Stop nag stays
 # out of the way; what is under test here is only the clock.
-sit_start() { jq -r '.sitting_start // 0' "$STATE/metrics/live/$1.nag.json" 2>/dev/null; }
+# 0 when the file is not there at all: no clock is a clock at zero, and the
+# assertions below are about a Stop never creating one.
+sit_start() { jq -r '.sitting_start // 0' "$SITF" 2>/dev/null || true; \
+              [ -f "$SITF" ] || printf 0; }
 
 TPS="$SCRATCH/stopfirst.jsonl"; turn "$TPS" 1000
+clock_clear
 payload "$TPS" sfirst "$SCRATCH" Stop \
   | bash "$HOOK" stop 0 show >/dev/null 2>&1
-t 'a Stop before any prompt does not start the clock' 0 "$(sit_start sfirst)"
+t 'a Stop before any prompt does not start the clock' 0 "$(sit_start)"
 
 payload "$TPS" sfirst "$SCRATCH" SubagentStop \
   | bash "$HOOK" subagentstop 0 show >/dev/null 2>&1
-t 'nor does a SubagentStop' 0 "$(sit_start sfirst)"
+t 'nor does a SubagentStop' 0 "$(sit_start)"
 
 out=$(payload "$TPS" sfirst "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
 hasnt 'so the first prompt after them is minute zero' '⏱' "$(msg "$out")"
 t 'and it is the prompt that starts the clock' yes \
-  "$( [ "$(sit_start sfirst)" -gt 0 ] && echo yes || echo no )"
+  "$( [ "$(sit_start)" -gt 0 ] && echo yes || echo no )"
 
 # An hour on the clock: a Stop must neither report it nor disturb it.
 sitting quiet 61 10
-before=$(sit_start quiet)
+before=$(sit_start)
 out=$(payload "$TPS" quiet "$SCRATCH" Stop | bash "$HOOK" stop 0 show 2>&1)
 hasnt 'a Stop past the line says nothing about sitting' '⏱ sitting' "$(msg "$out")"
-t    'and leaves the clock exactly where it found it' "$before" "$(sit_start quiet)"
+t    'and leaves the clock exactly where it found it' "$before" "$(sit_start)"
 out=$(payload "$TPS" quiet "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
 has  'the next prompt is what reports it' '⏱ sitting 1h00' "$(msg "$out")"
+
+# --- 2c. one clock for the machine, one report per session -------------------
+# Three chats open is still one person in one chair. sitting_start and
+# last_prompt live in a single file under the state dir's metrics directory
+# that any session's UserPromptSubmit advances; only time_line is per session,
+# so each chat says a threshold once where its reader is looking.
+TPM="$SCRATCH/multi.jsonl"; turn "$TPM" 1000
+P() { payload "$TPM" "$1" "$SCRATCH" | bash "$HOOK" prompt 0 2>&1; }
+nag_field() { jq -r "$2" "$STATE/metrics/live/$1.nag.json" 2>/dev/null; }
+
+clock_clear
+P mA >/dev/null
+started=$(sit_start)
+t 'the first prompt anywhere starts the one clock' yes \
+  "$( [ "${started:-0}" -gt 0 ] && echo yes || echo no )"
+P mB >/dev/null
+t 'a second session id does not start a second clock' "$started" "$(sit_start)"
+t 'and no session keeps a clock of its own' '' \
+  "$(cat "$STATE"/metrics/live/m[AB].nag.json | jq -r '.sitting_start // empty')"
+
+# A prompt in either session is the same person still sitting: it advances the
+# shared last_prompt, and both sessions read the same elapsed time back.
+clock 61 10
+outA=$(P mA)
+has 'a prompt in one session reports the shared hour' '⏱ sitting 1h00' "$(msg "$outA")"
+kept=$(sit_start)
+outB=$(P mB)
+has 'and the other session reports the same hour, not zero' '⏱ sitting 1h00' "$(msg "$outB")"
+t   'neither prompt restarted the sitting' "$kept" "$(sit_start)"
+t   'the second prompt advanced the shared last_prompt' yes \
+  "$( [ "$(jq -r '.last_prompt' "$SITF")" -ge "$(( $(date +%s) - 5 ))" ] && echo yes || echo no )"
+
+# The report is per session, so each says the hour once and only once.
+t 'the line does not repeat in the session that said it' '' "$(msg "$(P mA)")"
+t 'nor in the other one'                                 '' "$(msg "$(P mB)")"
+
+# A session opened partway into someone else's sitting inherits the clock it
+# walked in on. Wall-clock time cannot be advanced inside a test, so the ten
+# minutes between mF's two prompts are expressed by rewriting the shared file
+# -- which is exactly what the other session's prompts would have left there.
+clock 50 5
+outF1=$(P mF)
+hasnt 'a session opened 50 minutes in says nothing at 50' '⏱' "$(msg "$outF1")"
+t     'and does not restart the clock it walked in on' 0 "$(nag_field mF '.time_line')"
+clock 61 5
+outF2=$(P mF)
+has 'and reports 1h00 at its next prompt' '⏱ sitting 1h00' "$(msg "$outF2")"
+has 'with the stand-up verdict, not a wrap-up' 'stand up' "$(msg "$outF2")"
+
+# A nag file written before the clock moved out of it carries a time_line
+# with no sitting to belong to. Spend it rather than trust it: the sitting it
+# was recorded in is one this machine has no record of.
+clock 61 10
+old=$STATE/metrics/live/mOld.nag.json
+jq -n --argjson ss "$(( $(date +%s) - 900 ))" \
+  '{context_line:200000, time_line:60, gate_line:0, friction_tripped:false,
+    sitting_start:$ss, last_prompt:$ss, since_nag:false,
+    resume_ts:0, nag_pending:false}' > "$old"
+has 'a pre-move nag file does not suppress the new hour' '⏱ sitting 1h00' \
+    "$(msg "$(P mOld)")"
+
+# When the shared clock restarts, every session is free to speak again, not
+# only the one whose prompt restarted it: a spent time_line belongs to the
+# sitting it was recorded in, and that sitting is over. The per-session file
+# carries that sitting's identity next to the line for exactly this.
+clock 61 10
+P mI >/dev/null
+t 'the hour is spent in that session' '' "$(msg "$(P mI)")"
+before_break=$(jq -r '.sitting_start' "$SITF")
+clock 62 10   # a different sitting, an hour into itself
+t 'which is a different sitting' no \
+  "$( [ "$before_break" = "$(jq -r '.sitting_start' "$SITF")" ] && echo yes || echo no )"
+has 'a restarted clock frees the other session to speak again' \
+    '⏱ sitting 1h00' "$(msg "$(P mI)")"
 
 # --- 3. Stop, archivable, past the line --------------------------------------
 REPO="$SCRATCH/repo"; mkdir -p "$REPO"
@@ -159,6 +247,25 @@ chmod +x "$SCRATCH/bin/gh"
 export PATH="$SCRATCH/bin:$PATH"
 
 TP3="$SCRATCH/stop.jsonl"; turn "$TP3" 1000
+
+# --- 3b. only "stop here" arms the Stop block --------------------------------
+# "Stand up" asks for five minutes out of the chair and the same session back;
+# it is not a wrap-up. Arming the block on it made every hour a demand for a
+# resume block. Two hours is the sitting clock's actual verdict, and the only
+# crossing on it that blocks. METRICS_STOP_HOUR=23 keeps the late-hour arm out
+# of the way so what is under test is the crossing alone.
+arm() {  # arm <session id> <minutes on the shared clock>
+  clock "$2" 10
+  payload "$TP3" "$1" "$REPO" | bash "$HOOK" prompt 0 >/dev/null 2>&1
+  payload "$TP3" "$1" "$REPO" Stop | METRICS_STOP_HOUR=23 bash "$HOOK" stop 0 show 2>&1
+}
+o=$(arm arm1 61)
+has 'the one-hour crossing is still reported' '⏱ sitting 1h00' \
+    "$(msg "$(clock 61 10; payload "$TP3" armX "$REPO" | bash "$HOOK" prompt 0 2>&1)")"
+t 'but it does not arm the Stop block' '' "$(printf '%s' "$o" | jq -r '.decision // ""')"
+o=$(arm arm2 121)
+t 'the two-hour crossing does' block "$(printf '%s' "$o" | jq -r '.decision // ""')"
+
 S() { payload "$TP3" stop1 "$REPO" Stop \
       | METRICS_STOP_HOUR=0 bash "$HOOK" stop 0 show 2>&1; }
 


### PR DESCRIPTION
Follow-up to #123, which merged before this landed.

## The clock

`sitting_start` and `last_prompt` lived in the per-session nag file. Three chats open is still one person in one chair, so every new session started its own clock at zero and an afternoon spread over four chats never reached the 60-minute line once.

They move to `$(state_dir)/metrics/sitting.json` — one file, machine-wide, advanced by any session's `UserPromptSubmit`, with the same 30-minute gap reset. The gap is now the gap between prompts *anywhere on the box*: a session left idle for an hour while its neighbour was worked in has not earned a fresh clock, because the person never left the chair.

`time_line` stays per session, alongside `time_line_sitting` — the `sitting_start` that line was recorded against. The clock is shared; the report of it is each chat's own, so a threshold is spoken once where each reader is looking. When the shared clock restarts, every session's stored line is stale and every session is freed to speak again, not only the one whose prompt restarted it.

The file is per-machine and gitignored in the state repo, for the reason `last_activity.json` is: it answers "how long has this body been at *this* box", and one shared file every session rewrites is the shape that made `metrics.json` conflict on pull.

## The Stop block

Arms on the 120-minute "stop here" crossing only. "Stand up" asks for five minutes out of the chair and the same session back; making it demand a resume block turned every hour into a wrap-up. Context crossings and the friction counter arm it as before.

## Tests

`metrics-live.test.sh` grows a section on the shared clock — two session ids share one clock and neither starts a second; a prompt in either continues the sitting and both read the same elapsed time back; the line is still spoken once per session; a session opened 50 minutes into another session's sitting says nothing at 50 and reports `1h00` at its next prompt; a restart frees a session that had already spent its line; and a nag file written before the move does not suppress the new hour. Two more assert the arming rule directly: the one-hour crossing does not block, the two-hour one does.

Every new assertion was mutation-checked against the pre-change hook and against a hook with only the arming rule reverted; both fail the ones they should.

```
metrics-live              57 passed, 0 failed
stop-continuity           15 passed, 0 failed
session-start-continuity  37 passed, 0 failed
```

`shellcheck` is clean apart from the `A && B || C` info note the file already carries in three other places.

## Seam worth knowing

Wall-clock time cannot be advanced inside a test, so "ten minutes pass" is expressed by rewriting the shared file — which is exactly what another session's prompts would have left there. Noted in the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
