### PR TITLE
hooks: one archivable_reasons() in lib-state.sh, two callers (#149)

### DIFF
--- a/.claude/hooks/lib-state.sh
+++ b/.claude/hooks/lib-state.sh
@@ -140,7 +140,7 @@ unpushed_state() {
 
 # archivable_reasons <work_root> <work_branch> -- the reasons a session on
 # this branch is not yet archivable, comma-joined; empty when it is. Order:
-# branch home, worktree dirty, unpushed commits.
+# worktree dirty, unpushed commits, branch home.
 #
 # Lives here for the same reason unpushed_state does: metrics-live.sh's live
 # nag and stop-continuity.sh's Stop-hook verdict must never disagree about
@@ -153,19 +153,18 @@ unpushed_state() {
 # this file and is shelled out to, not sourced, so its own gate (which fires
 # once per session, separately) and this read-only check never share state.
 #
+# Home is checked last, and only when dirty/unpushed are already clean: it's
+# the one check here that can shell out to `gh` (up to two 30s calls in
+# branch-home-gate.sh), so a dirty mid-work tree -- the common case, and the
+# one Stop fires on every turn -- never pays that cost. Restores the
+# short-circuit the pre-dotfiles#149 archivable() had.
+#
 # Not this function's job: "not a git repo" (there is no branch here to
 # judge) and anything that only becomes true after a push is attempted --
 # both are the caller's own facts to add.
 archivable_reasons() {
   local work_root="$1" work_branch="$2" reasons="" home ust
   add_reason() { reasons="${reasons:+$reasons, }$1"; }
-
-  home=$(sh "$HOOK_DIR/branch-home-gate.sh" --check "$work_root" 2>/dev/null)
-  case "$home" in
-    home:*)       : ;;
-    unverified:*) add_reason "branch home unverified (${home#unverified: })" ;;
-    *)            add_reason "no PR and no pointer for \`$work_branch\`" ;;
-  esac
 
   [ -z "$(git -C "$work_root" status --porcelain 2>/dev/null)" ] || add_reason "worktree dirty"
 
@@ -182,6 +181,15 @@ archivable_reasons() {
       fi
       ;;
   esac
+
+  if [ -z "$reasons" ]; then
+    home=$(sh "$HOOK_DIR/branch-home-gate.sh" --check "$work_root" 2>/dev/null)
+    case "$home" in
+      home:*)       : ;;
+      unverified:*) add_reason "branch home unverified (${home#unverified: })" ;;
+      *)            add_reason "no PR and no pointer for \`$work_branch\`" ;;
+    esac
+  fi
 
   printf '%s' "$reasons"
 }

--- a/.claude/hooks/lib-state.sh
+++ b/.claude/hooks/lib-state.sh
@@ -137,3 +137,51 @@ unpushed_state() {
   ahead=$(git -C "$root" rev-list --count "$base..HEAD" 2>/dev/null || printf 0)
   [ "${ahead:-0}" -gt 0 ] && printf 'never-pushed' || printf 'safe'
 }
