### PR TITLE
metrics-live: frozen guard covers all four crossing blocks, adds cadence clause

### DIFF
--- a/.claude/hooks/lib-metrics-fmt.jq
+++ b/.claude/hooks/lib-metrics-fmt.jq
@@ -13,6 +13,11 @@ def k: if . >= 1000 then "\(. / 1000 | floor)k" else "\(.)" end;
 
 # other UTF-8 single width chars for consideration:
 # § ¶ ◊ ⁂ ‽ ⸎ ❖ ⌖ ◎ ⊙ ⦾ ⎊ • · ✦  ‖ ⁄ ⁞ ┄ — . ¤ ✎ ⚙  ⚑ ⚠
+#
+# other emoji held for consideration, from 2026-09-10's mockup session --
+# not wired to any output yet, just reserved so the option isn't lost:
+# 🧘‍♀️🌌 (calm/zero state, proposed for friction) ✅ (clear/ok, proposed for
+# blocked=0) ⏰ (louder alarm variant, proposed for a hotter nag/alarm tier)
 
 # Right-pad to $w visible characters. Only ever widens; a field that is
 # already over budget is left alone rather than truncated mid-number.

--- a/.claude/hooks/lib-metrics-test-harness.sh
+++ b/.claude/hooks/lib-metrics-test-harness.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Shared harness for anything that drives metrics-live.sh with a synthetic
+# transcript: metrics-live.test.sh (assertions) and metrics-live.examples.sh
+# (rendered output, no assertions). Kept in one place so a transcript-shape
+# change is fixed once, not in two scripts that quietly drift.
+#
+# Caller sets HOME/CLAUDE_STATE_REPO/SCRATCH before sourcing this.
+
+# --- transcripts -------------------------------------------------------------
+# One human turn plus one assistant turn carrying the context number. Appending
+# another pair with a bigger number is how a session grows past a line.
+turn() {  # turn <file> <context tokens>
+  jq -nc --arg ts "2026-09-09T10:00:00.000Z" \
+    '{type:"queue-operation", operation:"enqueue", timestamp:$ts,
+      sessionId:"t", content:"go on"}' >> "$1"
+  jq -nc --arg ts "2026-09-09T10:00:00.000Z" --argjson n "$2" \
+    --arg u "req-$(wc -l < "$1" | tr -d ' ')" \
+    '{type:"assistant", timestamp:$ts, requestId:$u,
+      message:{model:"claude-opus-5", role:"assistant",
+               content:[{type:"text", text:"ok"}],
+               usage:{input_tokens:$n, output_tokens:10,
+                      cache_read_input_tokens:0, cache_creation_input_tokens:0}}}' >> "$1"
+}
+
+payload() {  # payload <transcript> <session id> <cwd> [hook_event_name]
+  jq -nc --arg tp "$1" --arg sid "$2" --arg cwd "$3" --arg h "${4:-}" \
+    '{transcript_path:$tp, session_id:$sid, cwd:$cwd}
+     + (if $h == "" then {} else {hook_event_name:$h} end)'
+}
+
+msg() { printf '%s' "$1" | jq -r '.systemMessage // ""' 2>/dev/null; }
+ctx() { printf '%s' "$1" | jq -r '.hookSpecificOutput.additionalContext // ""' 2>/dev/null; }

