### PR TITLE
skills: rename resume -> pickup, avoid /resume collision

### DIFF
--- a/.claude/skills/pickup/SKILL.md
+++ b/.claude/skills/pickup/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: resume
-description: Pick up a session where an earlier one left it, from the resume block that session wrote into its own checkpoint. Use when Solace says "resume", "/resume", "/resume <branch>", "pick up where we left off", or opens a session meaning to continue work rather than choose new work.
+name: pickup
+description: Pick up a session where an earlier one left it, from the resume block that session wrote into its own checkpoint. Use when Solace says "resume", "pick up", "/pickup", "/pickup <branch>", "pick up where we left off", or opens a session meaning to continue work rather than choose new work. Not `/resume` — that name is claimed by Claude Code's own terminal-session resume.
 ---
 
-# Resume
+# Pickup
 
 Thin by design. `resume-list` holds the parsing, the drop rules and the
 table; this skill picks a row and starts.
@@ -20,7 +20,7 @@ Run `~/.local/bin/resume-list`.
 - **No rows** — say so in one line and stop. There is nothing to resume;
   `worklist` is the tool for choosing new work, and Solace will ask for it.
 - **One row** — take it.
-- **Several** — if Solace named a branch (`/resume <branch>`), take that row.
+- **Several** — if Solace named a branch (`/pickup <branch>`), take that row.
   Otherwise print the table and ask for a one-line pick. That is the one
   question this skill is allowed to ask.
 

--- a/.claude/skills/wrapup/SKILL.md
+++ b/.claude/skills/wrapup/SKILL.md
@@ -29,7 +29,7 @@ Read the verdict line at the top of this session's auto-checkpoint
   wrap-up and sometimes turns it into an archive.
 
 If the session's only remaining need is "the next session should start here",
-that is a resume block (`/resume`, four lines), not a wrap-up.
+that is a resume block (`/pickup`, four lines), not a wrap-up.
 
 ## 1. Where state lands
 


### PR DESCRIPTION
`/resume` is claimed by Claude Code's own terminal-session resume (local-environment only) — it intercepted before the skill's trigger could load, surfacing as "Terminal sessions can only be resumed in a Local environment." Renamed the skill to `pickup`, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