+
+# archivable_reasons <work_root> <work_branch> -- the reasons a session on
+# this branch is not yet archivable, comma-joined; empty when it is. Order:
+# branch home, worktree dirty, unpushed commits.
+#
+# Lives here for the same reason unpushed_state does: metrics-live.sh's live
+# nag and stop-continuity.sh's Stop-hook verdict must never disagree about
+# what "archivable" means (dotfiles#149). Before this they didn't even
+# agree on what a "home" is -- metrics-live.sh re-checked PR-or-kanban
+# inline and never looked for a pointer issue, the one branch-home-gate.sh
+# already finds.
+#
+# Requires $HOOK_DIR set by the caller: branch-home-gate.sh lives beside
+# this file and is shelled out to, not sourced, so its own gate (which fires
+# once per session, separately) and this read-only check never share state.
+#
+# Not this function's job: "not a git repo" (there is no branch here to
+# judge) and anything that only becomes true after a push is attempted --
+# both are the caller's own facts to add.
+archivable_reasons() {
+  local work_root="$1" work_branch="$2" reasons="" home ust
+  add_reason() { reasons="${reasons:+$reasons, }$1"; }
+
+  home=$(sh "$HOOK_DIR/branch-home-gate.sh" --check "$work_root" 2>/dev/null)
+  case "$home" in
+    home:*)       : ;;
+    unverified:*) add_reason "branch home unverified (${home#unverified: })" ;;
+    *)            add_reason "no PR and no pointer for \`$work_branch\`" ;;
+  esac
+
+  [ -z "$(git -C "$work_root" status --porcelain 2>/dev/null)" ] || add_reason "worktree dirty"
+
+  ust=$(unpushed_state "$work_root" "$work_branch")
+  case "$ust" in
+    'ahead 0')   ;;
+    'ahead '*)   add_reason "${ust#ahead } commit(s) unpushed" ;;
+    unknown)     add_reason "could not count unpushed commits" ;;
+    never-pushed)
+      if [ "$work_branch" = HEAD ] || [ -z "$work_branch" ]; then
+        add_reason "detached HEAD, no upstream to compare against"
+      else
+        add_reason "\`$work_branch\` has no upstream (never pushed)"
+      fi
+      ;;
+  esac
+
+  printf '%s' "$reasons"
+}

--- a/.claude/hooks/metrics-live.sh
+++ b/.claude/hooks/metrics-live.sh
@@ -575,41 +575,24 @@ fi
 # "archivable" is the verdict that the chat can be closed without losing
 # anything: clean worktree, nothing unpushed, the state repo's own commits
 # pushed, and the branch either has an open PR or is named by a pointer card.
-_to() { if command -v timeout >/dev/null 2>&1; then timeout "$@"; else shift; "$@"; fi; }
 archival_reasons=""
 archivable() {
-  local sr n c home_ok=0
+  local sr n
   archival_reasons=""
   add_areason() { archival_reasons="${archival_reasons:+$archival_reasons, }$1"; }
 
-  [ "${dirty:-0}" -eq 0 ] || add_areason "worktree dirty"
-  [ "${no_upstream:-0}" -eq 0 ] \
-    && { [ "${unpushed:-0}" -eq 0 ] || add_areason "$unpushed commit(s) unpushed"; } \
-    || add_areason "\`$work_branch\` has no upstream (never pushed)"
+  if [ -z "$work_root" ]; then
+    add_areason "not a git repo"
+  else
+    # archivable_reasons() is lib-state.sh's -- the home/dirty/unpushed
+    # check shared with stop-continuity.sh's Stop-hook verdict (#149).
+    archival_reasons=$(archivable_reasons "$work_root" "$work_branch")
+  fi
+
   sr=$(state_repo 2>/dev/null) || sr=""
   if [ -n "$sr" ]; then
     n=$(git -C "$sr" rev-list --count '@{u}..HEAD' 2>/dev/null || echo 0)
     [ "${n:-0}" -eq 0 ] || add_areason "state repo $n commit(s) unpushed"
-  fi
-  if [ -z "$work_root" ]; then
-    add_areason "not a git repo"
-  elif [ -z "$archival_reasons" ]; then
-    case "$work_branch" in
-      main|master|HEAD|"") home_ok=1 ;;
-      *)
-        if command -v gh >/dev/null 2>&1; then
-          c=$( (cd "$work_root" 2>/dev/null \
-                && _to 10 gh pr list --head "$work_branch" --state open --json number \
-                     --jq 'length') 2>/dev/null )
-          [ "${c:-0}" -gt 0 ] 2>/dev/null && home_ok=1
-        fi
-        if [ "$home_ok" -eq 0 ] && [ -n "$sr" ] \
-           && grep -qF -- "$work_branch" "$sr/state/global/kanban.md" 2>/dev/null; then
-          home_ok=1
-        fi
-        [ "$home_ok" -eq 1 ] || add_areason "no PR or pointer card for \`$work_branch\`"
-        ;;
-    esac
   fi
 
   [ -z "$archival_reasons" ]

