### PR TITLE
hooks: one unpushed_state() in lib-state.sh, two callers

### DIFF
--- a/.claude/hooks/lib-state.sh
+++ b/.claude/hooks/lib-state.sh
@@ -93,3 +93,47 @@ block() { printf '{"decision":"block","reason":%s}\n' "$(json_str "$1")"; exit 0
 git_event_re() {
   printf '%s' '\bgit\s+(commit|push|pull|merge|rebase|cherry-pick|revert|checkout|switch|branch|worktree|tag|stash|reset|restore|rm|mv|apply|am)\b|\bgh\s+(pr|release)\b|\b(yadm|dotsync)\b|create_pull_request|merge_pull_request|update_pull_request|update_pull_request_branch|push_files|create_or_update_file|delete_file|create_branch|create_repository|fork_repository'
 }
+
+# Answer "does this branch hold commits that exist nowhere but here?" for a
+# repo root ($1) and the branch name ($2, `HEAD` or empty when detached).
+#
+# It lives here because two hooks have to agree on the answer: metrics-live.sh
+# draws the ⎇ nag and the archival verdict from it, stop-continuity.sh's
+# set_verdict decides from it whether the session is safe to kill. When each
+# had its own copy they drifted -- #148 had to port two carve-outs back into
+# metrics-live.sh that stop-continuity.sh had grown in #126 and #128/#143.
+#
+# Prints one word, plus a count for the first:
+#   ahead <n>     an upstream exists; n commits are not on it (n may be 0)
+#   unknown       an upstream exists, but the count could not be taken
+#   never-pushed  no upstream, and there is work on the branch to lose
+#   safe          no upstream, but nothing on the branch to lose
+#
+# The last two are the carve-outs. A detached HEAD whose commit already lives
+# on some remote branch is not a hazard (#128/#143), and a named branch with
+# no upstream is not one either until it is actually ahead of the default
+# branch (#126) -- the same test branch-home-gate.sh applies before it looks
+# for a home. `rev-list @{u}..HEAD` fails outright when there is no upstream,
+# and the `|| echo 0` that used to swallow that read a never-pushed branch as
+# fully pushed: the "lost work" failure one step earlier than #108/#110.
+unpushed_state() {
+  local root="$1" branch="$2" n base ahead
+
+  if git -C "$root" rev-parse --verify -q --symbolic-full-name '@{u}' >/dev/null 2>&1; then
+    n=$(git -C "$root" rev-list --count '@{u}..HEAD' 2>/dev/null || printf '')
+    [ -n "$n" ] && printf 'ahead %s' "$n" || printf 'unknown'
+    return 0
+  fi
+
+  if [ "$branch" = HEAD ] || [ -z "$branch" ]; then
+    [ -n "$(git -C "$root" branch -r --contains HEAD 2>/dev/null)" ] \
+      && printf 'safe' || printf 'never-pushed'
+    return 0
+  fi
+
+  base=$(git -C "$root" symbolic-ref -q --short refs/remotes/origin/HEAD 2>/dev/null)
+  base="${base:-origin/main}"
+  git -C "$root" rev-parse --verify -q "$base" >/dev/null 2>&1 || base=origin/master
+  ahead=$(git -C "$root" rev-list --count "$base..HEAD" 2>/dev/null || printf 0)
+  [ "${ahead:-0}" -gt 0 ] && printf 'never-pushed' || printf 'safe'
+}

--- a/.claude/hooks/metrics-live.sh
+++ b/.claude/hooks/metrics-live.sh
@@ -162,24 +162,14 @@ metrics=$(jq -s \
 dirty=0; unpushed=0; no_upstream=0; ncommits=0; start_sha=""
 if [ -n "$work_root" ]; then
   dirty=$(git -C "$work_root" status --porcelain 2>/dev/null | wc -l | tr -d ' ')
-  # `rev-list @{u}..HEAD` fails when the branch has no upstream at all, and
-  # the `|| echo 0` below used to swallow that into "0 unpushed" -- a never-
-  # pushed branch read as clean. Tell the two apart, same guard (and the
-  # same two carve-outs) as stop-continuity.sh's set_verdict: a detached
-  # HEAD whose commit already lives on some remote branch isn't a hazard
-  # (#128/#143), and a named branch with no upstream isn't one either
-  # unless it's actually ahead of the default branch -- nothing to lose
-  # yet (#126).
-  if git -C "$work_root" rev-parse --verify -q --symbolic-full-name '@{u}' >/dev/null 2>&1; then
-    unpushed=$(git -C "$work_root" rev-list --count '@{u}..HEAD' 2>/dev/null || echo 0)
-  elif [ "$work_branch" = HEAD ] || [ -z "$work_branch" ]; then
-    [ -n "$(git -C "$work_root" branch -r --contains HEAD 2>/dev/null)" ] || no_upstream=1
-  else
-    vbase=$(git -C "$work_root" symbolic-ref -q --short refs/remotes/origin/HEAD 2>/dev/null)
-    git -C "$work_root" rev-parse --verify -q "${vbase:-origin/main}" >/dev/null 2>&1 || vbase=origin/master
-    vahead=$(git -C "$work_root" rev-list --count "${vbase:-origin/main}..HEAD" 2>/dev/null || echo 0)
-    [ "${vahead:-0}" -gt 0 ] && no_upstream=1
-  fi
+  # Whether this branch holds work that exists nowhere else. lib-state.sh
+  # owns the answer, carve-outs and all, so this hook and stop-continuity.sh
+  # cannot disagree about it (#149).
+  ust=$(unpushed_state "$work_root" "$work_branch")
+  case "$ust" in
+    'ahead '*)    unpushed=${ust#ahead } ;;
+    never-pushed) no_upstream=1 ;;
+  esac
   # Commits counted from the SHA this session started at, not by timestamp.
   # `--since=<start>` counts everything in the window whatever wrote it, so a
   # fresh clone whose history landed today reports a session's commits as 13

--- a/.claude/hooks/stop-continuity.sh
+++ b/.claude/hooks/stop-continuity.sh
@@ -206,29 +206,22 @@ set_verdict() {
   esac
   if [ -n "$work_root" ]; then
     [ -n "$(git -C "$work_root" status --porcelain 2>/dev/null)" ] && add_reason "worktree dirty"
-    # An unconfigured upstream makes `rev-list @{u}..HEAD` fail, and a failure
-    # that falls back to 0 is indistinguishable from a fully-pushed branch --
-    # the "lost work" failure mode one step earlier than #108/#110. Ask about
-    # the upstream first, so a never-pushed branch gets its own reason.
-    if git -C "$work_root" rev-parse --verify -q --symbolic-full-name '@{u}' >/dev/null 2>&1; then
-      unpushed=$(git -C "$work_root" rev-list --count "@{u}..HEAD" 2>/dev/null || printf '')
-      case "${unpushed:-}" in
-        0)  ;;
-        '') add_reason "could not count unpushed commits" ;;
-        *)  add_reason "$unpushed commit(s) unpushed" ;;
-      esac
-    elif [ "$work_branch" = HEAD ] || [ -z "$work_branch" ]; then
-      [ -n "$(git -C "$work_root" branch -r --contains HEAD 2>/dev/null)" ] \
-        || add_reason "detached HEAD, no upstream to compare against"
-    else
-      # #126: no upstream is only a hazard when there is something on the
-      # branch to lose -- the same "ahead of the default branch" test
-      # branch-home-gate.sh already applies before it looks for a home.
-      vbase=$(git -C "$work_root" symbolic-ref -q --short refs/remotes/origin/HEAD 2>/dev/null)
-      git -C "$work_root" rev-parse --verify -q "${vbase:-origin/main}" >/dev/null 2>&1 || vbase=origin/master
-      vahead=$(git -C "$work_root" rev-list --count "${vbase:-origin/main}..HEAD" 2>/dev/null || echo 0)
-      [ "${vahead:-0}" -gt 0 ] && add_reason "\`$work_branch\` has no upstream (never pushed)"
-    fi
+    # Whether the branch holds work that exists nowhere else -- lib-state.sh
+    # owns that question and its carve-outs, so this verdict and the one
+    # metrics-live.sh draws cannot disagree (#149). Only the wording is here.
+    ust=$(unpushed_state "$work_root" "$work_branch")
+    case "$ust" in
+      'ahead 0')   ;;
+      'ahead '*)   add_reason "${ust#ahead } commit(s) unpushed" ;;
+      unknown)     add_reason "could not count unpushed commits" ;;
+      never-pushed)
+        if [ "$work_branch" = HEAD ] || [ -z "$work_branch" ]; then
+          add_reason "detached HEAD, no upstream to compare against"
+        else
+          add_reason "\`$work_branch\` has no upstream (never pushed)"
+        fi
+        ;;
+    esac
   fi
   [ -n "${1:-}" ] && add_reason "$1"
 

