### PR TITLE
metrics-live: no-upstream branch is not "0 unpushed"

### DIFF
--- a/.claude/hooks/metrics-live.sh
+++ b/.claude/hooks/metrics-live.sh
@@ -159,10 +159,18 @@ metrics=$(jq -s \
 [ -n "$metrics" ] || exit 0
 
 # Git state, the part that decides whether the chat is safe to kill.
-dirty=0; unpushed=0; ncommits=0; start_sha=""
+dirty=0; unpushed=0; no_upstream=0; ncommits=0; start_sha=""
 if [ -n "$work_root" ]; then
   dirty=$(git -C "$work_root" status --porcelain 2>/dev/null | wc -l | tr -d ' ')
-  unpushed=$(git -C "$work_root" rev-list --count '@{u}..HEAD' 2>/dev/null || echo 0)
+  # `rev-list @{u}..HEAD` fails when the branch has no upstream at all, and
+  # the `|| echo 0` below used to swallow that into "0 unpushed" -- a never-
+  # pushed branch read as clean. Tell the two apart, same guard as
+  # stop-continuity.sh's.
+  if git -C "$work_root" rev-parse --verify -q --symbolic-full-name '@{u}' >/dev/null 2>&1; then
+    unpushed=$(git -C "$work_root" rev-list --count '@{u}..HEAD' 2>/dev/null || echo 0)
+  else
+    no_upstream=1
+  fi
   # Commits counted from the SHA this session started at, not by timestamp.
   # `--since=<start>` counts everything in the window whatever wrote it, so a
   # fresh clone whose history landed today reports a session's commits as 13
@@ -363,11 +371,12 @@ rung_of() {
 # `work`, but the crossing lines run in bash, not jq. Empty on a clean tree.
 work_str() {
   [ "${ncommits:-0}" -gt 0 ] || [ "${dirty:-0}" -gt 0 ] || [ "${unpushed:-0}" -gt 0 ] \
-    || return 0
+    || [ "${no_upstream:-0}" -gt 0 ] || return 0
   local s="⎇ "
   [ "${ncommits:-0}" -gt 0 ] && s="${s}${ncommits}c"
   [ "${dirty:-0}" -gt 0 ]    && s="${s}${dirty}~"
-  [ "${unpushed:-0}" -gt 0 ] && s="${s}${unpushed}↑"
+  if [ "${no_upstream:-0}" -gt 0 ]; then s="${s}no-upstream"
+  elif [ "${unpushed:-0}" -gt 0 ]; then s="${s}${unpushed}↑"; fi
   printf '%s' "$s"
 }
 
@@ -572,7 +581,9 @@ archivable() {
   add_areason() { archival_reasons="${archival_reasons:+$archival_reasons, }$1"; }
 
   [ "${dirty:-0}" -eq 0 ] || add_areason "worktree dirty"
-  [ "${unpushed:-0}" -eq 0 ] || add_areason "$unpushed commit(s) unpushed"
+  [ "${no_upstream:-0}" -eq 0 ] \
+    && { [ "${unpushed:-0}" -eq 0 ] || add_areason "$unpushed commit(s) unpushed"; } \
+    || add_areason "\`$work_branch\` has no upstream (never pushed)"
   sr=$(state_repo 2>/dev/null) || sr=""
   if [ -n "$sr" ]; then
     n=$(git -C "$sr" rev-list --count '@{u}..HEAD' 2>/dev/null || echo 0)

--- a/.claude/hooks/metrics-live.sh
+++ b/.claude/hooks/metrics-live.sh
@@ -164,12 +164,21 @@ if [ -n "$work_root" ]; then
   dirty=$(git -C "$work_root" status --porcelain 2>/dev/null | wc -l | tr -d ' ')
   # `rev-list @{u}..HEAD` fails when the branch has no upstream at all, and
   # the `|| echo 0` below used to swallow that into "0 unpushed" -- a never-
-  # pushed branch read as clean. Tell the two apart, same guard as
-  # stop-continuity.sh's.
+  # pushed branch read as clean. Tell the two apart, same guard (and the
+  # same two carve-outs) as stop-continuity.sh's set_verdict: a detached
+  # HEAD whose commit already lives on some remote branch isn't a hazard
+  # (#128/#143), and a named branch with no upstream isn't one either
+  # unless it's actually ahead of the default branch -- nothing to lose
+  # yet (#126).
   if git -C "$work_root" rev-parse --verify -q --symbolic-full-name '@{u}' >/dev/null 2>&1; then
     unpushed=$(git -C "$work_root" rev-list --count '@{u}..HEAD' 2>/dev/null || echo 0)
+  elif [ "$work_branch" = HEAD ] || [ -z "$work_branch" ]; then
+    [ -n "$(git -C "$work_root" branch -r --contains HEAD 2>/dev/null)" ] || no_upstream=1
   else
-    no_upstream=1
+    vbase=$(git -C "$work_root" symbolic-ref -q --short refs/remotes/origin/HEAD 2>/dev/null)
+    git -C "$work_root" rev-parse --verify -q "${vbase:-origin/main}" >/dev/null 2>&1 || vbase=origin/master
+    vahead=$(git -C "$work_root" rev-list --count "${vbase:-origin/main}..HEAD" 2>/dev/null || echo 0)
+    [ "${vahead:-0}" -gt 0 ] && no_upstream=1
   fi
   # Commits counted from the SHA this session started at, not by timestamp.
   # `--since=<start>` counts everything in the window whatever wrote it, so a

--- a/.claude/hooks/metrics-live.test.sh
+++ b/.claude/hooks/metrics-live.test.sh
@@ -449,5 +449,30 @@ TP7="$SCRATCH/sit7.jsonl"; turn "$TP7" 1000
 o7=$(clock 61 10; payload "$TP7" sit7 "$REPO7" | bash "$HOOK" prompt 0 2>&1)
 has 'the sitting line shows the dirty tree' '⎇ 1~' "$(msg "$o7")"
 
+# --- 8. no upstream is only a hazard with something on the branch to lose ----
+# The carve-out this PR's review asked for, mirroring stop-continuity.sh's
+# set_verdict (#126): a branch with no @{u} isn't flagged unless it's ahead
+# of the default branch -- $REPO/$REPO7 above have no origin at all, so
+# that comparison always falls back to "not ahead" for them. Exercise it
+# for real with an origin that has a main to compare against.
+ORIGIN8="$SCRATCH/origin8.git"; git init -q --bare "$ORIGIN8"
+REPO8="$SCRATCH/repo8"; mkdir -p "$REPO8"
+git -C "$REPO8" init -q -b main
+git -C "$REPO8" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+git -C "$REPO8" remote add origin "$ORIGIN8"
+git -C "$REPO8" push -q -u origin main
+TP8="$SCRATCH/repo8.jsonl"; turn "$TP8" 1000
+
+git -C "$REPO8" checkout -q -b feat/ahead
+git -C "$REPO8" -c user.email=t@t -c user.name=t commit -q --allow-empty -m work
+o8=$(payload "$TP8" stop8a "$REPO8" Stop | METRICS_STOP_HOUR=23 bash "$HOOK" stop 0 show 2>&1)
+has 'no upstream, ahead of origin/main: not archivable' \
+    'has no upstream \(never pushed\)' "$(msg "$o8")"
+
+git -C "$REPO8" checkout -q -b feat/nothing-to-lose main
+o8b=$(payload "$TP8" stop8b "$REPO8" Stop | METRICS_STOP_HOUR=23 bash "$HOOK" stop 0 show 2>&1)
+hasnt 'no upstream, nothing ahead of origin/main: not flagged' \
+      'has no upstream' "$(msg "$o8b")"
+
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/.claude/hooks/metrics-live.test.sh
+++ b/.claude/hooks/metrics-live.test.sh
@@ -222,6 +222,13 @@ has 'a restarted clock frees the other session to speak again' \
 REPO="$SCRATCH/repo"; mkdir -p "$REPO"
 git -C "$REPO" init -q -b feat/nags
 git -C "$REPO" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+# A real upstream, pushed and clean -- these tests are about the sitting
+# clock and the Stop block, not about unpushed work, and a branch with no
+# upstream at all is its own "not archivable" reason (metrics-live's
+# archivable() checks that before anything else below runs).
+git init -q --bare "$SCRATCH/repo.git"
+git -C "$REPO" remote add origin "$SCRATCH/repo.git"
+git -C "$REPO" push -q -u origin feat/nags
 cat > "$SCRATCH/bin/gh" <<'GH'
 #!/bin/sh
 echo 1


### PR DESCRIPTION
`rev-list --count '@{u}..HEAD'` (metrics-live.sh:165) fails on a branch
with no upstream, and the `|| echo 0` fallback read that as clean. A
never-pushed branch with an open PR or kanban pointer reported
`📦 archivable.` — wrong, and silent.

Same guard stop-continuity.sh already has: check `@{u}` resolves before
counting, and surface "no upstream" as its own archival reason instead of
folding it into the unpushed count. Also fixes the `⎇` work_str nag line,
which had the same blind spot.

## Rendered, real hook run

Scratch repo, branch checked out with no upstream configured, a kanban
pointer present (so the PR/pointer check alone doesn't mask the bug).
Piped a real `Stop` payload (`hook_event_name:"Stop"`, not just the
positional arg) through the actual `metrics-live.sh Stop 0 show`.

**Before:**
```json
{"systemMessage":"» 0/60k 🔧✅(x0) — still room.\n📦 archivable."}
```

**After, same scenario:**
```json
{"systemMessage":"» 0/60k 🔧✅(x0) — still room.\n📦 not archivable: `no-upstream-branch` has no upstream (never pushed)."}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)