--- a/.claude/hooks/metrics-live.sh
+++ b/.claude/hooks/metrics-live.sh
@@ -757,7 +757,7 @@ if [ "$SHOW" = show ] && [ -f "$OUT" ]; then
 
   bl_second=$(jq -r -L "$HOOK_DIR" \
     'include "lib-metrics-fmt";
-     turns + (work as $w | if $w == "" then "" else " " + $w end)' \
+     turns + ((work // "") as $w | if $w == "" then "" else " " + $w end)' \
     "$OUT" 2>/dev/null)
   bl_block="$bl_main"
   [ -n "$bl_second" ] && bl_block="$bl_block

--- a/.claude/hooks/metrics-live.sh
+++ b/.claude/hooks/metrics-live.sh
@@ -121,6 +121,9 @@ fi
 # it is the whole block that stays suppressed.
 case "$EVENT" in prompt|userpromptsubmit|statusline) SHOW="" ;; esac
 
+# HUMAN NOTE: The statement "the jq pass is too expensive" is categorically wrong.
+# Do not consider jq passes to be "too expensive" even if the code is suboptimal;
+# compute over text processing is dirt cheap...the only real cost is tokens.
 # A git event means an actual git-state change, not every Bash call: the jq
 # pass is too expensive to run after `ls`. The set is git_event_re in
 # lib-state.sh -- shared with measure-git-events.sh so the counter and the

