### PR TITLE
stop-continuity: never-pushed reason only when there's something to lose

### DIFF
--- a/.claude/hooks/stop-continuity.sh
+++ b/.claude/hooks/stop-continuity.sh
@@ -221,7 +221,13 @@ set_verdict() {
       [ -n "$(git -C "$work_root" branch -r --contains HEAD 2>/dev/null)" ] \
         || add_reason "detached HEAD, no upstream to compare against"
     else
-      add_reason "\`$work_branch\` has no upstream (never pushed)"
+      # #126: no upstream is only a hazard when there is something on the
+      # branch to lose -- the same "ahead of the default branch" test
+      # branch-home-gate.sh already applies before it looks for a home.
+      vbase=$(git -C "$work_root" symbolic-ref -q --short refs/remotes/origin/HEAD 2>/dev/null)
+      git -C "$work_root" rev-parse --verify -q "${vbase:-origin/main}" >/dev/null 2>&1 || vbase=origin/master
+      vahead=$(git -C "$work_root" rev-list --count "${vbase:-origin/main}..HEAD" 2>/dev/null || echo 0)
+      [ "${vahead:-0}" -gt 0 ] && add_reason "\`$work_branch\` has no upstream (never pushed)"
     fi
   fi
   [ -n "${1:-}" ] && add_reason "$1"

--- a/.claude/hooks/stop-continuity.test.sh
+++ b/.claude/hooks/stop-continuity.test.sh
@@ -104,6 +104,14 @@ eq 'never pushed is not archivable' \
   'not archivable: `claude/never-pushed` has no upstream (never pushed)' "$(verdict)"
 gitq "$WORK" checkout claude/work
 
+# --- a fresh branch, no upstream, zero commits ahead of main -----------------------
+# branch-home-gate.sh already treats this as "nothing to strand"; the verdict
+# should agree instead of flagging the same branch as never-pushed.
+gitq "$WORK" checkout -b claude/fresh-review main
+GH_PRS='[{"url":"https://github.com/o/r/pull/7"}]' stop
+eq 'zero commits ahead, no upstream: archivable' 'archivable' "$(verdict)"
+gitq "$WORK" checkout claude/work
+
 # --- "cannot verify" is never a pass ------------------------------------------------
 GH_FAIL=1 stop
 has 'unverified is not archivable' '^\*\*Verdict:\*\* not archivable: branch home unverified' "$CKPT"


### PR DESCRIPTION
Fixes #126.

```
before: not archivable: `claude/fresh-review` has no upstream (never pushed)
after:  archivable
```

(same fixture, same scenario: fresh branch off main, zero commits ahead, no upstream, PR open)

16/16 `stop-continuity.test.sh` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
