### PR TITLE
stop-continuity: detached HEAD on a remote branch is archivable

### DIFF
--- a/.claude/hooks/stop-continuity.sh
+++ b/.claude/hooks/stop-continuity.sh
@@ -218,7 +218,8 @@ set_verdict() {
         *)  add_reason "$unpushed commit(s) unpushed" ;;
       esac
     elif [ "$work_branch" = HEAD ] || [ -z "$work_branch" ]; then
-      add_reason "detached HEAD, no upstream to compare against"
+      [ -n "$(git -C "$work_root" branch -r --contains HEAD 2>/dev/null)" ] \
+        || add_reason "detached HEAD, no upstream to compare against"
     else
       add_reason "\`$work_branch\` has no upstream (never pushed)"
     fi


### PR DESCRIPTION
Fixes #128.

Only add the "no upstream to compare against" reason when the commit
isn't reachable from any remote-tracking branch — `git branch -r --contains HEAD`.

## Verification
Manual: detached at a commit on a pushed branch no longer carries the reason; detached at a local-only commit still does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)