### PR TITLE
metrics-live: stop the Stop block depending on $OUT surviving to display

### DIFF
--- a/.claude/hooks/metrics-live.sh
+++ b/.claude/hooks/metrics-live.sh
@@ -198,14 +198,18 @@ mkdir -p "$LIVE" 2>/dev/null || exit 0
 # lib-metrics-fmt.jq -- the sitting clock is the only sitting clock now.
 now_ts=$(date +%s)
 
-tmp="$OUT.$$"
-printf '%s\n' "$metrics" | jq -c \
+merged=$(printf '%s\n' "$metrics" | jq -c \
   --arg ev "$EVENT" --arg now "$now" \
   --argjson d "${dirty:-0}" --argjson u "${unpushed:-0}" --argjson c "${ncommits:-0}" \
   --arg sha "$start_sha" \
   '.session + {last_event: $ev, updated_at: $now, start_sha: $sha,
-               dirty: $d, unpushed: $u, commits: $c}' > "$tmp" 2>/dev/null \
-  && mv -f "$tmp" "$OUT" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+               dirty: $d, unpushed: $u, commits: $c}' 2>/dev/null)
+
+tmp="$OUT.$$"
+if [ -n "$merged" ]; then
+  printf '%s\n' "$merged" > "$tmp" 2>/dev/null \
+    && mv -f "$tmp" "$OUT" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+fi
 
 # =========================================================== crossing engine
 # Edge-triggered. State lives in one small file per session next to the cache;
@@ -694,7 +698,7 @@ fi
 # Shown to the user at the end of a turn -- never sent to the model, so the
 # running decision count costs nothing to display. Any crossing line rides on
 # the front of it rather than arriving as a second message.
-if [ "$SHOW" = show ] && [ -f "$OUT" ]; then
+if [ "$SHOW" = show ] && [ -n "$metrics" ]; then
   # night_nag needs Pacific time, not the host's TZ -- an ephemeral/cloud
   # session usually runs UTC, which read as "LATE!" all evening. Compute the
   # US/Pacific UTC offset here (handles PST/PDT) and hand it to jq as seconds,
@@ -758,10 +762,10 @@ if [ "$SHOW" = show ] && [ -f "$OUT" ]; then
   [ -n "$bl_sit_cluster" ] && bl_main="$bl_main $bl_sit_cluster"
   bl_main="$bl_main — ${bl_reason}${bl_verdict}."
 