--- a/.claude/hooks/metrics-live.examples.sh
+++ b/.claude/hooks/metrics-live.examples.sh
@@ -29,7 +29,7 @@ turn "$TP" 152000
 out=$(payload "$TP" a "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
 printf '  %s\n' "$(msg "$out")"
 
-show "one jump crosses five rungs at once (350k)"
+show "one jump crosses six rungs at once (350k)"
 TP2="$SCRATCH/b.jsonl"; turn "$TP2" 350000
 out=$(payload "$TP2" b "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
 printf '%s\n' "$(msg "$out")" | sed 's/^/  /'

--- a/.claude/hooks/metrics-live.examples.sh
+++ b/.claude/hooks/metrics-live.examples.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Rendered output for the interesting scenarios in metrics-live.sh's crossing
+# engine -- not a test (no assertions, nothing fails), a display. Run this
+# and paste its output into a PR that touches any # FROZEN block, per the
+# guard at the top of metrics-live.sh: rendered examples, not prose.
+#
+# Uses the same transcript-building harness as metrics-live.test.sh, so a
+# shape change is fixed once in lib-metrics-test-harness.sh, not twice.
+#
+# Run: bash .claude/hooks/metrics-live.examples.sh
+set -uo pipefail
+HOOK="$(cd "$(dirname "$0")" && pwd)/metrics-live.sh"
+SCRATCH=$(mktemp -d); trap 'rm -rf "$SCRATCH"' EXIT
+export HOME="$SCRATCH/home"; mkdir -p "$HOME"
+export CLAUDE_STATE_REPO=""
+
+# shellcheck source=lib-metrics-test-harness.sh
+. "$(dirname "$HOOK")/lib-metrics-test-harness.sh"
+
+show() { printf '\n### %s\n' "$1"; }
+
+show "first context crossing (100k)"
+TP="$SCRATCH/a.jsonl"; turn "$TP" 103000
+out=$(payload "$TP" a "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
+printf '  %s\n' "$(msg "$out")"
+
+show "second crossing, same session (150k)"
+turn "$TP" 152000
+out=$(payload "$TP" a "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
+printf '  %s\n' "$(msg "$out")"
+
+show "one jump crosses five rungs at once (350k)"
+TP2="$SCRATCH/b.jsonl"; turn "$TP2" 350000
+out=$(payload "$TP2" b "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
+printf '%s\n' "$(msg "$out")" | sed 's/^/  /'
+
+show "model injection: below stop threshold (103k) -- screen only"
+TP3="$SCRATCH/c.jsonl"; turn "$TP3" 103000
+out=$(payload "$TP3" c "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
+printf '  additionalContext: [%s]\n' "$(ctx "$out")"
+
+show "model injection: first crossing at/above stop threshold (152k)"
+turn "$TP3" 152000
+out=$(payload "$TP3" c "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
+printf '  additionalContext: %s\n' "$(ctx "$out")"
+
+show "model injection: one call crossing three stop-armed rungs (0 -> 260k)"
+TP4="$SCRATCH/d.jsonl"; turn "$TP4" 260000
+out=$(payload "$TP4" d "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
+printf '  additionalContext: %s\n' "$(ctx "$out")"
+
+show "friction crossing (committed contentious fixture)"
+FIX="$(dirname "$HOOK")/fixtures/friction-contentious.jsonl"
+if [ -f "$FIX" ]; then
+  out=$(payload "$FIX" e "$SCRATCH" | METRICS_FRICTION_TURNS=200 bash "$HOOK" prompt 0 2>&1)
+  printf '  additionalContext: %s\n' "$(ctx "$out")"
+else
+  printf '  (fixture missing)\n'
+fi
+
+printf '\n'

--- a/.claude/hooks/metrics-live.sh
+++ b/.claude/hooks/metrics-live.sh
@@ -23,6 +23,25 @@
 #
 # stdin: any hook payload carrying transcript_path/session_id/cwd.
 # Always exits 0.
+#
+# FROZEN -- THAW CAREFULLY. Every block below tagged with that phrase (the
+# ⛁ context, ⚖ gate, ⚡ friction and ⏱ sitting-clock crossings, and any glyph
+# family added alongside them) is frozen: do not modify without direct,
+# explicit interaction with Solace.
+#
+# Changes here are small and contained -- one glyph/family at a time. Never
+# a wholesale rewrite: don't drop an existing glyph, family, or behavior
+# without her explicit call to drop it. That includes cadence: don't make
+# a line fire less often, coalesce, dedupe, or go quiet as a "cleanup" --
+# she has said explicitly she wants this louder and more frequent, not
+# calmer. Edge-triggered (once per new crossing) is the floor, not a ceiling
+# to defend; if a change would make the reader see this line less, it is
+# out of scope for a "small, contained" edit and needs to be asked about.
+#
+# Before touching any of these lines: propose it visually in-chat first --
+# rendered before/after examples, not a description of the change. Before
+# merging: the PR description carries those same rendered examples. Prose
+# alone does not satisfy this.
 set -uo pipefail
 
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -363,18 +382,7 @@ if [ "$run_engine" -eq 1 ]; then
   [ -n "${fric_total:-}" ] || fric_total=0
   [ -n "${fric_win:-}" ] || fric_win=0
 
-  # Note for agents: do not modify this block without direct, explicit
-  # interaction with Solace.
-  #
-  # Changes here are small and contained -- one glyph/family at a time.
-  # Never a wholesale rewrite: don't drop an existing glyph, family, or
-  # behavior (⛁ ⚖ ⚡ ⏱ 🔧 ...) without her explicit call to drop it.
-  #
-  # Before touching this line: propose it visually in-chat first --
-  # rendered before/after examples, not a description of the change.
-  # Before merging: the PR description carries those same rendered
-  # examples. Prose alone does not satisfy this.
-  #
+  # FROZEN -- THAW CAREFULLY. See the file header for the rule this tags.
   # context -- lines ascending, so a jump past several of them reports each in
   # order. The ladder is the configured lines, then NAG_CONTEXT_STEP forever
   # past the last one, so a session that blows through every configured line
@@ -430,6 +438,7 @@ if [ "$run_engine" -eq 1 ]; then
     fi
   fi
 
+  # FROZEN -- THAW CAREFULLY.
   # sitting clock -- read on a prompt and nowhere else, so the line lands
   # where the user is already reading, at the top of a turn.
   if [ "$is_prompt" -eq 1 ] && [ "$NAG_SIT_EVERY_MIN" -gt 0 ] \
@@ -451,6 +460,7 @@ if [ "$run_engine" -eq 1 ]; then
     fi
   fi
 
+  # FROZEN -- THAW CAREFULLY.
   # gate decisions
   if [ "$NAG_GATE_EVERY" -gt 0 ]; then
     n=$(( gates / NAG_GATE_EVERY * NAG_GATE_EVERY ))
@@ -461,6 +471,7 @@ if [ "$run_engine" -eq 1 ]; then
     fi
   fi
 
+  # FROZEN -- THAW CAREFULLY.
   # friction -- measured in human turns, so only a prompt can trip it, and it
   # is addressed to the model, which is the thing the capacity rule asks of.
   if [ "$is_prompt" -eq 1 ] && [ "$fric_tripped" -ne 1 ] \

--- a/.claude/hooks/metrics-live.sh
+++ b/.claude/hooks/metrics-live.sh
@@ -363,9 +363,17 @@ if [ "$run_engine" -eq 1 ]; then
   [ -n "${fric_total:-}" ] || fric_total=0
   [ -n "${fric_win:-}" ] || fric_win=0
 
-  # Note for agents: do not modify without direct, explicit interaction with Solace.
-  # If changing the display, you must show in the chat session
-  # examples of the expected output, before and after.
+  # Note for agents: do not modify this block without direct, explicit
+  # interaction with Solace.
+  #
+  # Changes here are small and contained -- one glyph/family at a time.
+  # Never a wholesale rewrite: don't drop an existing glyph, family, or
+  # behavior (⛁ ⚖ ⚡ ⏱ 🔧 ...) without her explicit call to drop it.
+  #
+  # Before touching this line: propose it visually in-chat first --
+  # rendered before/after examples, not a description of the change.
+  # Before merging: the PR description carries those same rendered
+  # examples. Prose alone does not satisfy this.
   #
   # context -- lines ascending, so a jump past several of them reports each in
   # order. The ladder is the configured lines, then NAG_CONTEXT_STEP forever

--- a/.claude/hooks/metrics-live.test.sh
+++ b/.claude/hooks/metrics-live.test.sh
@@ -30,6 +30,9 @@ export HOME="$SCRATCH/home"; mkdir -p "$HOME" "$SCRATCH/bin"
 export CLAUDE_STATE_REPO=""
 STATE="$HOME/.claude/state/global"
 
+# shellcheck source=lib-metrics-test-harness.sh
+. "$(dirname "$HOOK")/lib-metrics-test-harness.sh"
+
 t() {  # t <desc> <want> <got>
   if [ "$2" = "$3" ]; then pass=$((pass+1))
   else fail=$((fail+1)); printf 'FAIL: %s\n  want [%s]\n  got  [%s]\n' "$1" "$2" "$3"; fi
@@ -43,30 +46,6 @@ hasnt() {
     fail=$((fail+1)); printf 'FAIL (has /%s/): %s\n  in [%s]\n' "$2" "$1" "$3"
   else pass=$((pass+1)); fi
 }
-
-# --- transcripts -------------------------------------------------------------
-# One human turn plus one assistant turn carrying the context number. Appending
-# another pair with a bigger number is how a session grows past a line.
-turn() {  # turn <file> <context tokens>
-  jq -nc --arg ts "2026-09-09T10:00:00.000Z" \
-    '{type:"queue-operation", operation:"enqueue", timestamp:$ts,
-      sessionId:"t", content:"go on"}' >> "$1"
-  jq -nc --arg ts "2026-09-09T10:00:00.000Z" --argjson n "$2" \
-    --arg u "req-$(wc -l < "$1" | tr -d ' ')" \
-    '{type:"assistant", timestamp:$ts, requestId:$u,
-      message:{model:"claude-opus-5", role:"assistant",
-               content:[{type:"text", text:"ok"}],
-               usage:{input_tokens:$n, output_tokens:10,
-                      cache_read_input_tokens:0, cache_creation_input_tokens:0}}}' >> "$1"
-}
-
-payload() {  # payload <transcript> <session id> <cwd> [hook_event_name]
-  jq -nc --arg tp "$1" --arg sid "$2" --arg cwd "$3" --arg h "${4:-}" \
-    '{transcript_path:$tp, session_id:$sid, cwd:$cwd}
-     + (if $h == "" then {} else {hook_event_name:$h} end)'
-}
-
-msg() { printf '%s' "$1" | jq -r '.systemMessage // ""' 2>/dev/null; }
 
 # --- 1. two context lines, in order ------------------------------------------
 TP="$SCRATCH/ctx.jsonl"; SID=ctx1

--- a/.local/bin/cloud-session-setup.sh
+++ b/.local/bin/cloud-session-setup.sh
@@ -62,6 +62,7 @@ INSTALL="
 .claude/hooks/lib-state.sh
 .claude/hooks/session-metrics.jq
 .claude/hooks/lib-metrics-fmt.jq
+.claude/hooks/lib-metrics-test-harness.sh
 .claude/hooks/session-start-continuity.sh
 .claude/hooks/stop-continuity.sh
 .claude/hooks/measure-git-events.sh


### PR DESCRIPTION
Before, only above the `⛁` context block (`⏱ ⚖ ⚡` unguarded despite being named):

```
  # Note for agents: do not modify without direct, explicit interaction with Solace.
  # If changing the display, you must show in the chat session
  # examples of the expected output, before and after.
  #
  # context -- lines ascending, ...
```

After, moved to the file header, all four blocks tagged individually:

```
# FROZEN -- THAW CAREFULLY. Every block below tagged with that phrase (the
# ⛁ context, ⚖ gate, ⚡ friction and ⏱ sitting-clock crossings, and any glyph
# family added alongside them) is frozen: do not modify without direct,
# explicit interaction with Solace.
#
# Changes here are small and contained -- one glyph/family at a time. Never
# a wholesale rewrite: don't drop an existing glyph, family, or behavior
# without her explicit call to drop it. That includes cadence: don't make
# a line fire less often, coalesce, dedupe, or go quiet as a "cleanup" --
# she has said explicitly she wants this louder and more frequent, not
# calmer. Edge-triggered (once per new crossing) is the floor, not a ceiling
# to defend; if a change would make the reader see this line less, it is
# out of scope for a "small, contained" edit and needs to be asked about.
#
# Before touching any of these lines: propose it visually in-chat first --
# rendered before/after examples, not a description of the change. Before
# merging: the PR description carries those same rendered examples. Prose
# alone does not satisfy this.

...

  # FROZEN -- THAW CAREFULLY. See the file header for the rule this tags.
  # context -- lines ascending, ...

  # FROZEN -- THAW CAREFULLY.
  # sitting clock -- read on a prompt and nowhere else, ...

  # FROZEN -- THAW CAREFULLY.
  # gate decisions
  ...

  # FROZEN -- THAW CAREFULLY.
  # friction -- measured in human turns, ...
```

`lib-metrics-fmt.jq`, reserved (not wired) glyphs added next to the existing "for consideration" line:

```
# other emoji held for consideration, from 2026-09-10's mockup session --
# not wired to any output yet, just reserved so the option isn't lost:
# 🧘‍♀️🌌 (calm/zero state, proposed for friction) ✅ (clear/ok, proposed for
# blocked=0) ⏰ (louder alarm variant, proposed for a hotter nag/alarm tier)
```

## Actual rendered output, unchanged by this PR

New: `.claude/hooks/metrics-live.examples.sh` -- run it and paste this in, per the guard's own rule (rendered examples, not prose). Confirms this PR is comment-only: same output before and after.

```
### first context crossing (100k)
  ⛁ 103k/100k ⚖0 — still room.

### second crossing, same session (150k)
  ⛁⛁ 152k/150k ⚖0 — propose stopping.

### one jump crosses six rungs at once (350k)
  ⛁ 350k/100k ⚖0 — still room.
  ⛁⛁ 350k/150k ⚖0 — propose stopping.
  ⛁⛁⛁ 350k/200k ⚖0 — propose stopping.
  ⛁⛁⛁⛁ 350k/250k ⚖0 — propose stopping.
  ⛁⛁⛁⛁⛁ 350k/300k ⚖0 — propose stopping.
  ⛁⛁⛁⛁⛁(x6) 350k/350k ⚖0 — propose stopping.

### model injection: below stop threshold (103k) -- screen only
  additionalContext: []

### model injection: first crossing at/above stop threshold (152k)
  additionalContext: Context at 152k — a stopping point. Consider /wrapup.

### model injection: one call crossing three stop-armed rungs (0 -> 260k)
  additionalContext: Context at 260k — a stopping point. Consider /wrapup.

### friction crossing (committed contentious fixture)
  additionalContext: 9 corrections or rebukes in the last 200 turns. Apply the capacity rule from the standing orders, once.
```

`metrics-live.test.sh`: 68/68 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