--- a/.claude/hooks/stop-continuity.test.sh
+++ b/.claude/hooks/stop-continuity.test.sh
@@ -112,6 +112,19 @@ GH_PRS='[{"url":"https://github.com/o/r/pull/7"}]' stop
 eq 'zero commits ahead, no upstream: archivable' 'archivable' "$(verdict)"
 gitq "$WORK" checkout claude/work
 
+# --- a detached HEAD, on and off a remote branch (#128/#143) -----------------------
+# The carve-out lib-state.sh's unpushed_state owns: a commit that already lives
+# on some remote branch is not stranded by being checked out detached, but one
+# that lives nowhere else is exactly the case the verdict exists for.
+gitq "$WORK" checkout --detach origin/claude/work
+GH_PRS='[{"url":"https://github.com/o/r/pull/7"}]' stop
+eq 'detached on a remote branch: archivable' 'archivable' "$(verdict)"
+echo six >> "$WORK/f"; gitq "$WORK" add f; gitq "$WORK" commit -m detached-only
+GH_PRS='[{"url":"https://github.com/o/r/pull/7"}]' stop
+eq 'detached off any remote branch: not archivable' \
+  'not archivable: detached HEAD, no upstream to compare against' "$(verdict)"
+gitq "$WORK" checkout claude/work
+
 # --- "cannot verify" is never a pass ------------------------------------------------
 GH_FAIL=1 stop
 has 'unverified is not archivable' '^\*\*Verdict:\*\* not archivable: branch home unverified' "$CKPT"


### PR DESCRIPTION
Step 1 of #149 — the leftover cleanup from #148.

#148 had to port two carve-outs into `metrics-live.sh` that `stop-continuity.sh`
had already grown in #126 and #128/#143. That is the tell: the same twelve-line
`@{u}` ladder written twice, drifting apart between fixes. It moves to
`unpushed_state <root> <branch>` in `lib-state.sh`, which both hooks already
source.

The function answers the question; the callers keep the wording. It prints one
of `ahead <n>` / `unknown` / `never-pushed` / `safe`, and each call site maps
that onto the text it already produced — **no displayed line changes**.

Behaviour is unchanged, with one addition: the detached-HEAD carve-out had no
test on either side. `stop-continuity.test.sh` now covers both halves — a
detached commit that lives on a remote branch is archivable, one that lives
nowhere else is not.

Also done outside this diff (it lives in the private state repo): the
`repro-*` fixture files #148 left under `metrics/live/` are deleted.

Green locally: `metrics-live.test.sh` 80 passed, `stop-continuity.test.sh` 18
passed (16 before, +2 detached).

🤖 Generated with [Claude Code](https://claude.com/claude-code)