### PR TITLE
metrics-live: rung-escalating persistent block

### DIFF
--- a/.claude/hooks/metrics-live.sh
+++ b/.claude/hooks/metrics-live.sh
@@ -320,10 +320,15 @@ glyphs() {
   printf '%s' "$out"
 }
 
-# Count of $2 (ascending, space-separated) that $1 has reached or passed.
-count_rungs() {
-  local total="$1" line="$2" n=0 L
-  for L in $line; do [ "$total" -ge "$L" ] && n=$((n + 1)); done
+fib_rungs() {
+  local total="$1" n=0 L
+  for L in 1 2 3 5 8; do [ "$total" -ge "$L" ] && n=$((n + 1)); done
+  printf '%s' "$n"
+}
+
+time_rungs() {
+  local total="$1" n=0 L
+  for L in 25 47 62 90 120; do [ "$total" -ge "$L" ] && n=$((n + 1)); done
   printf '%s' "$n"
 }
 
@@ -591,12 +596,6 @@ fi
 # Shown to the user at the end of a turn -- never sent to the model, so the
 # running decision count costs nothing to display. Any crossing line rides on
 # the front of it rather than arriving as a second message.
-#
-# dotfiles#137: persistent block, rung vocabulary (⛁/⚖/⚡ reps = rungs
-# crossed), built in bash next to the state it already tracks. `row` is
-# untouched. Descopes: sitting glyph reads night/day off the current clock,
-# not each rung's crossing time; nag-reason cluster omits ⚡/🌙/⏱️ (no
-# threshold set yet).
 if [ "$SHOW" = show ] && [ -f "$OUT" ]; then
   # night_nag needs Pacific time, not the host's TZ -- an ephemeral/cloud
   # session usually runs UTC, which read as "LATE!" all evening. Compute the
@@ -610,10 +609,9 @@ if [ "$SHOW" = show ] && [ -f "$OUT" ]; then
   }')
   export TZOFF
 
