### PR TITLE
metrics-live: Stop always states archival status, with reasons

### DIFF
--- a/.claude/hooks/metrics-live.sh
+++ b/.claude/hooks/metrics-live.sh
@@ -490,26 +490,41 @@ fi
 # anything: clean worktree, nothing unpushed, the state repo's own commits
 # pushed, and the branch either has an open PR or is named by a pointer card.
 _to() { if command -v timeout >/dev/null 2>&1; then timeout "$@"; else shift; "$@"; fi; }
+archival_reasons=""
 archivable() {
-  [ "${dirty:-0}" -eq 0 ] || return 1
-  [ "${unpushed:-0}" -eq 0 ] || return 1
-  local sr n c
+  local sr n c home_ok=0
+  archival_reasons=""
+  add_areason() { archival_reasons="${archival_reasons:+$archival_reasons, }$1"; }
+
+  [ "${dirty:-0}" -eq 0 ] || add_areason "worktree dirty"
+  [ "${unpushed:-0}" -eq 0 ] || add_areason "$unpushed commit(s) unpushed"
   sr=$(state_repo 2>/dev/null) || sr=""
   if [ -n "$sr" ]; then
     n=$(git -C "$sr" rev-list --count '@{u}..HEAD' 2>/dev/null || echo 0)
-    [ "${n:-0}" -eq 0 ] || return 1
+    [ "${n:-0}" -eq 0 ] || add_areason "state repo $n commit(s) unpushed"
   fi
-  [ -n "$work_root" ] || return 1
-  case "$work_branch" in main|master|HEAD|"") return 0 ;; esac
-  if command -v gh >/dev/null 2>&1; then
-    c=$( (cd "$work_root" 2>/dev/null \
-          && _to 10 gh pr list --head "$work_branch" --state open --json number \
-               --jq 'length') 2>/dev/null )
-    [ "${c:-0}" -gt 0 ] 2>/dev/null && return 0
+  if [ -z "$work_root" ]; then
+    add_areason "not a git repo"
+  elif [ -z "$archival_reasons" ]; then
+    case "$work_branch" in
+      main|master|HEAD|"") home_ok=1 ;;
+      *)
+        if command -v gh >/dev/null 2>&1; then
+          c=$( (cd "$work_root" 2>/dev/null \
+                && _to 10 gh pr list --head "$work_branch" --state open --json number \
+                     --jq 'length') 2>/dev/null )
+          [ "${c:-0}" -gt 0 ] 2>/dev/null && home_ok=1
+        fi
+        if [ "$home_ok" -eq 0 ] && [ -n "$sr" ] \
+           && grep -qF -- "$work_branch" "$sr/state/global/kanban.md" 2>/dev/null; then
+          home_ok=1
+        fi
+        [ "$home_ok" -eq 1 ] || add_areason "no PR or pointer card for \`$work_branch\`"
+        ;;
+    esac
   fi
-  [ -n "$sr" ] && grep -qF -- "$work_branch" "$sr/state/global/kanban.md" 2>/dev/null \
-    && return 0
-  return 1
+
+  [ -z "$archival_reasons" ]
 }
 
 # The resume block is a `## Resume` heading in this session's checkpoint
@@ -522,6 +537,13 @@ resume_ckpt() {
 }
 
 if [ "$hook_name" = Stop ]; then
+  archivable > /dev/null
+  if [ -z "$archival_reasons" ]; then
+    add_line "📦 archivable."
+  else
+    add_line "📦 not archivable: ${archival_reasons}."
+  fi
+
   if [ "$nag_pending" -eq 1 ]; then
     # The block above has been answered. Whether the resume block exists is a
     # fact on disk, not an inference from having asked. Either way the nag is

--- a/.claude/hooks/metrics-live.test.sh
+++ b/.claude/hooks/metrics-live.test.sh
@@ -263,7 +263,7 @@ o2=$(S)
 t   'the second Stop does not block' '' "$(printf '%s' "$o2" | jq -r '.decision // ""')"
 has 'and reports the resume block it found' \
     '^Archivable\. Resume block written [0-9]{2}:[0-9]{2} in 2026-09-09-repo-stop1\.md\. Next time: `/resume`\.$' \
-    "$(msg "$o2" | head -1)"
+    "$(msg "$o2" | sed -n 2p)"
 
 o3=$(S)
 t     'a later Stop does not block'  '' "$(printf '%s' "$o3" | jq -r '.decision // ""')"


### PR DESCRIPTION
Stop's `systemMessage` gets the same baseline emoji/metrics block every
event gets. It now also always prepends one line naming whether the chat
is archivable -- and if not, why -- instead of only surfacing that on the
(rare) nag path.

Before, an archivable Stop with nothing new to say showed only the
metrics baseline; you couldn't tell archival status without triggering
the nag. Now every Stop shows both, joined as one message, e.g.:

```
not archivable: worktree dirty.
0/0 gate 0 friction 0
```

archivable() now records its reasons (dirty, unpushed, state-repo
unpushed, no PR/pointer, not a git repo) instead of a bare pass/fail;
the nag path is unchanged.

Generated with Claude Code