--- a/.claude/hooks/metrics-live.test.sh
+++ b/.claude/hooks/metrics-live.test.sh
@@ -474,5 +474,22 @@ o8b=$(payload "$TP8" stop8b "$REPO8" Stop | METRICS_STOP_HOUR=23 bash "$HOOK" st
 hasnt 'no upstream, nothing ahead of origin/main: not flagged' \
       'has no upstream' "$(msg "$o8b")"
 
+# --- 9. the turns line survives a clean tree --------------------------------
+# The block's second line is "⇢ turns ⚙ tools", with git state appended only
+# when there is any. `work` used to yield jq's `empty` on a clean tree, and an
+# empty stream swallows the concatenation whole -- so the line that always
+# applies vanished exactly when nothing else was wrong (#149).
+REPO9="$SCRATCH/repo9"; mkdir -p "$REPO9"
+git -C "$REPO9" init -q -b main
+git -C "$REPO9" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+TP9="$SCRATCH/repo9.jsonl"; turn "$TP9" 1000
+o9=$(payload "$TP9" show9 "$REPO9" Stop | METRICS_STOP_HOUR=23 bash "$HOOK" stop 0 show 2>&1)
+has 'a clean tree still prints the turns line' '⇢ [0-9]+ ⚙ [0-9]+' "$(msg "$o9")"
+hasnt 'and says nothing about git state' '⎇' "$(msg "$o9")"
+
+: > "$REPO9/scratch-file"
+o9b=$(payload "$TP9" show9b "$REPO9" Stop | METRICS_STOP_HOUR=23 bash "$HOOK" stop 0 show 2>&1)
+has 'a dirty tree appends git state to the same line' '⇢ [0-9]+ ⚙ [0-9]+ ⎇ 1~' "$(msg "$o9b")"
+
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/.claude/hooks/stop-continuity.sh
+++ b/.claude/hooks/stop-continuity.sh
@@ -192,37 +192,26 @@ sc_note() { printf '\n## Stop-commit\n\n%s\n' "$1" >> "$ckpt"; }
 #      not known until the bottom of this script).
 # "Could not verify" is never a pass, here as in the gate.
 verdict=""
+_archivable_reasons=""
+_archivable_reasons_cached=0
 set_verdict() {
   reasons=""
   add_reason() { reasons="${reasons:+$reasons, }$1"; }
 
-  # Cached across calls: the check costs a `gh` round trip and the branch's
-  # home does not change between the salvage and the state-repo push.
-  [ -n "${home:-}" ] || home=$(sh "$HOOK_DIR/branch-home-gate.sh" --check "$cwd" 2>/dev/null)
-  case "$home" in
-    home:*)       : ;;
-    unverified:*) add_reason "branch home unverified (${home#unverified: })" ;;
-    *)            add_reason "no PR and no pointer for \`$work_branch\`" ;;
-  esac
-  if [ -n "$work_root" ]; then
-    [ -n "$(git -C "$work_root" status --porcelain 2>/dev/null)" ] && add_reason "worktree dirty"
-    # Whether the branch holds work that exists nowhere else -- lib-state.sh
-    # owns that question and its carve-outs, so this verdict and the one
-    # metrics-live.sh draws cannot disagree (#149). Only the wording is here.
-    ust=$(unpushed_state "$work_root" "$work_branch")
-    case "$ust" in
-      'ahead 0')   ;;
-      'ahead '*)   add_reason "${ust#ahead } commit(s) unpushed" ;;
-      unknown)     add_reason "could not count unpushed commits" ;;
-      never-pushed)
-        if [ "$work_branch" = HEAD ] || [ -z "$work_branch" ]; then
-          add_reason "detached HEAD, no upstream to compare against"
-        else
-          add_reason "\`$work_branch\` has no upstream (never pushed)"
-        fi
-        ;;
-    esac
+  # Cached across calls: nothing about work_root changes between the salvage
+  # and the state-repo push below, and the home check costs a `gh` round
+  # trip. archivable_reasons() is lib-state.sh's -- the home/dirty/unpushed
+  # check shared with metrics-live.sh's live nag, so the two can never
+  # disagree about what "archivable" means (#149).
+  if [ "$_archivable_reasons_cached" -eq 0 ]; then
+    if [ -n "$work_root" ]; then
+      _archivable_reasons=$(archivable_reasons "$work_root" "$work_branch")
+    else
+      _archivable_reasons="no PR and no pointer for \`$work_branch\`"
+    fi
+    _archivable_reasons_cached=1
   fi
+  reasons="$_archivable_reasons"
   [ -n "${1:-}" ] && add_reason "$1"
 
   if [ -n "$reasons" ]; then verdict="not archivable: $reasons"; else verdict="archivable"; fi


### PR DESCRIPTION
Step 3 of dotfiles#149: one `archivable_reasons()` in `lib-state.sh`, called
by `metrics-live.sh`'s live nag and `stop-continuity.sh`'s Stop-hook verdict,
so the two agree on wording and, more importantly, on what counts as a
"home" — `metrics-live.sh` previously re-checked PR-or-kanban inline and
never looked for a pointer issue, the one `branch-home-gate.sh --check`
already finds and `stop-continuity.sh` already used.

Each caller still bolts its own extra reason onto the shared result, same
as before: `metrics-live.sh` adds "state repo N commit(s) unpushed",
`stop-continuity.sh` adds its post-push failure reasons. `stop-continuity.sh`
keeps the caching it had (the home check costs a `gh` round trip and
`set_verdict` can be called more than once per run).

Stacked on #151 (step 2, the turns line) — not yet merged, not touched here.
Will rebase once it lands.

Not in scope: dotfiles#152 (a real, separate bug — `stop-continuity.sh`
deletes the live cache file `metrics-live.sh` gates its display block on,
so the block occasionally vanishes on a race). This PR doesn't touch that
file's lifetime or the display-gating logic; flagged by the user before I
started, confirmed by diff that nothing here overlaps it.

Tests: `metrics-live.test.sh` (83), `stop-continuity.test.sh` (18),
`branch-home-gate.test.sh` (30) — all green, no changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)