### PR TITLE
metrics: escalating context/friction glyphs, model injection, extendable ladder

### DIFF
--- a/.claude/hooks/metrics-live.sh
+++ b/.claude/hooks/metrics-live.sh
@@ -40,7 +40,13 @@ SHOW="${3:-}"               # "show" -> also print a systemMessage block
 # fires once, when the counter first crosses it this session, and then says
 # nothing until the next line up -- edge-triggered, not level-triggered.
 #
-#   context   size and a verdict; "propose stopping" from CONTEXT_STOP_AT up
+#   context   size and a verdict; "propose stopping" from CONTEXT_STOP_AT up.
+#             The line repeats its glyph once per threshold rung crossed this
+#             session (capped at 5, then "(xN)"), and the ladder extends past
+#             the last configured line by CONTEXT_STEP forever, so it keeps
+#             escalating instead of going quiet at the top. At or above
+#             CONTEXT_STOP_AT it also reaches the model: once as an offer to
+#             stop, and plainly, not repeated, on every rung after that
 #   sitting   elapsed, context, verdict -- driven entirely by prompts: it
 #             starts at the first one, restarts when the gap between two of
 #             them runs past SIT_GAP_MIN (a session picked up after dinner is
@@ -55,6 +61,7 @@ SHOW="${3:-}"               # "show" -> also print a systemMessage block
 #   gate      gate decisions pushed to the user, every GATE_EVERY
 NAG_CONTEXT_LINES="${METRICS_CONTEXT_LINES:-100000 150000 200000}"
 NAG_CONTEXT_STOP_AT="${METRICS_CONTEXT_STOP_AT:-150000}"
+NAG_CONTEXT_STEP="${METRICS_CONTEXT_STEP:-50000}"
 NAG_SIT_EVERY_MIN="${METRICS_SIT_EVERY_MIN:-60}"
 NAG_SIT_GAP_MIN="${METRICS_SIT_GAP_MIN:-30}"
 NAG_FRICTION_N="${METRICS_FRICTION_N:-3}"