-  bl_dec=$(printf '%s\n' "$metrics" | jq -r '.session.decisions.total // 0')
-  bl_fric=$(printf '%s\n' "$metrics" | jq -r '.session.friction.total // 0')
-  bl_blocked=$(printf '%s\n' "$metrics" | jq -r '.session.blocked.total // 0')
-  bl_ctx=$(printf '%s\n' "$metrics" | jq -r '.session.context_peak // 0')
+  IFS=$'\t' read -r bl_dec bl_fric bl_blocked bl_ctx <<<"$(printf '%s\n' "$metrics" | jq -r \
+    '[(.session.decisions.total // 0), (.session.friction.total // 0),
+      (.session.blocked.total // 0), (.session.context_peak // 0)] | @tsv')"
 
   bl_ctx_denom=$ctx_line
   if [ "${bl_ctx_denom:-0}" -eq 0 ]; then
@@ -625,7 +623,7 @@ if [ "$SHOW" = show ] && [ -f "$OUT" ]; then
 
   bl_dec_cluster=""
   if [ "${bl_dec:-0}" -gt 0 ]; then
-    r=$(count_rungs "$bl_dec" "1 2 3 5 8")
+    r=$(fib_rungs "$bl_dec")
     g=""; for ((i = 0; i < r; i++)); do g="${g}⚖"; done
     p=""; [ "$bl_dec" -gt 3 ] && p="🤔"
     bl_dec_cluster="${p}${g}(x${bl_dec})"
@@ -633,7 +631,7 @@ if [ "$SHOW" = show ] && [ -f "$OUT" ]; then
 
   bl_fric_cluster=""
   if [ "${bl_fric:-0}" -gt 0 ]; then
-    r=$(count_rungs "$bl_fric" "1 2 3 5 8")
+    r=$(fib_rungs "$bl_fric")
     g=""; for ((i = 0; i < r; i++)); do g="${g}⚡"; done
     bl_fric_cluster="${g}(x${bl_fric})"
   fi
@@ -644,9 +642,9 @@ if [ "$SHOW" = show ] && [ -f "$OUT" ]; then
   bl_sit_cluster=""
   if [ "${sit_start:-0}" -gt 0 ]; then
     sit_min=$(( (now_ts - sit_start) / 60 ))
-    r=$(count_rungs "$sit_min" "25 46 66 90 120")
+    r=$(time_rungs "$sit_min")
     pac_hour=$(( ( ($(date +%s) + TZOFF) / 3600 ) % 24 ))
-    sg="⏱️"; [ "$pac_hour" -ge 23 ] && sg="🌙"
+    sg="⏱️"; { [ "$pac_hour" -ge 22 ] || [ "$pac_hour" -lt 5 ]; } && sg="🌙"
     reps=""; for ((i = 0; i < r; i++)); do reps="${reps}${sg}"; done
     bl_sit_cluster="⏱$(hm "$sit_min")${reps}"
   fi

--- a/.claude/hooks/metrics-live.sh
+++ b/.claude/hooks/metrics-live.sh
@@ -320,6 +320,13 @@ glyphs() {
   printf '%s' "$out"
 }
 
+# Count of $2 (ascending, space-separated) that $1 has reached or passed.
+count_rungs() {
+  local total="$1" line="$2" n=0 L
+  for L in $line; do [ "$total" -ge "$L" ] && n=$((n + 1)); done
+  printf '%s' "$n"
+}
+
 # Git state folded into a nag line -- the same shorthand as lib-metrics-fmt.jq's
 # `work`, but the crossing lines run in bash, not jq. Empty on a clean tree.
 work_str() {
@@ -584,6 +591,12 @@ fi
 # Shown to the user at the end of a turn -- never sent to the model, so the
 # running decision count costs nothing to display. Any crossing line rides on
 # the front of it rather than arriving as a second message.
+#
+# dotfiles#137: persistent block, rung vocabulary (⛁/⚖/⚡ reps = rungs
+# crossed), built in bash next to the state it already tracks. `row` is
+# untouched. Descopes: sitting glyph reads night/day off the current clock,
+# not each rung's crossing time; nag-reason cluster omits ⚡/🌙/⏱️ (no
+# threshold set yet).
 if [ "$SHOW" = show ] && [ -f "$OUT" ]; then
   # night_nag needs Pacific time, not the host's TZ -- an ephemeral/cloud
   # session usually runs UTC, which read as "LATE!" all evening. Compute the
@@ -596,10 +609,73 @@ if [ "$SHOW" = show ] && [ -f "$OUT" ]; then
     print sign * (hh * 3600 + mm * 60)
   }')
   export TZOFF
-  jq -c -L "$HOOK_DIR" --arg x "$sys_lines" \
+
+  bl_dec=$(printf '%s\n' "$metrics" | jq -r '.session.decisions.total // 0')
+  bl_fric=$(printf '%s\n' "$metrics" | jq -r '.session.friction.total // 0')
+  bl_blocked=$(printf '%s\n' "$metrics" | jq -r '.session.blocked.total // 0')
+  bl_ctx=$(printf '%s\n' "$metrics" | jq -r '.session.context_peak // 0')
+
+  bl_ctx_denom=$ctx_line
+  if [ "${bl_ctx_denom:-0}" -eq 0 ]; then
+    set -- $NAG_CONTEXT_LINES
+    bl_ctx_denom=${1:-100000}
+  fi
+  bl_ctx_glyphs="⛁"; [ "${ctx_rungs:-0}" -gt 0 ] && bl_ctx_glyphs=$(glyphs "$ctx_rungs" "⛁")
+  bl_ctx_cluster="$bl_ctx_glyphs $(kfmt "$bl_ctx")/$(kfmt "$bl_ctx_denom")"
+
+  bl_dec_cluster=""
+  if [ "${bl_dec:-0}" -gt 0 ]; then
+    r=$(count_rungs "$bl_dec" "1 2 3 5 8")
+    g=""; for ((i = 0; i < r; i++)); do g="${g}⚖"; done
+    p=""; [ "$bl_dec" -gt 3 ] && p="🤔"
+    bl_dec_cluster="${p}${g}(x${bl_dec})"
+  fi
+
+  bl_fric_cluster=""
+  if [ "${bl_fric:-0}" -gt 0 ]; then
+    r=$(count_rungs "$bl_fric" "1 2 3 5 8")
+    g=""; for ((i = 0; i < r; i++)); do g="${g}⚡"; done
+    bl_fric_cluster="${g}(x${bl_fric})"
+  fi
+
+  bl_blocked_state="✅"; [ "${bl_blocked:-0}" -gt 0 ] && bl_blocked_state="⛔"
+  bl_blocked_cluster="🔧${bl_blocked_state}(x${bl_blocked:-0})"
+
+  bl_sit_cluster=""
+  if [ "${sit_start:-0}" -gt 0 ]; then
+    sit_min=$(( (now_ts - sit_start) / 60 ))
+    r=$(count_rungs "$sit_min" "25 46 66 90 120")
+    pac_hour=$(( ( ($(date +%s) + TZOFF) / 3600 ) % 24 ))
+    sg="⏱️"; [ "$pac_hour" -ge 23 ] && sg="🌙"
+    reps=""; for ((i = 0; i < r; i++)); do reps="${reps}${sg}"; done
+    bl_sit_cluster="⏱$(hm "$sit_min")${reps}"
+  fi
+
+  bl_reason=""; bl_propose=0
+  [ "${ctx_stop_line:-0}" -gt 0 ] && { bl_reason="${bl_reason}💸"; bl_propose=1; }
+  [ "${bl_dec:-0}" -gt 3 ]        && { bl_reason="${bl_reason}🤔"; bl_propose=1; }
+  [ "${bl_blocked:-0}" -ge 3 ]    && { bl_reason="${bl_reason}⛔"; bl_propose=1; }
+  bl_verdict="still room"
+  [ "$bl_propose" -eq 1 ] && bl_verdict="propose stopping"
+  [ -n "$bl_reason" ] && bl_reason="${bl_reason} "
+
+  bl_main="$bl_ctx_cluster"
+  [ -n "$bl_dec_cluster" ] && bl_main="$bl_main $bl_dec_cluster"
+  [ -n "$bl_fric_cluster" ] && bl_main="$bl_main $bl_fric_cluster"
+  bl_main="$bl_main $bl_blocked_cluster"
+  [ -n "$bl_sit_cluster" ] && bl_main="$bl_main $bl_sit_cluster"
+  bl_main="$bl_main — ${bl_reason}${bl_verdict}."
+
+  bl_second=$(jq -r -L "$HOOK_DIR" \
     'include "lib-metrics-fmt";
-     {systemMessage: (if $x == "" then block else $x + "\n" + block end)}' \
-    "$OUT" 2>/dev/null
+     turns + (work as $w | if $w == "" then "" else " " + $w end)' \
+    "$OUT" 2>/dev/null)
+  bl_block="$bl_main"
+  [ -n "$bl_second" ] && bl_block="$bl_block
+$bl_second"
+
+  jq -nc --arg s "$sys_lines" --arg b "$bl_block" \
+    '{systemMessage: (if $s == "" then $b else $s + "\n" + $b end)}'
 elif [ -n "$sys_lines" ]; then
   jq -nc --arg s "$sys_lines" '{systemMessage: $s}'
 fi


### PR DESCRIPTION
Part of #137 — the block (systemMessage) unification piece only. Single file changed, no new tests, no CI changes, no docs touched. Zero comments added by this PR (the review asked for two existing ones cut; they are).

`metrics-live.sh`'s `SHOW=show` render (fires on Stop/SubagentStop/PostToolUse/git/question) now uses the locked crossing-line vocabulary instead of `lib-metrics-fmt.jq`'s old `block()`. `block()` itself is untouched and still compiles — left dead, not cut. `row` (the terminal statusline) is untouched.

```
before (git/question/stop, old block()):
  103k/170k ⚖ 1[0/0/1] ⚡ 1[0/0/1] ⛔ 3  ⏱9m⟳10m
  ⇢ 3 ⚙ 29 ⎇ 1~

after:
  ⛁⛁⛁ 205k/200k 🤔⚖⚖⚖⚖(x5) ⚡⚡⚡⚡⚡(x11) 🔧⛔(x4) ⏱3h14⏱️⏱️⏱️⏱️⏱️ — 💸🤔⛔ propose stopping.
  ⇢ 3 ⚙ 29 ⎇ 1~
```

Built in bash (`metrics-live.sh`), not `lib-metrics-fmt.jq` — every piece it needs (`ctx_rungs`, `sit_start`) already lives in the crossing engine's own state; threading that into jq just to render it back out would be the bigger change.

## Review round: what changed since the first push

- `count_rungs` split into two hardcoded ladders, `fib_rungs` (1 2 3 5 8) and `time_rungs` (25 47 62 90 120) — per review. The time ladder's rungs 2 and 3 moved: 46→47, 62 replacing 66.
- Night glyph now uses `night_nag`'s own definition (`>= 22 or < 5`). It was `>= 23` with no lower bound, so Pacific 00:00–04:59 rendered the **day** glyph.
- Four `jq` spawns for four scalar fields out of one `$metrics` value collapsed into one `@tsv` read — this path fires on `PostToolUse`, i.e. every tool call.
- Both comments the review asked to cut are cut.

Not taken: the bot's third finding, that the three ladders are hardcoded rather than `METRICS_*`-overridable. Hardcoding them is what the review asked for.

# Rendered examples

Everything below is real output from `metrics-live.sh` driven through `lib-metrics-test-harness.sh` with synthetic transcripts, not hand-written.

## Decisions ladder — glyph reps = fib rungs crossed, `(xN)` = raw total, 🤔 prefix past 3

```
n=1    ⛁ 40k/100k ⚖(x1) 🔧✅(x0) — still room.
n=2    ⛁ 40k/100k ⚖⚖(x2) 🔧✅(x0) — still room.
n=3    ⛁ 40k/100k ⚖⚖⚖(x3) 🔧✅(x0) — still room.
n=4    ⛁ 40k/100k 🤔⚖⚖⚖(x4) 🔧✅(x0) — 🤔 propose stopping.
n=5    ⛁ 40k/100k 🤔⚖⚖⚖⚖(x5) 🔧✅(x0) — 🤔 propose stopping.
n=8    ⛁ 40k/100k 🤔⚖⚖⚖⚖⚖(x8) 🔧✅(x0) — 🤔 propose stopping.
n=13   ⛁ 40k/100k 🤔⚖⚖⚖⚖⚖(x13) 🔧✅(x0) — 🤔 propose stopping.
```

## Friction ladder — same fib rungs, driven off the committed contentious fixture, truncated

```
friction=0   ⛁ 1/100k 🔧✅(x0) — still room.
friction=1   ⛁ 1/100k ⚡(x1) 🔧✅(x0) — still room.
friction=2   ⛁ 1/100k ⚡⚡(x2) 🔧✅(x0) — still room.
friction=3   ⛁ 1/100k ⚡⚡⚡(x3) 🔧✅(x0) — still room.
friction=4   ⛁ 1/100k ⚡⚡⚡(x4) 🔧✅(x0) — still room.
friction=5   ⛁ 1/100k ⚡⚡⚡⚡(x5) 🔧✅(x0) — still room.
friction=6   ⛁ 1/100k ⚡⚡⚡⚡(x6) 🔧✅(x0) — still room.
friction=7   ⛁ 1/100k ⚡⚡⚡⚡(x7) 🔧✅(x0) — still room.
friction=8   ⛁ 1/100k ⚡⚡⚡⚡⚡(x8) 🔧✅(x0) — still room.
friction=11  ⛁ 1/100k ⚡⚡⚡⚡⚡(x11) 🔧✅(x0) — still room.
```

## Blocked — 🔧 prefix always, state glyph flips at the first refusal, ⛔ joins the nag cluster at 3

```
n=0   ⛁ 40k/100k 🔧✅(x0) — still room.
n=1   ⛁ 40k/100k 🔧⛔(x1) — still room.
n=3   ⛁ 40k/100k 🔧⛔(x3) — ⛔ propose stopping.
n=7   ⛁ 40k/100k 🔧⛔(x7) — ⛔ propose stopping.
```

## Context rungs — the crossing lines still ride in front of the block

The one-shot crossing lines' own `⚖`/`⚡` format is untouched by this PR (still `⚖0`, the pre-existing plain-digit style), so both styles appear in one Stop output. That is on #137, not here.

```
--- 103k ---
⛁ 103k/100k ⚖0 — still room.
⛁ 103k/100k 🔧✅(x0) — still room.

--- 152k ---
⛁ 152k/100k ⚖0 — still room.
⛁⛁ 152k/150k ⚖0 — propose stopping.
⛁⛁ 152k/150k 🔧✅(x0) — 💸 propose stopping.

--- 350k ---
⛁ 350k/100k ⚖0 — still room.
⛁⛁ 350k/150k ⚖0 — propose stopping.
⛁⛁⛁ 350k/200k ⚖0 — propose stopping.
⛁⛁⛁⛁ 350k/250k ⚖0 — propose stopping.
⛁⛁⛁⛁⛁ 350k/300k ⚖0 — propose stopping.
⛁⛁⛁⛁⛁(x6) 350k/350k ⚖0 — propose stopping.
⛁⛁⛁⛁⛁(x6) 350k/350k 🔧✅(x0) — 💸 propose stopping.
```

## Sitting clock — the ladder move, before and after

Same run, day glyph forced by pinning the clock to 15:00 PT.

```
        before (46/66)          after (47/62)
10m     ⏱10m                    ⏱10m
24m     ⏱24m                    ⏱24m
25m     ⏱25m⏱️                   ⏱25m⏱️
46m     ⏱46m⏱️⏱️                  ⏱46m⏱️              <- rung 2 moved to 47
47m     ⏱47m⏱️⏱️                  ⏱47m⏱️⏱️
61m     ⏱1h01⏱️⏱️                 ⏱1h01⏱️⏱️
62m     ⏱1h02⏱️⏱️                 ⏱1h02⏱️⏱️⏱️            <- rung 3 moved to 62
89m     ⏱1h29⏱️⏱️⏱️                ⏱1h29⏱️⏱️⏱️
90m     ⏱1h30⏱️⏱️⏱️⏱️               ⏱1h30⏱️⏱️⏱️⏱️
119m    ⏱1h59⏱️⏱️⏱️⏱️               ⏱1h59⏱️⏱️⏱️⏱️
120m    ⏱2h00⏱️⏱️⏱️⏱️⏱️              ⏱2h00⏱️⏱️⏱️⏱️⏱️
200m    ⏱3h20⏱️⏱️⏱️⏱️⏱️              ⏱3h20⏱️⏱️⏱️⏱️⏱️         (capped at 5)
```

Full lines, after:

```
10m   ⛁ 40k/100k 🔧✅(x0) ⏱10m — still room.
25m   ⛁ 40k/100k 🔧✅(x0) ⏱25m⏱️ — still room.
47m   ⛁ 40k/100k 🔧✅(x0) ⏱47m⏱️⏱️ — still room.
62m   ⛁ 40k/100k 🔧✅(x0) ⏱1h02⏱️⏱️⏱️ — still room.
90m   ⛁ 40k/100k 🔧✅(x0) ⏱1h30⏱️⏱️⏱️⏱️ — still room.
120m  ⛁ 40k/100k 🔧✅(x0) ⏱2h00⏱️⏱️⏱️⏱️⏱️ — still room.
200m  ⛁ 40k/100k 🔧✅(x0) ⏱3h20⏱️⏱️⏱️⏱️⏱️ — still room.
```

## Night glyph — the bug the review caught, before and after

90 minutes sitting, same session, the clock walked around the Pacific day.

```
              before (>= 23)              after (>= 22 or < 5)
09:00 PT      ⏱1h30⏱️⏱️⏱️⏱️                  ⏱1h30⏱️⏱️⏱️⏱️
14:00 PT      ⏱1h30⏱️⏱️⏱️⏱️                  ⏱1h30⏱️⏱️⏱️⏱️
21:00 PT      ⏱1h30⏱️⏱️⏱️⏱️                  ⏱1h30⏱️⏱️⏱️⏱️
22:00 PT      ⏱1h30⏱️⏱️⏱️⏱️  <- wrong        ⏱1h30🌙🌙🌙🌙
23:00 PT      ⏱1h30🌙🌙🌙🌙                  ⏱1h30🌙🌙🌙🌙
02:00 PT      ⏱1h30⏱️⏱️⏱️⏱️  <- wrong        ⏱1h30🌙🌙🌙🌙
04:00 PT      ⏱1h30⏱️⏱️⏱️⏱️  <- wrong        ⏱1h30🌙🌙🌙🌙
05:00 PT      ⏱1h30⏱️⏱️⏱️⏱️                  ⏱1h30⏱️⏱️⏱️⏱️
```

## Everything lit at once

205k context, 5 decisions, 11 friction, 4 blocked, 3h14 sitting.

```
15:00 PT:
  ⛁ 205k/100k ⚖0 ⚡⚡⚡⚡⚡(x11) 11 — still room.
  ⛁⛁ 205k/150k ⚖0 ⚡⚡⚡⚡⚡(x11) 11 — propose stopping.
  ⛁⛁⛁ 205k/200k ⚖0 ⚡⚡⚡⚡⚡(x11) 11 — propose stopping.
  ⛁⛁⛁ 205k/200k 🤔⚖⚖⚖⚖(x5) ⚡⚡⚡⚡⚡(x11) 🔧⛔(x4) ⏱3h14⏱️⏱️⏱️⏱️⏱️ — 💸🤔⛔ propose stopping.

23:00 PT, same session:
  ⛁⛁⛁ 205k/200k 🤔⚖⚖⚖⚖(x5) ⚡⚡⚡⚡⚡(x11) 🔧⛔(x4) ⏱3h14🌙🌙🌙🌙🌙 — 💸🤔⛔ propose stopping.
```

## Quiet session, nothing tripped

```
⛁ 40k/100k 🔧✅(x0) — still room.
```

## Two disclosed descopes (both narrow, both still standing)

- **Sitting-clock night/day**: reads night/day off the *current* clock, not each rung's own crossing time — never mixes 🌙/⏱️ in one line, so "grouped night-glyphs first" is moot rather than violated.
- **Nag-reason cluster**: only carries 💸 (context) / 🤔 (decisions>3) / ⛔ (blocked≥3). ⚡/🌙/⏱️ (friction/night/sitting) are omitted — their trigger thresholds aren't set yet (locked spec left them TBD).

Still on #137, not here: the one-shot crossing lines' own `⚖`/`⚡` format, model-injection wording, and the header-comment/PR #136 wiring mismatch.

## Verification

- `bash .claude/hooks/metrics-live.test.sh` — 68/68 pass, suite unmodified.
- `METRICS_HOOKS=$PWD/.claude/hooks bash .local/bin/metrics-preview.sh --quiet` — silent, exit 0.
- `shellcheck -S warning .claude/hooks/metrics-live.sh` — clean.
- Every table above rendered against both the pre-review and post-review script, so the three fixes are shown as diffs, not asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
