### PR TITLE
metrics-live: the turns line survives a clean tree (#149)

### DIFF
--- a/.claude/hooks/lib-metrics-fmt.jq
+++ b/.claude/hooks/lib-metrics-fmt.jq
@@ -68,17 +68,15 @@ def blk:
 
 def turns: "⇢ \(.user_turns) ⚙ \(.tool_calls)";
 
-# Git state, the part that decides whether the chat is safe to kill. The empty
-# string when the tree is clean: "0c/0~/0↑" is the common case and says
-# nothing. A string, never jq's `empty` -- an empty stream would silently
-# swallow whatever it is concatenated with.
+# Git state, the part that decides whether the chat is safe to kill. Empty
+# when the tree is clean: "0c/0~/0↑" is the common case and says nothing.
 def work:
   if .commits > 0 or .dirty > 0 or .unpushed > 0
   then "⎇ " + (if .commits  > 0 then "\(.commits)c" else "" end)
            + (if .dirty    > 0 then "\(.dirty)~"  else "" end)
            + (if .unpushed > 0 then "\(.unpushed)↑unpushed" else "" end)
            + (if .unpushed > 0 then "  ← not safe to kill" else "" end)
-  else "" end;
+  else empty end;
 
 # Seconds as a glanceable duration: "45s", "24m", "1h48".
 def dur:

--- a/.claude/hooks/lib-metrics-fmt.jq
+++ b/.claude/hooks/lib-metrics-fmt.jq
@@ -68,15 +68,17 @@ def blk:
 
 def turns: "⇢ \(.user_turns) ⚙ \(.tool_calls)";
 
-# Git state, the part that decides whether the chat is safe to kill. Empty
-# when the tree is clean: "0c/0~/0↑" is the common case and says nothing.
+# Git state, the part that decides whether the chat is safe to kill. The empty
+# string when the tree is clean: "0c/0~/0↑" is the common case and says
+# nothing. A string, never jq's `empty` -- an empty stream would silently
+# swallow whatever it is concatenated with.
 def work:
   if .commits > 0 or .dirty > 0 or .unpushed > 0
   then "⎇ " + (if .commits  > 0 then "\(.commits)c" else "" end)
            + (if .dirty    > 0 then "\(.dirty)~"  else "" end)
            + (if .unpushed > 0 then "\(.unpushed)↑unpushed" else "" end)
            + (if .unpushed > 0 then "  ← not safe to kill" else "" end)
-  else empty end;
+  else "" end;
 
 # Seconds as a glanceable duration: "45s", "24m", "1h48".
 def dur:

--- a/.claude/hooks/metrics-live.sh
+++ b/.claude/hooks/metrics-live.sh
@@ -760,7 +760,7 @@ if [ "$SHOW" = show ] && [ -f "$OUT" ]; then
 
   bl_second=$(jq -r -L "$HOOK_DIR" \
     'include "lib-metrics-fmt";
-     turns + (work as $w | if $w == "" then "" else " " + $w end)' \
+     turns + ((work // "") as $w | if $w == "" then "" else " " + $w end)' \
     "$OUT" 2>/dev/null)
   bl_block="$bl_main"
   [ -n "$bl_second" ] && bl_block="$bl_block

--- a/.claude/hooks/metrics-live.test.sh
+++ b/.claude/hooks/metrics-live.test.sh
@@ -474,5 +474,22 @@ o8b=$(payload "$TP8" stop8b "$REPO8" Stop | METRICS_STOP_HOUR=23 bash "$HOOK" st
 hasnt 'no upstream, nothing ahead of origin/main: not flagged' \
       'has no upstream' "$(msg "$o8b")"
 
+# --- 9. the turns line survives a clean tree --------------------------------
+# The block's second line is "⇢ turns ⚙ tools", with git state appended only
+# when there is any. `work` used to yield jq's `empty` on a clean tree, and an
+# empty stream swallows the concatenation whole -- so the line that always
+# applies vanished exactly when nothing else was wrong (#149).
+REPO9="$SCRATCH/repo9"; mkdir -p "$REPO9"
+git -C "$REPO9" init -q -b main
+git -C "$REPO9" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+TP9="$SCRATCH/repo9.jsonl"; turn "$TP9" 1000
+o9=$(payload "$TP9" show9 "$REPO9" Stop | METRICS_STOP_HOUR=23 bash "$HOOK" stop 0 show 2>&1)
+has 'a clean tree still prints the turns line' '⇢ [0-9]+ ⚙ [0-9]+' "$(msg "$o9")"
+hasnt 'and says nothing about git state' '⎇' "$(msg "$o9")"
+
+: > "$REPO9/scratch-file"
+o9b=$(payload "$TP9" show9b "$REPO9" Stop | METRICS_STOP_HOUR=23 bash "$HOOK" stop 0 show 2>&1)
+has 'a dirty tree appends git state to the same line' '⇢ [0-9]+ ⚙ [0-9]+ ⎇ 1~' "$(msg "$o9b")"
+
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
Step 2 of #149.

`work` yields jq's `empty` when the tree is clean. In `turns + (work as $w | …)` an empty stream swallows the whole expression, so `⇢ N ⚙ M` — the line that always applies — vanished exactly when nothing else was wrong.

Fixed at the call site with `(work // "")`. `work`'s empty-on-clean contract stays intact, because two other consumers depend on it: `fields2` joins `work` into a line (returning `""` there would leave a trailing space on a clean tree), and `metrics-preview.sh` does `work // "(empty on a clean tree)"` and would print `""` instead of its placeholder. The first revision changed `work` itself; review caught that, and this is the corrected shape.

## Before / after

Same fixture both times, run through `lib-metrics-test-harness.sh` in a sandboxed `$HOME` — **not a live Stop**, deliberately: per #152, a live Stop races `stop-continuity.sh`'s cache delete and drops the block entirely, which would make a working fix look like a no-op.

A Stop on a session with 1 turn and 0 tool calls, against a fresh repo — first clean, then with one untracked file.

**Before (origin/main)**

```
» 10/1k 🔧✅(x0) — still room.
📦 archivable.
-----
» 10/1k 🔧✅(x0) — still room.
⇢ 1 ⚙ 0 ⎇ 1~
📦 not archivable: worktree dirty.
```

**After**

```
» 10/1k 🔧✅(x0) — still room.
⇢ 1 ⚙ 0
📦 archivable.
-----
» 10/1k 🔧✅(x0) — still room.
⇢ 1 ⚙ 0 ⎇ 1~
📦 not archivable: worktree dirty.
```

The dirty case is byte-identical; only the clean case gains its line back.

## Verification

`bash .claude/hooks/metrics-live.test.sh` — 83 passed, 0 failed. New case 9 covers both trees; reintroducing the bug fails it:

```
FAIL (no /⇢ [0-9]+ ⚙ [0-9]+/): a clean tree still prints the turns line
82 passed, 1 failed
```

The two other consumers, checked on a clean-tree fixture: `fields2` joins to `[⇢ 3 ⚙ 9]` with no trailing space, and `metrics-preview.sh`'s field still prints `(empty on a clean tree)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