-  bl_second=$(jq -r -L "$HOOK_DIR" \
+  bl_second=$(printf '%s\n' "$merged" | jq -r -L "$HOOK_DIR" \
     'include "lib-metrics-fmt";
      turns + ((work // "") as $w | if $w == "" then "" else " " + $w end)' \
-    "$OUT" 2>/dev/null)
+    2>/dev/null)
   bl_block="$bl_main"
   [ -n "$bl_second" ] && bl_block="$bl_block
 $bl_second"

--- a/.claude/hooks/metrics-live.test.sh
+++ b/.claude/hooks/metrics-live.test.sh
@@ -562,10 +562,13 @@ OUT10="$STATE/metrics/live/race.json"
 payload "$TP10" race "$REPO10" Stop \
   | METRICS_STOP_HOUR=23 bash "$HOOK" stop 0 show > "$SCRATCH/o10.out" 2>&1 &
 hook_pid=$!
+until [ -f "$OUT10" ]; do :; done
 rm -f "$OUT10"
 wait "$hook_pid"
 o10=$(cat "$SCRATCH/o10.out")
 has 'the block still opens with $OUT removed mid-run' '^(»|⛁)' "$(msg "$o10")"
+t   '$OUT was actually gone when the hook read it' absent \
+    "$( [ -f "$OUT10" ] && echo present || echo absent )"
 cat > "$SCRATCH/bin/gh" <<'GH'
 #!/bin/sh
 echo 1

--- a/.claude/hooks/metrics-live.test.sh
+++ b/.claude/hooks/metrics-live.test.sh
@@ -491,5 +491,31 @@ hasnt 'and says nothing about git state' '⎇' "$(msg "$o9")"
 o9b=$(payload "$TP9" show9b "$REPO9" Stop | METRICS_STOP_HOUR=23 bash "$HOOK" stop 0 show 2>&1)
 has 'a dirty tree appends git state to the same line' '⇢ [0-9]+ ⚙ [0-9]+ ⎇ 1~' "$(msg "$o9b")"
 
+# --- 10. the block survives $OUT being deleted mid-run -----------------------
+# dotfiles#152: stop-continuity.sh's Stop hook deletes $OUT concurrently, and
+# metrics-live.sh spends real time in archivable()'s `gh pr list` between
+# writing $OUT and reaching the display check. If that delete lands in the
+# window, the display must still open with the block -- it comes from
+# $metrics/$merged in memory now, not a re-read of the cache file.
+TP10="$SCRATCH/race.jsonl"; turn "$TP10" 1000
+cat > "$SCRATCH/bin/gh" <<'GH'
+#!/bin/sh
+sleep 0.3
+echo 1
+GH
+chmod +x "$SCRATCH/bin/gh"
+OUT10="$STATE/metrics/live/race.json"
+( sleep 0.1; rm -f "$OUT10" ) &
+o10=$(payload "$TP10" race "$REPO" Stop | METRICS_STOP_HOUR=23 bash "$HOOK" stop 0 show 2>&1)
+wait
+has 'the block still opens with $OUT removed just before display' '^(»|⛁)' "$(msg "$o10")"
+t   '$OUT was actually gone when the hook read it' absent \
+    "$( [ -f "$OUT10" ] && echo present || echo absent )"
+cat > "$SCRATCH/bin/gh" <<'GH'
+#!/bin/sh
+echo 1
+GH
+chmod +x "$SCRATCH/bin/gh"
+
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/.claude/hooks/metrics-live.test.sh
+++ b/.claude/hooks/metrics-live.test.sh
@@ -497,6 +497,19 @@ has 'a dirty tree appends git state to the same line' '⇢ [0-9]+ ⚙ [0-9]+ ⎇
 # writing $OUT and reaching the display check. If that delete lands in the
 # window, the display must still open with the block -- it comes from
 # $metrics/$merged in memory now, not a re-read of the cache file.
+#
+# A clean, pushed repo of its own -- not $REPO, which carries the leftover
+# "dirty" file from test 3 onward. archivable() short-circuits on a dirty
+# worktree before it ever shells out to `gh`, so reusing $REPO would let this
+# test pass on the timing of the script's own subprocess spawns rather than
+# on the slow `gh` mock it's actually exercising.
+REPO10="$SCRATCH/repo10"; mkdir -p "$REPO10"
+git -C "$REPO10" init -q -b feat/race
+git -C "$REPO10" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+git init -q --bare "$SCRATCH/repo10.git"
+git -C "$REPO10" remote add origin "$SCRATCH/repo10.git"
+git -C "$REPO10" push -q -u origin feat/race
+
 TP10="$SCRATCH/race.jsonl"; turn "$TP10" 1000
 cat > "$SCRATCH/bin/gh" <<'GH'
 #!/bin/sh
@@ -506,7 +519,7 @@ GH
 chmod +x "$SCRATCH/bin/gh"
 OUT10="$STATE/metrics/live/race.json"
 ( sleep 0.1; rm -f "$OUT10" ) &
-o10=$(payload "$TP10" race "$REPO" Stop | METRICS_STOP_HOUR=23 bash "$HOOK" stop 0 show 2>&1)
+o10=$(payload "$TP10" race "$REPO10" Stop | METRICS_STOP_HOUR=23 bash "$HOOK" stop 0 show 2>&1)
 wait
 has 'the block still opens with $OUT removed just before display' '^(»|⛁)' "$(msg "$o10")"
 t   '$OUT was actually gone when the hook read it' absent \

--- a/.claude/hooks/metrics-live.test.sh
+++ b/.claude/hooks/metrics-live.test.sh
@@ -537,12 +537,18 @@ has 'a dirty tree appends git state to the same line' '⇢ [0-9]+ ⚙ [0-9]+ ⎇
 # "dirty" file from test 3 onward. archivable() short-circuits on a dirty
 # worktree before it ever shells out to `gh`, so reusing $REPO would let this
 # test pass on the timing of the script's own subprocess spawns rather than
-# on the slow `gh` mock it's actually exercising.
+# on the slow `gh` mock it's actually exercising. And it needs a pushed
+# `main` to compare against, and a commit ahead of it -- branch-home-gate.sh
+# quiet-exits on "no default branch to compare against" before it ever
+# reaches `gh` otherwise (mirrors test 8's ORIGIN8/REPO8 setup).
+ORIGIN10="$SCRATCH/origin10.git"; git init -q --bare "$ORIGIN10"
 REPO10="$SCRATCH/repo10"; mkdir -p "$REPO10"
-git -C "$REPO10" init -q -b feat/race
+git -C "$REPO10" init -q -b main
 git -C "$REPO10" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
-git init -q --bare "$SCRATCH/repo10.git"
-git -C "$REPO10" remote add origin "$SCRATCH/repo10.git"
+git -C "$REPO10" remote add origin "$ORIGIN10"
+git -C "$REPO10" push -q -u origin main
+git -C "$REPO10" checkout -q -b feat/race
+git -C "$REPO10" -c user.email=t@t -c user.name=t commit -q --allow-empty -m work
 git -C "$REPO10" push -q -u origin feat/race
 
 TP10="$SCRATCH/race.jsonl"; turn "$TP10" 1000
@@ -553,12 +559,13 @@ echo 1
 GH
 chmod +x "$SCRATCH/bin/gh"
 OUT10="$STATE/metrics/live/race.json"
-( sleep 0.1; rm -f "$OUT10" ) &
-o10=$(payload "$TP10" race "$REPO10" Stop | METRICS_STOP_HOUR=23 bash "$HOOK" stop 0 show 2>&1)
-wait
-has 'the block still opens with $OUT removed just before display' '^(»|⛁)' "$(msg "$o10")"
-t   '$OUT was actually gone when the hook read it' absent \
-    "$( [ -f "$OUT10" ] && echo present || echo absent )"
+payload "$TP10" race "$REPO10" Stop \
+  | METRICS_STOP_HOUR=23 bash "$HOOK" stop 0 show > "$SCRATCH/o10.out" 2>&1 &
+hook_pid=$!
+rm -f "$OUT10"
+wait "$hook_pid"
+o10=$(cat "$SCRATCH/o10.out")
+has 'the block still opens with $OUT removed mid-run' '^(»|⛁)' "$(msg "$o10")"
 cat > "$SCRATCH/bin/gh" <<'GH'
 #!/bin/sh
 echo 1


### PR DESCRIPTION
Fixes #152.

`stop-continuity.sh` deletes `$OUT` (the live cache file) as a no-matcher
Stop hook running concurrently with `metrics-live.sh`, which reads `$OUT`
again at display time after spending seconds in `archivable()`'s `gh pr
list`. When the delete lands in that window, the block silently drops.

Fix: build the merged block JSON into `$merged` once, write that to
`$OUT`, and feed the same variable to the `lib-metrics-fmt` jq on stdin
instead of re-reading `$OUT`. Display guard changed from `[ -f "$OUT" ]`
to `[ -n "$metrics" ]`. No displayed string changes — this is step 2a,
before #149 step 4.

Added a `metrics-live.test.sh` case that races a background `rm -f`
against a slowed `archivable()` and asserts the block still opens.

Rebased onto current `main` (post-#151, no conflicting `bl_second` lines
to reconcile — #151 was already merged when this branch started).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved live metrics handling to avoid writing empty cache results.
  - Ensured metrics remain available for display even if the cache file is removed during processing.

- **Tests**
  - Added coverage for concurrent cache-file deletion while live metrics are being displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->