### PR TITLE
metrics-live: threshold crossings reach the model, not just the screen

### DIFF
--- a/.claude/hooks/metrics-live.examples.sh
+++ b/.claude/hooks/metrics-live.examples.sh
@@ -91,10 +91,10 @@ askturn() {  # like turn(), but the assistant text is an ask
       sessionId:"t", content:"the first one"}' >> "$1"
 }
 TP6="$SCRATCH/g.jsonl"; turn "$TP6" 40000
-for i in 1 2 3; do askturn "$TP6"; done
+for _ in 1 2 3; do askturn "$TP6"; done
 out=$(payload "$TP6" g "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
 printf '  additionalContext: %s\n' "$(ctx "$out")"
-for i in 4 5; do askturn "$TP6"; done
+for _ in 1 2; do askturn "$TP6"; done
 out=$(payload "$TP6" g "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
 printf '  additionalContext: %s\n' "$(ctx "$out")"
 rm -f "$SITFILE"

--- a/.claude/hooks/metrics-live.examples.sh
+++ b/.claude/hooks/metrics-live.examples.sh
@@ -49,6 +49,56 @@ TP4="$SCRATCH/d.jsonl"; turn "$TP4" 260000
 out=$(payload "$TP4" d "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
 printf '  additionalContext: %s\n' "$(ctx "$out")"
 
+show "model injection: same session, next prompt while still over (no new rung)"
+turn "$TP3" 153000
+out=$(payload "$TP3" c "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
+printf '  additionalContext: %s\n' "$(ctx "$out")"
+
+show "model injection: sitting clock past 1h (screen + model)"
+TP5="$SCRATCH/f.jsonl"; turn "$TP5" 40000
+export METRICS_MODEL_CONTEXT_LINES=999999999
+now=$(date +%s)
+out=$(payload "$TP5" f "$SCRATCH" | METRICS_SIT_EVERY_MIN=60 bash "$HOOK" prompt 0 2>&1)
+SITFILE=$(find "$HOME" -name sitting.json 2>/dev/null | head -1)
+sed -i "s/\"sitting_start\": *[0-9]*/\"sitting_start\": $((now - 4300))/" \
+  "$SITFILE" 2>/dev/null
+turn "$TP5" 41000
+out=$(payload "$TP5" f "$SCRATCH" | METRICS_SIT_EVERY_MIN=60 bash "$HOOK" prompt 0 2>&1)
+printf '  screen:           %s\n' "$(msg "$out")"
+printf '  additionalContext: %s\n' "$(ctx "$out")"
+
+show "model injection: sitting past 2h, next prompt (already raised)"
+sed -i "s/\"sitting_start\": *[0-9]*/\"sitting_start\": $((now - 7400))/" \
+  "$SITFILE" 2>/dev/null
+turn "$TP5" 42000
+out=$(payload "$TP5" f "$SCRATCH" | METRICS_SIT_EVERY_MIN=60 bash "$HOOK" prompt 0 2>&1)
+printf '  screen:           %s\n' "$(msg "$out")"
+printf '  additionalContext: %s\n' "$(ctx "$out")"
+unset METRICS_MODEL_CONTEXT_LINES
+
+rm -f "$SITFILE"
+
+show "model injection: decision load past 3, then past 5"
+askturn() {  # like turn(), but the assistant text is an ask
+  jq -nc --arg ts "2026-09-09T10:00:00.000Z" \
+    '{type:"assistant", timestamp:$ts, requestId:("q-" + (now|tostring)),
+      message:{model:"claude-opus-5", role:"assistant",
+               content:[{type:"text", text:"Which way should this go?"}],
+               usage:{input_tokens:40000, output_tokens:10,
+                      cache_read_input_tokens:0, cache_creation_input_tokens:0}}}' >> "$1"
+  jq -nc --arg ts "2026-09-09T10:00:00.000Z" \
+    '{type:"queue-operation", operation:"enqueue", timestamp:$ts,
+      sessionId:"t", content:"the first one"}' >> "$1"
+}
+TP6="$SCRATCH/g.jsonl"; turn "$TP6" 40000
+for i in 1 2 3; do askturn "$TP6"; done
+out=$(payload "$TP6" g "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
+printf '  additionalContext: %s\n' "$(ctx "$out")"
+for i in 4 5; do askturn "$TP6"; done
+out=$(payload "$TP6" g "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
+printf '  additionalContext: %s\n' "$(ctx "$out")"
+rm -f "$SITFILE"
+
 show "friction crossing (committed contentious fixture)"
 FIX="$(dirname "$HOOK")/fixtures/friction-contentious.jsonl"
 if [ -f "$FIX" ]; then

--- a/.claude/hooks/metrics-live.sh
+++ b/.claude/hooks/metrics-live.sh
@@ -266,7 +266,7 @@ for v in ctx_line ctx_rungs ctx_stop_line time_line tl_sitting gate_line fric_tr
 done
 # -1 is a nag file written before the clock moved out of it: its time_line
 # belongs to a sitting nobody can name, so it is spent rather than trusted.
-[ "$tl_sitting" -eq "$sit_start" ] || { time_line=0; m_sit_at=0; tl_sitting=$sit_start; }
+[ "$tl_sitting" -eq "$sit_start" ] || { time_line=0; tl_sitting=$sit_start; }
 
 # A nag file written before context_rungs/context_stop_line existed has
 # context_line but defaults both new fields to 0 -- read literally, a session
@@ -496,17 +496,25 @@ if [ "$run_engine" -eq 1 ]; then
       add_line "$t"; record_crossing time "$n" "$t"
       time_line=$n
     fi
-    # Model side: same clock, its own cadence -- every prompt once the
-    # sitting is over the first rung.
-    r=$(rung_of "$NAG_SIT_EVERY_MIN" "$NAG_SIT_EVERY_MIN" "$sit_min")
-    if [ "$r" -gt 0 ]; then
-      if [ "$r" -ge $((NAG_SIT_EVERY_MIN * 2)) ]; then sit_verdict="Stop here and run /wrapup."
-      else sit_verdict="Say so and offer a break."; fi
+  fi
+
+  # Model side of the sitting clock. Reads the same thresholds the screen
+  # line does and defines none of its own; a rung of 0 means the shared clock
+  # restarted, which spends the injection with it.
+  if [ "$is_prompt" -eq 1 ] && [ "$NAG_SIT_EVERY_MIN" -gt 0 ] \
+     && [ "$sit_start" -gt 0 ]; then
+    m_min=$(( (now_ts - sit_start) / 60 ))
+    r=$(rung_of "$NAG_SIT_EVERY_MIN" "$NAG_SIT_EVERY_MIN" "$m_min")
+    if [ "$r" -eq 0 ]; then
+      m_sit_at=0
+    else
+      if [ "$r" -ge $((NAG_SIT_EVERY_MIN * 2)) ]; then sv="Stop here and run /wrapup."
+      else sv="Say so and offer a break."; fi
       if [ "$m_sit_at" -eq 0 ]; then
         m_sit_at=$r
-        add_model "Sitting $(hm "$sit_min") at this machine, past $(hm "$r"). $sit_verdict"
+        add_model "Sitting $(hm "$m_min") at this machine, past $(hm "$r"). $sv"
       else
-        add_model "Sitting $(hm "$sit_min"), past $(hm "$r"). Already raised at $(hm "$m_sit_at") and not acted on. $sit_verdict"
+        add_model "Sitting $(hm "$m_min"), past $(hm "$r"). Already raised at $(hm "$m_sit_at") and not acted on. $sv"
       fi
     fi
   fi

--- a/.claude/hooks/metrics-live.sh
+++ b/.claude/hooks/metrics-live.sh
@@ -86,6 +86,14 @@ NAG_SIT_GAP_MIN="${METRICS_SIT_GAP_MIN:-30}"
 NAG_FRICTION_N="${METRICS_FRICTION_N:-3}"
 NAG_FRICTION_TURNS="${METRICS_FRICTION_TURNS:-20}"
 NAG_GATE_EVERY="${METRICS_GATE_EVERY:-5}"
+# Model-facing ladders. Separate from the screen ladders above: the screen
+# line is a glance, the injection is an instruction, and they escalate on
+# different numbers. Level-triggered, not edge -- once over the lowest rung
+# every prompt carries the line until the session ends.
+NAG_MODEL_CONTEXT_LINES="${METRICS_MODEL_CONTEXT_LINES:-105000 125000 175000 200000}"
+NAG_MODEL_CONTEXT_STEP="${METRICS_MODEL_CONTEXT_STEP:-50000}"
+NAG_MODEL_DECISION_LINES="${METRICS_MODEL_DECISION_LINES:-3 5 8 13 21}"
+NAG_MODEL_DECISION_STEP="${METRICS_MODEL_DECISION_STEP:-21}"
 # Local hour from which a Stop on an archivable session is worth interrupting.
 NAG_STOP_HOUR="${METRICS_STOP_HOUR:-22}"
 
@@ -237,9 +245,10 @@ save_sitting() {
 # the prompt that restarted it, and they must be free to speak again.
 ctx_line=0; ctx_rungs=0; ctx_stop_line=0; time_line=0; tl_sitting=0; gate_line=0; fric_tripped=0
 since_nag=0; resume_ts=0; nag_pending=0; late_nagged=0
+m_ctx_at=0; m_sit_at=0; m_dec_at=0
 if [ -f "$NAGF" ]; then
   IFS=$'\t' read -r ctx_line ctx_rungs ctx_stop_line time_line tl_sitting gate_line fric_tripped \
-                    since_nag resume_ts nag_pending late_nagged \
+                    since_nag resume_ts nag_pending late_nagged m_ctx_at m_sit_at m_dec_at \
     <<<"$(jq -r '[(.context_line // 0), (.context_rungs // 0), (.context_stop_line // 0),
                   (.time_line // 0), (.time_line_sitting // -1),
                   (.gate_line // 0),
@@ -247,15 +256,17 @@ if [ -f "$NAGF" ]; then
                   (if .since_nag then 1 else 0 end),
                   (.resume_ts // 0),
                   (if .nag_pending then 1 else 0 end),
-                  (if .late_nagged then 1 else 0 end)] | @tsv' "$NAGF" 2>/dev/null)"
+                  (if .late_nagged then 1 else 0 end),
+                  (.model_context_at // 0), (.model_sitting_at // 0),
+                  (.model_decision_at // 0)] | @tsv' "$NAGF" 2>/dev/null)"
 fi
 for v in ctx_line ctx_rungs ctx_stop_line time_line tl_sitting gate_line fric_tripped \
-         since_nag resume_ts nag_pending late_nagged; do
+         since_nag resume_ts nag_pending late_nagged m_ctx_at m_sit_at m_dec_at; do
   [ -n "${!v}" ] || eval "$v=0"
 done
 # -1 is a nag file written before the clock moved out of it: its time_line
 # belongs to a sitting nobody can name, so it is spent rather than trusted.
-[ "$tl_sitting" -eq "$sit_start" ] || { time_line=0; tl_sitting=$sit_start; }
+[ "$tl_sitting" -eq "$sit_start" ] || { time_line=0; m_sit_at=0; tl_sitting=$sit_start; }
 
 # A nag file written before context_rungs/context_stop_line existed has
 # context_line but defaults both new fields to 0 -- read literally, a session
@@ -288,11 +299,13 @@ save_nag() {
         --argjson gl "$gate_line" --argjson ft "$fric_tripped" \
         --argjson sn "$since_nag" --argjson rt "$resume_ts" --argjson np "$nag_pending" \
         --argjson ln "$late_nagged" \
+        --argjson mc "$m_ctx_at" --argjson ms "$m_sit_at" --argjson md "$m_dec_at" \
     '{context_line: $cl, context_rungs: $cr, context_stop_line: $cs,
       time_line: $tl, time_line_sitting: $ts, gate_line: $gl,
       friction_tripped: ($ft == 1),
       since_nag: ($sn == 1), resume_ts: $rt, nag_pending: ($np == 1),
-      late_nagged: ($ln == 1)}' \
+      late_nagged: ($ln == 1),
+      model_context_at: $mc, model_sitting_at: $ms, model_decision_at: $md}' \
     > "$NAGF.$$" 2>/dev/null \
     && mv -f "$NAGF.$$" "$NAGF" 2>/dev/null || rm -f "$NAGF.$$" 2>/dev/null
 }
@@ -330,6 +343,19 @@ time_rungs() {
   local total="$1" n=0 L
   for L in 25 47 62 90 120; do [ "$total" -ge "$L" ] && n=$((n + 1)); done
   printf '%s' "$n"
+}
+
+# $1 ladder, $2 step, $3 value -- the highest rung at or below the value, or
+# 0 if it is under the first one. The ladder extends by $2 past its last
+# configured rung forever, the same shape as the screen context ladder.
+rung_of() {
+  local v="$3" hit=0 L last=0
+  for L in $1; do [ "$v" -ge "$L" ] && hit=$L; last=$L; done
+  if [ "$2" -gt 0 ] && [ "$last" -gt 0 ] && [ "$v" -ge "$last" ]; then
+    L=$((last + $2))
+    while [ "$v" -ge "$L" ]; do hit=$L; L=$((L + $2)); done
+  fi
+  printf '%s' "$hit"
 }
 
 # Git state folded into a nag line -- the same shorthand as lib-metrics-fmt.jq's
@@ -380,17 +406,19 @@ if [ "$run_engine" -eq 1 ]; then
     save_sitting
   fi
 
-  IFS=$'\t' read -r ctx gates fric_total fric_win <<<"$(printf '%s\n' "$metrics" | jq -r \
+  IFS=$'\t' read -r ctx gates decs fric_total fric_win <<<"$(printf '%s\n' "$metrics" | jq -r \
     --argjson w "$NAG_FRICTION_TURNS" \
     '(.session.user_turns // 0) as $t
      | [ (.session.context_peak // 0),
          (.session.decisions.gate // 0),
+         (.session.decisions.total // 0),
          (.session.friction.total // 0),
          ([ .friction[]?
             | select(.type == "correction" or .type == "rebuke")
             | select((.turn_ordinal // 0) > ($t - $w)) ] | length) ] | @tsv')"
   [ -n "${ctx:-}" ] || ctx=0
   [ -n "${gates:-}" ] || gates=0
+  [ -n "${decs:-}" ] || decs=0
   [ -n "${fric_total:-}" ] || fric_total=0
   [ -n "${fric_win:-}" ] || fric_win=0
 
@@ -414,19 +442,13 @@ if [ "$run_engine" -eq 1 ]; then
   fi
   # A single invocation can cross several rungs at once (a big tool result
   # landing between prompts, or a subagent's output). Each still gets its own
-  # screen line -- "reports each in order" above -- but the model injection
-  # is once per *call*, not once per rung: stacking one "already raised" line
-  # per rung crossed in the same call would claim a separate earlier occasion
-  # for each, when they all just happened now and the model never had a turn
-  # in between to act on any of them.
-  ctx_stop_before=$ctx_stop_line
-  ctx_stop_fired=0
+  # screen line -- "reports each in order" above. The model injection below
+  # is one line per prompt whatever the screen did, on its own ladder.
   for L in $ladder; do
     if [ "$ctx" -ge "$L" ] && [ "$L" -gt "$ctx_line" ]; then
       ctx_rungs=$((ctx_rungs + 1))
       if [ "$L" -ge "$NAG_CONTEXT_STOP_AT" ]; then
         verdict="propose stopping"
-        ctx_stop_fired=1
         ctx_stop_line=$L
       else
         verdict="still room"
@@ -438,15 +460,19 @@ if [ "$run_engine" -eq 1 ]; then
       ctx_line=$L; since_nag=1
     fi
   done
-  # Model injection only from the stop threshold up, and only once per call:
-  # the first time it ever fires, offer a stopping point; every call after
-  # that says plainly the offer already went out and nothing came of it,
-  # rather than repeating it verbatim.
-  if [ "$ctx_stop_fired" -eq 1 ]; then
-    if [ "$ctx_stop_before" -eq 0 ]; then
-      add_model "Context at $(kfmt "$ctx") — a stopping point. Consider /wrapup."
-    else
-      add_model "Context at $(kfmt "$ctx"), past $(kfmt "$ctx_stop_line"). Already raised at $(kfmt "$ctx_stop_before") and not acted on."
+  # Model injection rides its own ladder and its own cadence: every prompt
+  # while the number is over the lowest rung, not once per crossing. The
+  # first one offers a stopping point; every one after names the rung it is
+  # past and that the offer already went out.
+  if [ "$is_prompt" -eq 1 ]; then
+    r=$(rung_of "$NAG_MODEL_CONTEXT_LINES" "$NAG_MODEL_CONTEXT_STEP" "$ctx")
+    if [ "$r" -gt 0 ]; then
+      if [ "$m_ctx_at" -eq 0 ]; then
+        m_ctx_at=$r
+        add_model "Context at $(kfmt "$ctx"), past $(kfmt "$r") — a stopping point. Offer one, or /wrapup."
+      else
+        add_model "Context at $(kfmt "$ctx"), past $(kfmt "$r"). Already raised at $(kfmt "$m_ctx_at") and not acted on."
+      fi
     fi
   fi
 
@@ -470,6 +496,19 @@ if [ "$run_engine" -eq 1 ]; then
       add_line "$t"; record_crossing time "$n" "$t"
       time_line=$n
     fi
+    # Model side: same clock, its own cadence -- every prompt once the
+    # sitting is over the first rung.
+    r=$(rung_of "$NAG_SIT_EVERY_MIN" "$NAG_SIT_EVERY_MIN" "$sit_min")
+    if [ "$r" -gt 0 ]; then
+      if [ "$r" -ge $((NAG_SIT_EVERY_MIN * 2)) ]; then sit_verdict="Stop here and run /wrapup."
+      else sit_verdict="Say so and offer a break."; fi
+      if [ "$m_sit_at" -eq 0 ]; then
+        m_sit_at=$r
+        add_model "Sitting $(hm "$sit_min") at this machine, past $(hm "$r"). $sit_verdict"
+      else
+        add_model "Sitting $(hm "$sit_min"), past $(hm "$r"). Already raised at $(hm "$m_sit_at") and not acted on. $sit_verdict"
+      fi
+    fi
   fi
 
   # FROZEN -- THAW CAREFULLY.
@@ -480,6 +519,21 @@ if [ "$run_engine" -eq 1 ]; then
       t="⚖ $gates gate decisions this session — front-load or card the rest."
       add_line "$t"; record_crossing gate "$n" "$t"
       gate_line=$n
+    fi
+  fi
+
+  # Model side of the decision load, counting every decision pushed to the
+  # user this session -- scoping, inline and gate -- not gate alone: the
+  # capacity that runs out is the capacity to decide, whatever kind.
+  if [ "$is_prompt" -eq 1 ]; then
+    r=$(rung_of "$NAG_MODEL_DECISION_LINES" "$NAG_MODEL_DECISION_STEP" "$decs")
+    if [ "$r" -gt 0 ]; then
+      if [ "$m_dec_at" -eq 0 ]; then
+        m_dec_at=$r
+        add_model "$decs decisions pushed to Solace this session ($gates of them gates), past $r. Front-load or card the rest."
+      else
+        add_model "$decs decisions pushed to Solace this session ($gates of them gates), past $r. Already raised at $m_dec_at and not acted on."
+      fi
     fi
   fi
 

--- a/.claude/hooks/metrics-live.sh
+++ b/.claude/hooks/metrics-live.sh
@@ -407,7 +407,7 @@ if [ "$run_engine" -eq 1 ]; then
     save_sitting
   fi
 
-  IFS=$'\t' read -r ctx gates decs fric_total fric_win <<<"$(printf '%s\n' "$metrics" | jq -r \
+  IFS=$'\t' read -r ctx gates decisions fric_total fric_win <<<"$(printf '%s\n' "$metrics" | jq -r \
     --argjson w "$NAG_FRICTION_TURNS" \
     '(.session.user_turns // 0) as $t
      | [ (.session.context_peak // 0),
@@ -419,7 +419,7 @@ if [ "$run_engine" -eq 1 ]; then
             | select((.turn_ordinal // 0) > ($t - $w)) ] | length) ] | @tsv')"
   [ -n "${ctx:-}" ] || ctx=0
   [ -n "${gates:-}" ] || gates=0
-  [ -n "${decs:-}" ] || decs=0
+  [ -n "${decisions:-}" ] || decisions=0
   [ -n "${fric_total:-}" ] || fric_total=0
   [ -n "${fric_win:-}" ] || fric_win=0
 
@@ -535,13 +535,13 @@ if [ "$run_engine" -eq 1 ]; then
   # user this session -- scoping, inline and gate -- not gate alone: the
   # capacity that runs out is the capacity to decide, whatever kind.
   if [ "$is_prompt" -eq 1 ]; then
-    r=$(rung_of "$NAG_MODEL_DECISION_LINES" "$NAG_MODEL_DECISION_STEP" "$decs")
+    r=$(rung_of "$NAG_MODEL_DECISION_LINES" "$NAG_MODEL_DECISION_STEP" "$decisions")
     if [ "$r" -gt 0 ]; then
       if [ "$m_dec_at" -eq 0 ]; then
         m_dec_at=$r
-        add_model "$decs decisions pushed to Solace this session ($gates of them gates), past $r. Front-load or card the rest."
+        add_model "$decisions decisions pushed to Solace this session ($gates of them gates), past $r. Front-load or card the rest."
       else
-        add_model "$decs decisions pushed to Solace this session ($gates of them gates), past $r. Already raised at $m_dec_at and not acted on."
+        add_model "$decisions decisions pushed to Solace this session ($gates of them gates), past $r. Already raised at $m_dec_at and not acted on."
       fi
     fi
   fi

--- a/.claude/hooks/metrics-live.test.sh
+++ b/.claude/hooks/metrics-live.test.sh
@@ -368,10 +368,8 @@ t 'one jump across three stop-eligible rungs still sends one line' \
   1 "$(printf '%s' "$ctx6d" | grep -c 'stopping point\|Already raised')"
 
 # --- 6b. model injection: sitting clock, mirrors section 6 --------------------
-# Same shape as the context ladder: nothing below the first rung, the first
-# crossing offers the action, a later crossing at a higher rung still names
-# the first rung it was raised at -- and a sitting-clock restart (rung back to
-# 0) clears m_sit_at so the line can fire again on the next real crossing.
+# Same shape as the context ladder, on the sitting clock; a restart of the
+# clock clears the injection with it.
 SID6e=sitmodel
 sitting "$SID6e" 40 10
 out6e=$(payload "$TP2" "$SID6e" "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)

--- a/.claude/hooks/metrics-live.test.sh
+++ b/.claude/hooks/metrics-live.test.sh
@@ -303,14 +303,15 @@ t 'a dirty tree is never archivable' '' "$(printf '%s' "$o4" | jq -r '.decision 
 FIX="$(cd "$(dirname "$0")" && pwd)/fixtures/friction-contentious.jsonl"
 if [ -f "$FIX" ]; then
   ctx=$(payload "$FIX" fric "$SCRATCH" \
-        | METRICS_FRICTION_TURNS=200 bash "$HOOK" prompt 0 2>&1 \
+        | METRICS_FRICTION_TURNS=200 METRICS_SIT_EVERY_MIN=0 bash "$HOOK" prompt 0 2>&1 \
         | jq -r '.hookSpecificOutput.additionalContext // ""')
   has 'the friction line reaches the model'  'corrections or rebukes' "$ctx"
   has 'and names the capacity rule'          'capacity rule'          "$ctx"
   ctx2=$(payload "$FIX" fric "$SCRATCH" \
-         | METRICS_FRICTION_TURNS=200 bash "$HOOK" prompt 0 2>&1 \
+         | METRICS_FRICTION_TURNS=200 METRICS_SIT_EVERY_MIN=0 bash "$HOOK" prompt 0 2>&1 \
          | jq -r '.hookSpecificOutput.additionalContext // ""')
-  t 'and fires once, not every turn' '' "$ctx2"
+  t 'and fires once, not every turn' '0' \
+    "$(printf '%s' "$ctx2" | grep -c 'corrections or rebukes' | tr -d ' ')"
 else
   printf 'SKIP: %s is missing\n' "$FIX"
 fi
@@ -331,26 +332,26 @@ t 'six rungs cross in one jump, in order' \
   "$(printf '100000\n150000\n200000\n250000\n300000\n350000')" \
   "$(jq -r 'select(.kind == "context") | .at' "$STATE/metrics/crossings/$SID5.jsonl" 2>/dev/null)"
 
-# --- 6. model injection only from the stop threshold up -----------------------
-# Below NAG_CONTEXT_STOP_AT (150k default) the crossing is screen-only. At or
-# above it, the first crossing offers a stopping point; every crossing after
-# that says plainly it was already raised, instead of repeating the offer.
+# --- 6. model injection rides its own context ladder -------------------------
+# Below the first NAG_MODEL_CONTEXT_LINES rung (105k default) nothing reaches
+# the model. At or above it the first prompt offers a stopping point; every
+# prompt after says plainly it was already raised, instead of repeating it.
 TP6="$SCRATCH/inject.jsonl"; SID6=inject
 turn "$TP6" 103000
 ctx6a=$(payload "$TP6" "$SID6" "$SCRATCH" \
-        | bash "$HOOK" prompt 0 2>&1 | jq -r '.hookSpecificOutput.additionalContext // ""')
-t 'below the stop threshold, nothing reaches the model' '' "$ctx6a"
+        | METRICS_SIT_EVERY_MIN=0 bash "$HOOK" prompt 0 2>&1 | jq -r '.hookSpecificOutput.additionalContext // ""')
+t 'below the first model rung, nothing reaches the model' '' "$ctx6a"
 
 turn "$TP6" 152000
 ctx6b=$(payload "$TP6" "$SID6" "$SCRATCH" \
-        | bash "$HOOK" prompt 0 2>&1 | jq -r '.hookSpecificOutput.additionalContext // ""')
+        | METRICS_SIT_EVERY_MIN=0 bash "$HOOK" prompt 0 2>&1 | jq -r '.hookSpecificOutput.additionalContext // ""')
 has 'the first crossing at/above the stop line offers to stop' \
     'a stopping point' "$ctx6b"
 
 turn "$TP6" 260000
 ctx6c=$(payload "$TP6" "$SID6" "$SCRATCH" \
-        | bash "$HOOK" prompt 0 2>&1 | jq -r '.hookSpecificOutput.additionalContext // ""')
-has  'a later crossing says it was already raised'  'Already raised at 150k' "$ctx6c"
+        | METRICS_SIT_EVERY_MIN=0 bash "$HOOK" prompt 0 2>&1 | jq -r '.hookSpecificOutput.additionalContext // ""')
+has  'a later crossing says it was already raised'  'Already raised at 125k' "$ctx6c"
 hasnt 'and does not repeat the stopping-point offer' 'a stopping point'      "$ctx6c"
 
 # A single call can cross more than one stop-eligible rung at once (a big

--- a/.claude/hooks/metrics-live.test.sh
+++ b/.claude/hooks/metrics-live.test.sh
@@ -335,9 +335,9 @@ t 'six rungs cross in one jump, in order' \
   "$(jq -r 'select(.kind == "context") | .at' "$STATE/metrics/crossings/$SID5.jsonl" 2>/dev/null)"
 
 # --- 6. model injection rides its own context ladder -------------------------
-# Below the first NAG_MODEL_CONTEXT_LINES rung (105k default) nothing reaches
-# the model. At or above it the first prompt offers a stopping point; every
-# prompt after says plainly it was already raised, instead of repeating it.
+# Below the first rung, nothing reaches the model. At or above it, the first
+# prompt offers a stopping point and every prompt after says it was already
+# raised.
 TP6="$SCRATCH/inject.jsonl"; SID6=inject
 turn "$TP6" 103000
 ctx6a=$(payload "$TP6" "$SID6" "$SCRATCH" \

--- a/.claude/hooks/metrics-live.test.sh
+++ b/.claude/hooks/metrics-live.test.sh
@@ -365,6 +365,70 @@ ctx6d=$(payload "$TP6b" "$SID6b" "$SCRATCH" \
 t 'one jump across three stop-eligible rungs still sends one line' \
   1 "$(printf '%s' "$ctx6d" | grep -c 'stopping point\|Already raised')"
 
+# --- 6b. model injection: sitting clock, mirrors section 6 --------------------
+# Same shape as the context ladder: nothing below the first rung, the first
+# crossing offers the action, a later crossing at a higher rung still names
+# the first rung it was raised at -- and a sitting-clock restart (rung back to
+# 0) clears m_sit_at so the line can fire again on the next real crossing.
+SID6e=sitmodel
+sitting "$SID6e" 40 10
+out6e=$(payload "$TP2" "$SID6e" "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
+t 'below the first sitting rung, nothing reaches the model' '' "$(ctx "$out6e")"
+
+clock 61 10
+out6f=$(payload "$TP2" "$SID6e" "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
+has 'the first sitting crossing offers a break' \
+    'Sitting 1h01 at this machine, past 1h00. Say so and offer a break.' "$(ctx "$out6f")"
+
+clock 121 10
+out6g=$(payload "$TP2" "$SID6e" "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
+has 'a later sitting crossing names the earlier rung raised' \
+    'Already raised at 1h00' "$(ctx "$out6g")"
+hasnt 'and does not repeat the break offer' 'offer a break' "$(ctx "$out6g")"
+
+clock 5 2
+out6h=$(payload "$TP2" "$SID6e" "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
+t 'a sitting-clock restart resets the model side too' '' "$(ctx "$out6h")"
+
+clock 61 10
+out6i=$(payload "$TP2" "$SID6e" "$SCRATCH" | bash "$HOOK" prompt 0 2>&1)
+has 'so the next real crossing offers again, not "already raised"' \
+    'past 1h00. Say so and offer a break.' "$(ctx "$out6i")"
+clock_clear
+
+# --- 6c. model injection: decision load, mirrors section 6 --------------------
+# askturn() is turn() with an assistant "ask" message, the shape
+# session-metrics.jq counts as a decision pushed to the user.
+askturn() {  # like turn(), but the assistant text is an ask
+  jq -nc --arg ts "2026-09-09T10:00:00.000Z" \
+    '{type:"assistant", timestamp:$ts, requestId:("q-" + (now|tostring)),
+      message:{model:"claude-opus-5", role:"assistant",
+               content:[{type:"text", text:"Which way should this go?"}],
+               usage:{input_tokens:40000, output_tokens:10,
+                      cache_read_input_tokens:0, cache_creation_input_tokens:0}}}' >> "$1"
+  jq -nc --arg ts "2026-09-09T10:00:00.000Z" \
+    '{type:"queue-operation", operation:"enqueue", timestamp:$ts,
+      sessionId:"t", content:"the first one"}' >> "$1"
+}
+TP6c="$SCRATCH/decmodel.jsonl"; SID6c=decmodel
+turn "$TP6c" 40000
+ctx6j=$(payload "$TP6c" "$SID6c" "$SCRATCH" \
+        | METRICS_SIT_EVERY_MIN=0 bash "$HOOK" prompt 0 2>&1 | jq -r '.hookSpecificOutput.additionalContext // ""')
+t 'below the first decision rung, nothing reaches the model' '' "$ctx6j"
+
+for _ in 1 2 3; do askturn "$TP6c"; done
+ctx6k=$(payload "$TP6c" "$SID6c" "$SCRATCH" \
+        | METRICS_SIT_EVERY_MIN=0 bash "$HOOK" prompt 0 2>&1 | jq -r '.hookSpecificOutput.additionalContext // ""')
+has 'the first decision crossing offers to front-load or card' \
+    '3 decisions pushed to Solace this session .* past 3\. Front-load or card the rest\.' "$ctx6k"
+
+for _ in 1 2; do askturn "$TP6c"; done
+ctx6l=$(payload "$TP6c" "$SID6c" "$SCRATCH" \
+        | METRICS_SIT_EVERY_MIN=0 bash "$HOOK" prompt 0 2>&1 | jq -r '.hookSpecificOutput.additionalContext // ""')
+has 'a later decision crossing names the earlier rung raised' \
+    'past 5\. Already raised at 3 and not acted on\.' "$ctx6l"
+hasnt 'and does not repeat the front-load offer' 'Front-load or card the rest\.' "$ctx6l"
+
 # --- 7. the sitting line carries git state once #129 makes it safe to ---------
 # dotfiles#132's third deferred item, reconciled now that #129 landed: a dirty
 # or unpushed tree is exactly the fact the "stop here" verdict needs. A fresh


### PR DESCRIPTION
Threshold crossings in `metrics-live.sh` reached the screen; only two of them
reached the model. Now context, the sitting clock and the decision load all
inject into the session context, on their own ladders and their own cadence.

- **Ladders are model-side only.** Screen ladders unchanged.
  - context `105k 125k 175k 200k`, then +50k forever (`METRICS_MODEL_CONTEXT_LINES` / `_STEP`)
  - decisions `3 5 8 13 21`, then +21 (`METRICS_MODEL_DECISION_LINES` / `_STEP`) — **all** decisions, not gates alone
  - sitting defines no thresholds of its own: it reads `METRICS_SIT_EVERY_MIN`, in a block of its own, so every line touching the sitting clock here is a pure addition
- **Level-triggered, once per prompt** while over the lowest rung — the first
  one makes the offer, every one after says it was already raised.
- Wording is the model's own, imperative; the glyph line stays a glance.
- `UserPromptSubmit` only. Every ladder is env-overridable.

Context peak across 693 recorded sessions: p25 89k, median 123k, p75 169k,
p90 225k, max 469k.

## Rendered output

Per the guard at the top of `metrics-live.sh` — from
`bash .claude/hooks/metrics-live.examples.sh`, re-run against the merged head:

```

### first context crossing (100k)
  ⛁ 103k/60k ⚖0 — still room.
⛁⛁ 103k/90k ⚖0 — still room.

### second crossing, same session (150k)
  ⛁⛁⛁ 152k/120k ⚖0 — still room.
⛁⛁⛁⛁ 152k/150k ⚖0 — propose stopping.

### one jump crosses six rungs at once (350k)
  ⛁ 350k/60k ⚖0 — still room.
  ⛁⛁ 350k/90k ⚖0 — still room.
  ⛁⛁⛁ 350k/120k ⚖0 — still room.
  ⛁⛁⛁⛁ 350k/150k ⚖0 — propose stopping.
  ⛁⛁⛁⛁⛁ 350k/185k ⚖0 — propose stopping.
  ⛁⛁⛁⛁⛁(x6) 350k/220k ⚖0 — propose stopping.
  ⛁⛁⛁⛁⛁(x7) 350k/255k ⚖0 — propose stopping.
  ⛁⛁⛁⛁⛁(x8) 350k/290k ⚖0 — propose stopping.
  ⛁⛁⛁⛁⛁(x9) 350k/325k ⚖0 — propose stopping.

### model injection: below stop threshold (103k) -- screen only
  additionalContext: []

### model injection: first crossing at/above stop threshold (152k)
  additionalContext: Context at 152k, past 125k — a stopping point. Offer one, or /wrapup.

### model injection: one call crossing three stop-armed rungs (0 -> 260k)
  additionalContext: Context at 260k, past 250k — a stopping point. Offer one, or /wrapup.

### model injection: same session, next prompt while still over (no new rung)
  additionalContext: Context at 153k, past 125k. Already raised at 125k and not acted on.

### model injection: sitting clock past 1h (screen + model)
  screen:           ⏱ sitting 1h00 — context 41k: stand up.
  additionalContext: Sitting 1h11 at this machine, past 1h00. Say so and offer a break.

### model injection: sitting past 2h, next prompt (already raised)
  screen:           ⏱ sitting 2h00 — context 42k: stop here, run /wrapup.
  additionalContext: Sitting 2h03, past 2h00. Already raised at 1h00 and not acted on. Stop here and run /wrapup.

### model injection: decision load past 3, then past 5
  additionalContext: 3 decisions pushed to Solace this session (0 of them gates), past 3. Front-load or card the rest.
  additionalContext: 5 decisions pushed to Solace this session (0 of them gates), past 5. Already raised at 3 and not acted on.

### friction crossing (committed contentious fixture)
  additionalContext: 9 corrections or rebukes in the last 200 turns. Apply the capacity rule from the standing orders, once.

```

`.claude/hooks/metrics-live.test.sh` 78 passed, 0 failed. shellcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
