### PR TITLE
settings: show metrics-live readout on every PostToolUse

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -258,6 +258,14 @@
     ],
     "PostToolUse": [
       {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "h=\"$HOME/.claude/hooks/metrics-live.sh\"; [ -f \"$h\" ] && bash \"$h\" posttooluse 0 show 2>/dev/null || true"
+          }
+        ]
+      },
+      {
         "matcher": "Edit|Write|MultiEdit",
         "hooks": [
           {


### PR DESCRIPTION
No-matcher `PostToolUse` entry calling `metrics-live.sh posttooluse 0 show`. Plain show-every-tool-call — no counter/throttle, no "pulse" naming/mechanism. Requested directly, twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)