### PR TITLE
metrics-live: Stop output is nags, block, archival (#149)

### DIFF
--- a/.claude/hooks/metrics-live.sh
+++ b/.claude/hooks/metrics-live.sh
@@ -382,10 +382,14 @@ work_str() {
   printf '%s' "$s"
 }
 
-sys_lines=""; model_line=""
+sys_lines=""; model_line=""; arch_lines=""
 add_line()  { sys_lines="${sys_lines:+$sys_lines
 }$1"; }
 add_model() { model_line="${model_line:+$model_line
+}$1"; }
+# Stop's archival verdict (📦 and what follows it) prints last, after the
+# block -- a separate bucket from the crossing nags above, which print first.
+add_arch()  { arch_lines="${arch_lines:+$arch_lines
 }$1"; }
 record_crossing() {
   mkdir -p "$CROSSD" 2>/dev/null || return 0
@@ -610,9 +614,9 @@ resume_ckpt() {
 if [ "$hook_name" = Stop ]; then
   archivable > /dev/null
   if [ -z "$archival_reasons" ]; then
-    add_line "📦 archivable."
+    add_arch "📦 archivable."
   else
-    add_line "📦 not archivable: ${archival_reasons}."
+    add_arch "📦 not archivable: ${archival_reasons}."
   fi
 
   if [ "$nag_pending" -eq 1 ]; then
@@ -624,9 +628,9 @@ if [ "$hook_name" = Stop ]; then
     found=$(resume_ckpt)
     if [ -n "$found" ]; then
       resume_ts=$now_ts
-      add_line "Archivable. Resume block written $(hhmm "$resume_ts") in $(basename "$found"). Next time: \`/resume\`."
+      add_arch "Archivable. Resume block written $(hhmm "$resume_ts") in $(basename "$found"). Next time: \`/resume\`."
     else
-      add_line "Archivable, but no \`## Resume\` block in $(state_dir)/log/auto/*-${sid:0:8}.md. Not asking again this session."
+      add_arch "Archivable, but no \`## Resume\` block in $(state_dir)/log/auto/*-${sid:0:8}.md. Not asking again this session."
     fi
     save_nag
   elif archivable; then
@@ -643,16 +647,20 @@ if [ "$hook_name" = Stop ]; then
       nag_pending=1; save_nag
       # The crossing lines that armed this Stop have already been persisted
       # as consumed, so this reason is their only chance to be seen. They go
-      # in front of the instruction rather than being dropped.
+      # in front of the instruction rather than being dropped -- nags, then
+      # the archival verdict, same order as the screen.
       reason="Write the resume block: append a \`## Resume\` block (next, link, model, effort) to this session's checkpoint in $(state_dir)/log/auto/."
-      [ -z "$sys_lines" ] || reason="$sys_lines
+      pre="$sys_lines"
+      [ -z "$arch_lines" ] || pre="${pre:+$pre
+}$arch_lines"
+      [ -z "$pre" ] || reason="$pre
 $reason"
       printf '{"decision":"block","reason":%s}\n' "$(json_str "$reason")"
       exit 0
     fi
     # Nothing new to say. Later Stops carry the block's age and nothing else.
     if [ "$resume_ts" -gt 0 ]; then
-      add_line "Resume block $(hm $(( (now_ts - resume_ts) / 60 ))) old."
+      add_arch "Resume block $(hm $(( (now_ts - resume_ts) / 60 ))) old."
     fi
   fi
 fi
@@ -749,9 +757,10 @@ if [ "$SHOW" = show ] && [ -f "$OUT" ]; then
   [ -n "$bl_second" ] && bl_block="$bl_block
 $bl_second"
 
-  jq -nc --arg s "$sys_lines" --arg b "$bl_block" \
-    '{systemMessage: (if $s == "" then $b else $b + "\n" + $s end)}'
-elif [ -n "$sys_lines" ]; then
-  jq -nc --arg s "$sys_lines" '{systemMessage: $s}'
+  jq -nc --arg s "$sys_lines" --arg b "$bl_block" --arg a "$arch_lines" \
+    '[$s, $b, $a] | map(select(. != "")) | join("\n") | {systemMessage: .}'
+elif [ -n "$sys_lines" ] || [ -n "$arch_lines" ]; then
+  jq -nc --arg s "$sys_lines" --arg a "$arch_lines" \
+    '[$s, $a] | map(select(. != "")) | join("\n") | {systemMessage: .}'
 fi
 exit 0

--- a/.claude/hooks/metrics-live.test.sh
+++ b/.claude/hooks/metrics-live.test.sh
@@ -303,6 +303,41 @@ has 'and the reason carries the crossing line' '⛁ 103k/100k' \
 o4=$(payload "$TP3" stop2 "$REPO" Stop | METRICS_STOP_HOUR=0 bash "$HOOK" stop 0 show 2>&1)
 t 'a dirty tree is never archivable' '' "$(printf '%s' "$o4" | jq -r '.decision // ""')"
 
+# --- 3c. order: nags before the block, archival after it ---------------------
+# dotfiles#149 step 4's whole point. A nag that fires on the same Stop that
+# also confirms a pending resume block must render before the block, with
+# the archival verdict after it -- never interleaved. Own repo so this does
+# not depend on section 3's ordering or its dirty-tree flip above.
+REPOO="$SCRATCH/repoo"; mkdir -p "$REPOO"
+git -C "$REPOO" init -q -b feat/order
+git -C "$REPOO" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+git init -q --bare "$SCRATCH/repoo.git"
+git -C "$REPOO" remote add origin "$SCRATCH/repoo.git"
+git -C "$REPOO" push -q -u origin feat/order
+
+TPO="$SCRATCH/order.jsonl"; turn "$TPO" 103000
+oO1=$(payload "$TPO" orderx "$REPOO" Stop | METRICS_STOP_HOUR=23 bash "$HOOK" stop 0 show 2>&1)
+t 'order setup: the first Stop blocks' block "$(printf '%s' "$oO1" | jq -r '.decision // ""')"
+
+printf '# ckpt\n\n## Resume\n\n- next: x\n' > "$CK/2026-09-09-repoo-orderx.md"
+
+# Second Stop: also crosses 150k while confirming the resume block, so a
+# nag, the block, and the archival tail all fire together -- no re-block.
+turn "$TPO" 152000
+oO2=$(payload "$TPO" orderx "$REPOO" Stop | METRICS_STOP_HOUR=23 bash "$HOOK" stop 0 show 2>&1)
+t 'order: the confirming Stop does not re-block' '' "$(printf '%s' "$oO2" | jq -r '.decision // ""')"
+msgO2=$(msg "$oO2")
+nag_at=$(printf '%s\n' "$msgO2" | grep -n '⛁⛁ 152k/150k' | head -1 | cut -d: -f1)
+block_at=$(printf '%s\n' "$msgO2" | grep -n '⇢ ' | head -1 | cut -d: -f1)
+arch_at=$(printf '%s\n' "$msgO2" | grep -n '📦' | head -1 | cut -d: -f1)
+t 'all three sections are present' yes \
+  "$( [ -n "$nag_at" ] && [ -n "$block_at" ] && [ -n "$arch_at" ] && echo yes || echo no )"
+t 'the nag line renders before the block' yes \
+  "$( [ "${nag_at:-0}" -lt "${block_at:-0}" ] 2>/dev/null && echo yes || echo no )"
+t 'the archival verdict renders after the block' yes \
+  "$( [ "${block_at:-0}" -lt "${arch_at:-0}" ] 2>/dev/null && echo yes || echo no )"
+has 'and reports the resume block it found' 'Resume block written' "$msgO2"
+
 # --- 4. the friction counter is the one line addressed to the model ----------
 # The standing orders' capacity clause no longer carries its own trigger, so
 # this line has to arrive as context, not as a systemMessage the model cannot


### PR DESCRIPTION
Step 4 of dotfiles#149's plan: reorder Stop's visible output to nags,
block, archival — the archival verdict (📦 ...) prints last.

## Before / after

Rebuilt with the old and new hook side by side, same scenario: a first
Stop crosses 100k and blocks; the checkpoint gets a `## Resume` block;
a second Stop crosses 150k *while* confirming that block, so a nag, the
block, and the archival tail all fire together with no re-block.

**Old** — archival landed after the block, but a nag landed *between*
the block and the archival text:
```
⛁⛁ 20/152k 🔧✅(x0) — 💸 propose stopping.
⇢ 2 ⚙ 0
⛁⛁ 152k/150k ⚖0 — propose stopping.
📦 not archivable: no PR and no pointer for `feat/demo`.
```

**New** — nag first, then the block, archival last:
```
⛁⛁ 152k/150k ⚖0 — propose stopping.
⛁⛁ 20/152k 🔧✅(x0) — 💸 propose stopping.
⇢ 2 ⚙ 0
📦 not archivable: no PR and no pointer for `feat/demo`.
```

## What changed

`metrics-live.sh`'s Stop section fed the 📦 verdict and its resume-block
follow-ups into the same `sys_lines`/`add_line` bucket as the crossing
nags, and the final render was `block + "\n" + sys_lines` — so the
visible order was block, nags, archival. This splits the archival text
into its own bucket (`add_arch`/`arch_lines`) and composes the final
message as nags, block, archival. The block-decision reason (the
early-exit path when the Stop actually blocks) still carries both nags
and the archival verdict ahead of the instruction, unchanged.

## Scope

- Rebased onto #153 (`archivable_reasons()` in lib-state.sh), which is
  merged into main.
- Does not touch `stop-continuity.sh`'s `rm -f`, per #152 (PR #154 owns
  that, in parallel).
- No FROZEN block touched (context/sitting/gate/friction ladders are
  untouched); the Stop nag section isn't tagged FROZEN.

## Verification

```
bash .claude/hooks/metrics-live.test.sh     # 83 passed, 0 failed
bash .claude/hooks/stop-continuity.test.sh  # 18 passed, 0 failed
```

Closes step 4 of #149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)