@@ -209,12 +216,13 @@ save_sitting() {
 # sitting_start that time_line was recorded against -- when the shared clock
 # restarts, every session's line is stale, including the ones that were not
 # the prompt that restarted it, and they must be free to speak again.
-ctx_line=0; time_line=0; tl_sitting=0; gate_line=0; fric_tripped=0
+ctx_line=0; ctx_rungs=0; ctx_stop_line=0; time_line=0; tl_sitting=0; gate_line=0; fric_tripped=0
 since_nag=0; resume_ts=0; nag_pending=0; late_nagged=0
 if [ -f "$NAGF" ]; then
-  IFS=$'\t' read -r ctx_line time_line tl_sitting gate_line fric_tripped \
+  IFS=$'\t' read -r ctx_line ctx_rungs ctx_stop_line time_line tl_sitting gate_line fric_tripped \
                     since_nag resume_ts nag_pending late_nagged \
-    <<<"$(jq -r '[(.context_line // 0), (.time_line // 0), (.time_line_sitting // -1),
+    <<<"$(jq -r '[(.context_line // 0), (.context_rungs // 0), (.context_stop_line // 0),
+                  (.time_line // 0), (.time_line_sitting // -1),
                   (.gate_line // 0),
                   (if .friction_tripped then 1 else 0 end),
                   (if .since_nag then 1 else 0 end),
@@ -222,7 +230,7 @@ if [ -f "$NAGF" ]; then
                   (if .nag_pending then 1 else 0 end),
                   (if .late_nagged then 1 else 0 end)] | @tsv' "$NAGF" 2>/dev/null)"
 fi
-for v in ctx_line time_line tl_sitting gate_line fric_tripped \
+for v in ctx_line ctx_rungs ctx_stop_line time_line tl_sitting gate_line fric_tripped \
          since_nag resume_ts nag_pending late_nagged; do
   [ -n "${!v}" ] || eval "$v=0"
 done
@@ -231,11 +239,13 @@ done
 [ "$tl_sitting" -eq "$sit_start" ] || { time_line=0; tl_sitting=$sit_start; }
 
 save_nag() {
-  jq -n --argjson cl "$ctx_line" --argjson tl "$time_line" --argjson ts "$tl_sitting" \
+  jq -n --argjson cl "$ctx_line" --argjson cr "$ctx_rungs" --argjson cs "$ctx_stop_line" \
+        --argjson tl "$time_line" --argjson ts "$tl_sitting" \
         --argjson gl "$gate_line" --argjson ft "$fric_tripped" \
         --argjson sn "$since_nag" --argjson rt "$resume_ts" --argjson np "$nag_pending" \
         --argjson ln "$late_nagged" \
-    '{context_line: $cl, time_line: $tl, time_line_sitting: $ts, gate_line: $gl,
+    '{context_line: $cl, context_rungs: $cr, context_stop_line: $cs,
+      time_line: $tl, time_line_sitting: $ts, gate_line: $gl,
       friction_tripped: ($ft == 1),
       since_nag: ($sn == 1), resume_ts: $rt, nag_pending: ($np == 1),
       late_nagged: ($ln == 1)}' \
@@ -255,8 +265,33 @@ kfmt() { awk -v n="$1" 'BEGIN { if (n >= 1000) printf "%dk", int(n / 1000); else
 hm()   { awk -v m="$1" 'BEGIN { if (m >= 60) printf "%dh%02d", int(m / 60), m % 60; else printf "%dm", m }'; }
 hhmm() { date -d "@$1" +%H:%M 2>/dev/null || date -r "$1" +%H:%M 2>/dev/null || echo "??:??"; }
 
+# $1 glyph count, $2 glyph char -- repeats the glyph up to 5 times, then
+# switches to "(xN)" so an escalation past the cap still reads as a number
+# instead of a wall of characters.
+glyphs() {
+  local n="$1" g="$2" i shown out=""
+  shown=$n; [ "$shown" -gt 5 ] && shown=5
+  for ((i = 0; i < shown; i++)); do out="${out}${g}"; done
+  [ "$n" -gt 5 ] && out="${out}(x${n})"
+  printf '%s' "$out"
+}
+
+# Git state folded into a nag line -- the same shorthand as lib-metrics-fmt.jq's
+# `work`, but the crossing lines run in bash, not jq. Empty on a clean tree.
+work_str() {
+  [ "${ncommits:-0}" -gt 0 ] || [ "${dirty:-0}" -gt 0 ] || [ "${unpushed:-0}" -gt 0 ] \
+    || return 0
+  local s="⎇ "
+  [ "${ncommits:-0}" -gt 0 ] && s="${s}${ncommits}c"
+  [ "${dirty:-0}" -gt 0 ]    && s="${s}${dirty}~"
+  [ "${unpushed:-0}" -gt 0 ] && s="${s}${unpushed}↑"
+  printf '%s' "$s"
+}
+
 sys_lines=""; model_line=""
-add_line() { sys_lines="${sys_lines:+$sys_lines
+add_line()  { sys_lines="${sys_lines:+$sys_lines
+}$1"; }
+add_model() { model_line="${model_line:+$model_line
 }$1"; }
 record_crossing() {
   mkdir -p "$CROSSD" 2>/dev/null || return 0
@@ -289,24 +324,62 @@ if [ "$run_engine" -eq 1 ]; then
     save_sitting
   fi
 
-  IFS=$'\t' read -r ctx gates fric_win <<<"$(printf '%s\n' "$metrics" | jq -r \
+  IFS=$'\t' read -r ctx gates fric_total fric_win <<<"$(printf '%s\n' "$metrics" | jq -r \
     --argjson w "$NAG_FRICTION_TURNS" \
     '(.session.user_turns // 0) as $t
      | [ (.session.context_peak // 0),
          (.session.decisions.gate // 0),
+         (.session.friction.total // 0),
          ([ .friction[]?
             | select(.type == "correction" or .type == "rebuke")
             | select((.turn_ordinal // 0) > ($t - $w)) ] | length) ] | @tsv')"
   [ -n "${ctx:-}" ] || ctx=0
   [ -n "${gates:-}" ] || gates=0
+  [ -n "${fric_total:-}" ] || fric_total=0
   [ -n "${fric_win:-}" ] || fric_win=0
 
-  # context -- lines ascending, so a jump past two of them reports both, in order
-  for L in $NAG_CONTEXT_LINES; do
+  # Note for agents: do not modify without direct, explicit interaction with Solace.
+  # If changing the display, you must show in the chat session
+  # examples of the expected output, before and after.
+  #
+  # context -- lines ascending, so a jump past several of them reports each in
+  # order. The ladder is the configured lines, then NAG_CONTEXT_STEP forever
+  # past the last one, so a session that blows through every configured line
+  # keeps getting a line instead of going quiet. ⛁ repeats once per rung
+  # crossed this session (glyphs(); capped at 5, then "(xN)") -- the same
+  # escalation as ⚡, keyed off the friction total instead of the rung count.
+  # ⚖ stays a plain digit; no rung tracks gate decisions.
+  ladder="$NAG_CONTEXT_LINES"
+  last_cfg=0
+  for L in $NAG_CONTEXT_LINES; do last_cfg=$L; done
+  if [ "$NAG_CONTEXT_STEP" -gt 0 ] && [ "$last_cfg" -gt 0 ]; then
+    L=$((last_cfg + NAG_CONTEXT_STEP))
+    while [ "$ctx" -ge "$L" ]; do
+      ladder="$ladder $L"
+      L=$((L + NAG_CONTEXT_STEP))
+    done
+  fi
+  for L in $ladder; do
     if [ "$ctx" -ge "$L" ] && [ "$L" -gt "$ctx_line" ]; then
-      if [ "$L" -ge "$NAG_CONTEXT_STOP_AT" ]; then verdict="propose stopping"
-      else verdict="still room"; fi
-      t="⛁ context $(kfmt "$ctx") — past $(kfmt "$L"): $verdict."
+      ctx_rungs=$((ctx_rungs + 1))
+      if [ "$L" -ge "$NAG_CONTEXT_STOP_AT" ]; then
+        verdict="propose stopping"
+        # Model injection only from the stop threshold up: the first such
+        # crossing offers a stopping point, every one after it says plainly
+        # that the offer already went out and nothing came of it, rather than
+        # repeating it verbatim rung after rung.
+        if [ "$ctx_stop_line" -eq 0 ]; then
+          add_model "Context at $(kfmt "$ctx") — a stopping point. Consider /wrapup."
+        else
+          add_model "Context at $(kfmt "$ctx"), past $(kfmt "$L"). Already raised at $(kfmt "$ctx_stop_line") and not acted on."
+        fi
+        ctx_stop_line=$L
+      else
+        verdict="still room"
+      fi
+      fpart=""
+      [ "$fric_total" -gt 0 ] && fpart=" $(glyphs "$fric_total" "⚡") $fric_total"
+      t="$(glyphs "$ctx_rungs" "⛁") $(kfmt "$ctx")/$(kfmt "$L") ⚖${gates}${fpart} — ${verdict}."
       add_line "$t"; record_crossing context "$L" "$t"
       ctx_line=$L; since_nag=1
     fi
@@ -327,6 +400,7 @@ if [ "$run_engine" -eq 1 ]; then
         verdict="stop here, run /wrapup"; since_nag=1
       else verdict="stand up"; fi
       t="⏱ sitting $(hm "$n") — context $(kfmt "$ctx"): $verdict."
+      w=$(work_str); [ -n "$w" ] && t="$t $w"
       add_line "$t"; record_crossing time "$n" "$t"
       time_line=$n
     fi
@@ -346,8 +420,8 @@ if [ "$run_engine" -eq 1 ]; then
   # is addressed to the model, which is the thing the capacity rule asks of.
   if [ "$is_prompt" -eq 1 ] && [ "$fric_tripped" -ne 1 ] \
      && [ "$fric_win" -ge "$NAG_FRICTION_N" ]; then
-    model_line="$fric_win corrections or rebukes in the last $NAG_FRICTION_TURNS turns. Apply the capacity rule from the standing orders, once."
-    record_crossing friction "$fric_win" "$model_line"
+    fm="$fric_win corrections or rebukes in the last $NAG_FRICTION_TURNS turns. Apply the capacity rule from the standing orders, once."
+    add_model "$fm"; record_crossing friction "$fric_win" "$fm"
     fric_tripped=1; since_nag=1
   fi
 fi

--- a/.claude/hooks/metrics-live.sh
+++ b/.claude/hooks/metrics-live.sh
@@ -238,6 +238,31 @@ done
 # belongs to a sitting nobody can name, so it is spent rather than trusted.
 [ "$tl_sitting" -eq "$sit_start" ] || { time_line=0; tl_sitting=$sit_start; }
 
+# A nag file written before context_rungs/context_stop_line existed has
+# context_line but defaults both new fields to 0 -- read literally, a session
+# that already crossed 200k before the upgrade would show only the rungs it
+# crosses from here, undercounting the glyph escalation, and would re-offer
+# to stop as if for the first time. Derive both from context_line and the
+# ladder as configured now, once, rather than trust a zero that only means
+# "this field didn't exist yet".
+if [ "$ctx_rungs" -eq 0 ] && [ "$ctx_line" -gt 0 ]; then
+  for L in $NAG_CONTEXT_LINES; do
+    [ "$L" -le "$ctx_line" ] && ctx_rungs=$((ctx_rungs + 1))
+  done
+  if [ "$NAG_CONTEXT_STEP" -gt 0 ]; then
+    last_cfg=0
+    for L in $NAG_CONTEXT_LINES; do last_cfg=$L; done
+    if [ "$last_cfg" -gt 0 ]; then
+      L=$((last_cfg + NAG_CONTEXT_STEP))
+      while [ "$L" -le "$ctx_line" ]; do
+        ctx_rungs=$((ctx_rungs + 1))
+        L=$((L + NAG_CONTEXT_STEP))
+      done
+    fi
+  fi
+fi
+[ "$ctx_stop_line" -eq 0 ] && [ "$ctx_line" -ge "$NAG_CONTEXT_STOP_AT" ] && ctx_stop_line=$ctx_line
+
 save_nag() {
   jq -n --argjson cl "$ctx_line" --argjson cr "$ctx_rungs" --argjson cs "$ctx_stop_line" \
         --argjson tl "$time_line" --argjson ts "$tl_sitting" \
@@ -359,20 +384,21 @@ if [ "$run_engine" -eq 1 ]; then
       L=$((L + NAG_CONTEXT_STEP))
     done
   fi
+  # A single invocation can cross several rungs at once (a big tool result
+  # landing between prompts, or a subagent's output). Each still gets its own
+  # screen line -- "reports each in order" above -- but the model injection
+  # is once per *call*, not once per rung: stacking one "already raised" line
+  # per rung crossed in the same call would claim a separate earlier occasion
+  # for each, when they all just happened now and the model never had a turn
+  # in between to act on any of them.
+  ctx_stop_before=$ctx_stop_line
+  ctx_stop_fired=0
   for L in $ladder; do
     if [ "$ctx" -ge "$L" ] && [ "$L" -gt "$ctx_line" ]; then
       ctx_rungs=$((ctx_rungs + 1))
       if [ "$L" -ge "$NAG_CONTEXT_STOP_AT" ]; then
         verdict="propose stopping"
-        # Model injection only from the stop threshold up: the first such
-        # crossing offers a stopping point, every one after it says plainly
-        # that the offer already went out and nothing came of it, rather than
-        # repeating it verbatim rung after rung.
-        if [ "$ctx_stop_line" -eq 0 ]; then
-          add_model "Context at $(kfmt "$ctx") — a stopping point. Consider /wrapup."
-        else
-          add_model "Context at $(kfmt "$ctx"), past $(kfmt "$L"). Already raised at $(kfmt "$ctx_stop_line") and not acted on."
-        fi
+        ctx_stop_fired=1
         ctx_stop_line=$L
       else
         verdict="still room"
@@ -384,6 +410,17 @@ if [ "$run_engine" -eq 1 ]; then
       ctx_line=$L; since_nag=1
     fi
   done
+  # Model injection only from the stop threshold up, and only once per call:
+  # the first time it ever fires, offer a stopping point; every call after
+  # that says plainly the offer already went out and nothing came of it,
+  # rather than repeating it verbatim.
+  if [ "$ctx_stop_fired" -eq 1 ]; then
+    if [ "$ctx_stop_before" -eq 0 ]; then
+      add_model "Context at $(kfmt "$ctx") — a stopping point. Consider /wrapup."
+    else
+      add_model "Context at $(kfmt "$ctx"), past $(kfmt "$ctx_stop_line"). Already raised at $(kfmt "$ctx_stop_before") and not acted on."
+    fi
+  fi
 
   # sitting clock -- read on a prompt and nowhere else, so the line lands
   # where the user is already reading, at the top of a turn.

--- a/.claude/hooks/metrics-live.test.sh
+++ b/.claude/hooks/metrics-live.test.sh
@@ -374,6 +374,17 @@ ctx6c=$(payload "$TP6" "$SID6" "$SCRATCH" \
 has  'a later crossing says it was already raised'  'Already raised at 150k' "$ctx6c"
 hasnt 'and does not repeat the stopping-point offer' 'a stopping point'      "$ctx6c"
 
+# A single call can cross more than one stop-eligible rung at once (a big
+# tool result landing between prompts). That must still emit exactly one
+# model line, not one per rung -- otherwise every rung but the first claims
+# a distinct earlier occasion nobody acted on, when they all just fired now.
+TP6b="$SCRATCH/inject2.jsonl"; SID6b=inject2
+turn "$TP6b" 300000
+ctx6d=$(payload "$TP6b" "$SID6b" "$SCRATCH" \
+        | bash "$HOOK" prompt 0 2>&1 | jq -r '.hookSpecificOutput.additionalContext // ""')
+t 'one jump across three stop-eligible rungs still sends one line' \
+  1 "$(printf '%s' "$ctx6d" | grep -c 'stopping point\|Already raised')"
+
 # --- 7. the sitting line carries git state once #129 makes it safe to ---------
 # dotfiles#132's third deferred item, reconciled now that #129 landed: a dirty
 # or unpushed tree is exactly the fact the "stop here" verdict needs. A fresh

--- a/.claude/hooks/metrics-live.test.sh
+++ b/.claude/hooks/metrics-live.test.sh
@@ -76,10 +76,12 @@ turn "$TP" 152000
 out2=$(payload "$TP" "$SID" "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
 out3=$(payload "$TP" "$SID" "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
 
-has  'first crossing names 100k'      'past 100k' "$(msg "$out1")"
+has  'first crossing names 100k'      '103k/100k' "$(msg "$out1")"
 hasnt 'first crossing does not propose stopping' 'propose stopping' "$(msg "$out1")"
-has  'second crossing names 150k'     'past 150k' "$(msg "$out2")"
+has  'second crossing names 150k'     '152k/150k' "$(msg "$out2")"
 has  'second crossing proposes stopping' 'propose stopping' "$(msg "$out2")"
+has  'first crossing shows one ⛁ glyph'  '⛁ 103k' "$(msg "$out1")"
+has  'second crossing shows two ⛁ glyphs' '⛁⛁ 152k' "$(msg "$out2")"
 t    'nothing fires a third time'     '' "$(msg "$out3")"
 
 CROSS="$STATE/metrics/crossings/$SID.jsonl"
@@ -305,7 +307,7 @@ o=$(S3); t 'and stays quiet after' '' "$(printf '%s' "$o" | jq -r '.decision // 
 TP4="$SCRATCH/cross.jsonl"; turn "$TP4" 103000
 o=$(payload "$TP4" stop4 "$REPO" Stop | METRICS_STOP_HOUR=23 bash "$HOOK" stop 0 show 2>&1)
 t   'a context crossing at Stop blocks' block "$(printf '%s' "$o" | jq -r '.decision // ""')"
-has 'and the reason carries the crossing line' '⛁ context 103k — past 100k' \
+has 'and the reason carries the crossing line' '⛁ 103k/100k' \
     "$(printf '%s' "$o" | jq -r '.reason // ""')"
 
 # A dirty tree is not archivable, so nothing blocks however late it is.
@@ -333,6 +335,57 @@ if [ -f "$FIX" ]; then
 else
   printf 'SKIP: %s is missing\n' "$FIX"
 fi
+
+# --- 5. the ladder extends past the configured lines, forever ----------------
+# dotfiles#132: NAG_CONTEXT_LINES stops at 200k by default, but a session that
+# blows straight past it must keep getting a line every NAG_CONTEXT_STEP,
+# not go quiet. A single jump to 320k crosses five rungs at once (100k, 150k,
+# 200k, 250k, 300k) and the glyph count escalates with each: the fifth rung is
+# capped at 5 ⛁ and switches to "(xN)".
+TP5="$SCRATCH/ladder.jsonl"; SID5=ladder
+turn "$TP5" 350000
+out5=$(payload "$TP5" "$SID5" "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
+has 'the ladder reaches past the last configured line' '350k/350k' "$(msg "$out5")"
+has 'and the glyph count is capped, with the total after it' \
+    '⛁⛁⛁⛁⛁\(x6\)' "$(msg "$out5")"
+t 'six rungs cross in one jump, in order' \
+  "$(printf '100000\n150000\n200000\n250000\n300000\n350000')" \
+  "$(jq -r 'select(.kind == "context") | .at' "$STATE/metrics/crossings/$SID5.jsonl" 2>/dev/null)"
+
+# --- 6. model injection only from the stop threshold up -----------------------
+# Below NAG_CONTEXT_STOP_AT (150k default) the crossing is screen-only. At or
+# above it, the first crossing offers a stopping point; every crossing after
+# that says plainly it was already raised, instead of repeating the offer.
+TP6="$SCRATCH/inject.jsonl"; SID6=inject
+turn "$TP6" 103000
+ctx6a=$(payload "$TP6" "$SID6" "$SCRATCH" \
+        | bash "$HOOK" prompt 0 2>&1 | jq -r '.hookSpecificOutput.additionalContext // ""')
+t 'below the stop threshold, nothing reaches the model' '' "$ctx6a"
+
+turn "$TP6" 152000
+ctx6b=$(payload "$TP6" "$SID6" "$SCRATCH" \
+        | bash "$HOOK" prompt 0 2>&1 | jq -r '.hookSpecificOutput.additionalContext // ""')
+has 'the first crossing at/above the stop line offers to stop' \
+    'a stopping point' "$ctx6b"
+
+turn "$TP6" 260000
+ctx6c=$(payload "$TP6" "$SID6" "$SCRATCH" \
+        | bash "$HOOK" prompt 0 2>&1 | jq -r '.hookSpecificOutput.additionalContext // ""')
+has  'a later crossing says it was already raised'  'Already raised at 150k' "$ctx6c"
+hasnt 'and does not repeat the stopping-point offer' 'a stopping point'      "$ctx6c"
+
+# --- 7. the sitting line carries git state once #129 makes it safe to ---------
+# dotfiles#132's third deferred item, reconciled now that #129 landed: a dirty
+# or unpushed tree is exactly the fact the "stop here" verdict needs. A fresh
+# repo, not $REPO -- that one already carries a leftover "dirty" file from the
+# archivable tests above, and this is checking the exact count.
+REPO7="$SCRATCH/repo7"; mkdir -p "$REPO7"
+git -C "$REPO7" init -q -b feat/nags
+git -C "$REPO7" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+TP7="$SCRATCH/sit7.jsonl"; turn "$TP7" 1000
+: > "$REPO7/scratch-file"
+o7=$(clock 61 10; payload "$TP7" sit7 "$REPO7" | bash "$HOOK" prompt 0 2>&1)
+has 'the sitting line shows the dirty tree' '⎇ 1~' "$(msg "$o7")"
 
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/.local/bin/cloud-session-setup.sh
+++ b/.local/bin/cloud-session-setup.sh
@@ -90,6 +90,7 @@ INSTALL="
 .claude/hooks/public-issue-guard.sh
 .claude/hooks/fixtures
 .local/bin/metrics-preview.sh
+.local/bin/metrics-breakdown.sh
 .local/bin/prose-budget
 .local/bin/worklist
 .local/bin/resume-list

--- a/.local/bin/metrics-breakdown.sh
+++ b/.local/bin/metrics-breakdown.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# On-demand breakdown of one session's decision/friction triples and git-event
+# counts -- the detail dotfiles#132 explicitly dropped from the nag display
+# (⚖0[0/0/0], ⚡0[0/0/0], tool-call/git-event counts) rather than bring back.
+# The data was never deleted: metrics-live.sh already caches it in
+# metrics/live/<sid>.json and measure-git-events.sh already logs it to
+# metrics/git-events/<sid>.jsonl. This just reads both, on request, from a
+# terminal -- not the statusline, not a hook.
+#
+# Usage: metrics-breakdown.sh [session-id-prefix]
+#   No argument: the most recently updated live cache.
+set -u
+
+HOOKS="${METRICS_HOOKS:-$HOME/.claude/hooks}"
+[ -d "$HOOKS" ] || { echo "no hooks at $HOOKS" >&2; exit 1; }
+# shellcheck source=.claude/hooks/lib-state.sh
+. "$HOOKS/lib-state.sh"
+
+LIVE="$(state_dir)/metrics/live"
+GITEV="$(state_dir)/metrics/git-events"
+
+# Excludes *.nag.json: metrics-live.sh's own crossing state, not the cache.
+F=""
+if [ $# -ge 1 ]; then
+  for c in "$LIVE/$1"*.json; do
+    case "$c" in *.nag.json) continue ;; esac
+    [ -f "$c" ] && F="$c" && break
+  done
+else
+  # shellcheck disable=SC2012,SC2045  # newest by mtime; a glob can't sort, and
+  # session ids are hex, so `ls` output here needs no further quoting care
+  for c in $(ls -t "$LIVE"/*.json 2>/dev/null); do
+    case "$c" in *.nag.json) continue ;; esac
+    F="$c"; break
+  done
+fi
+[ -n "${F:-}" ] && [ -f "$F" ] || { echo "no live cache found (searched $LIVE)" >&2; exit 1; }
+
+sid=$(basename "$F" .json)
+echo "session $sid"
+jq -r '
+  "decisions ⚖\(.decisions.total // 0)[\(.decisions.scoping // 0)/\(.decisions.inline // 0)/\(.decisions.gate // 0)]  (scoping/inline/gate)",
+  "friction  ⚡\(.friction.total // 0)[\(.friction.correction // 0)/\(.friction.override // 0)/\(.friction.rebuke // 0)]  (correction/override/rebuke)",
+  "blocked   ⛔\(.blocked.total // 0)[\(.blocked.classifier // 0)/\(.blocked.rule // 0)/\(.blocked.user // 0)]  (classifier/rule/user)",
+  "tool calls \(.tool_calls // 0)"
+' "$F"
+
+GF="$GITEV/$sid.jsonl"
+if [ -f "$GF" ]; then
+  echo "git events:"
+  jq -r '.kind' "$GF" 2>/dev/null | sort | uniq -c | sort -rn | sed 's/^/  /'
+else
+  echo "git events: none logged"
+fi


### PR DESCRIPTION
Closes #132.

## Context crossing line

Drops the redundant `context`/`past` words and packs in gate and friction
counts:

```
⛁⛁⛁ 205k/200k ⚖8 ⚡⚡ 2 — propose stopping.
```

- `⛁` repeats once per threshold rung crossed this session, capped at 5
  glyphs then `(xN)`.
- `⚡` escalates the same way, keyed off the friction total instead of the
  rung count; omitted entirely at 0 friction, same as `⚖` already was.
- `⚖` stays a plain digit -- no escalation on gate decisions.
- `NAG_CONTEXT_LINES` (100k/150k/200k default) now extends forever past its
  last configured line by `NAG_CONTEXT_STEP` (default 50k), so a session
  that blows past every configured line keeps getting a line instead of
  going quiet.

Before/after mockups were shown in-session per the guard comment above the
edited block, before it was touched.

## Model injection

From `NAG_CONTEXT_STOP_AT` up, a crossing now also reaches the model as
`additionalContext`: the first such crossing offers a stopping point, every
one after it says plainly that the offer already went out and nothing came
of it, instead of repeating it. Below the stop threshold: screen-only, as
before. Friction's own model-injection line is unchanged.

## Deferred items, folded in (per Solace's mid-turn note)

- **Sitting-clock line carries git state** -- the "time/git-status ...
  reconcile there" item, now that #129 landed. `⏱ sitting 1h00 — context
  187k: stop here, run /wrapup. ⎇ 3c/2~/1↑`.
- **The wall-clock bedtime nag** turns out to already be wired --
  `night_nag` in `lib-metrics-fmt.jq`, live in `block` on Stop/SubagentStop.
  Confirmed it still fires; no new code needed, no card to file.
- **Full breakdown triples**, explicitly kept off the display line:
  `.local/bin/metrics-breakdown.sh`, a small on-demand CLI that reads the
  decision/friction/blocked triples and git-event counts metrics-live.sh
  and measure-git-events.sh already collect, and prints them on request.
  Added to `cloud-session-setup.sh`'s INSTALL list alongside
  `metrics-preview.sh`.

## Tests

`metrics-live.test.sh`: existing assertions updated for the new line
format, plus new cases for the extended ladder (a jump straight to 350k
crosses six rungs in one call, glyph-capped with `(x6)`), the
model-injection escalation (below/first/later), and the sitting-line
git-status addition. 67 passed, 0 failed. `shellcheck --severity=warning`
clean on every changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an on-demand terminal report for session metrics, including decisions, friction, blocked actions, tool calls, and git activity.
  - Context notifications now continue tracking repeated threshold crossings, with clearer escalation indicators.
  - Added a stopping-point prompt when context usage first reaches the configured limit, followed by concise repeat notices.
  - Session status now includes relevant git work-state information, such as uncommitted changes or pending commits.
  - The metrics report is automatically available in cloud sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->