### PR TITLE
branch-home-gate: recognize a mergify stack PR as the branch's home

### DIFF
--- a/.claude/hooks/branch-home-gate.sh
+++ b/.claude/hooks/branch-home-gate.sh
@@ -146,6 +146,23 @@ if [ -z "$found" ]; then
     else
       unverified="gh pr list failed (not authenticated here?)"
     fi
+
+    # `mergify stack push` opens the PR from a generated head,
+    # stack/<login>/<local-branch>/<slug>--<change-id>, so the exact --head
+    # lookup above misses it. Broaden once, only if that lookup found
+    # nothing and didn't fail outright.
+    if [ -z "$found" ] && [ -z "$unverified" ]; then
+      if prs=$( (cd "$work_root" && run_to 30 gh pr list --state all --limit 50 --json url,headRefName) 2>/dev/null ); then
+        url=$(printf '%s' "$prs" | jq -r --arg b "$branch" \
+          '[.[] | select(.headRefName as $h
+                          | ($h | startswith("stack/"))
+                            and (($h | split("/"))[2:] | join("/") | startswith($b + "/")))
+           ][0].url // empty' 2>/dev/null)
+        [ -n "$url" ] && found="$url has this head (a mergify stack PR)"
+      else
+        unverified="gh pr list failed (not authenticated here?)"
+      fi
+    fi
   else
     unverified="gh is not installed here"
   fi

--- a/.claude/hooks/branch-home-gate.test.sh
+++ b/.claude/hooks/branch-home-gate.test.sh
@@ -33,7 +33,12 @@ cat > "$BIN/gh" <<'EOF'
 #!/bin/sh
 [ "${GH_FAIL:-0}" = 1 ] && { echo "gh: could not authenticate" >&2; exit 1; }
 case "$1 ${2:-}" in
-  "pr list")    printf '%s\n' "${GH_PRS:-[]}" ;;
+  "pr list")
+    case " $* " in
+      *" --head "*) printf '%s\n' "${GH_PRS:-[]}" ;;
+      *)            printf '%s\n' "${GH_PRS_ALL:-[]}" ;;
+    esac
+    ;;
   "issue list") printf '%s\n' "${GH_ISSUES:-[]}" ;;
   *) exit 1 ;;
 esac
@@ -125,6 +130,13 @@ gitq "$SR" checkout -- state/global/kanban.md 2>/dev/null || \
 
 GH_ISSUES='[{"number":4,"title":"t","body":"the work is on claude/homed"}]' \
   check silent 'an open issue names the branch' h3
+
+# A mergify stack PR's head is stack/<login>/<branch>/<slug>--<change-id>, not
+# the branch name -- the exact --head lookup misses it, so this must fall
+# back to the broad state-based match.
+setup_repo claude/homed
+GH_PRS_ALL='[{"url":"https://github.com/o/r/pull/9","headRefName":"stack/mark-brannan/claude/homed/record-rulings--ad4fbbdd"}]' \
+  check silent 'a mergify stack PR has this head' h3b
 
 # A card or issue naming a longer branch must not give a false home to its
 # prefix: claude/homed-extra does not mean claude/homed has one.


### PR DESCRIPTION
The gate's PR lookup does an exact `--head <branch>` match, but `mergify stack push` opens PRs from a generated head — `stack/<login>/<local-branch>/<slug>--<change-id>` — so the lookup finds nothing and the gate blocks a session whose work is already in an open PR.

## Fix

When the exact `--head` match finds nothing (and doesn't itself fail), fall back to a broad `--state all` listing and match `headRefName` by stripping the `stack/<login>/` prefix and checking the remainder starts with `<branch>/`. Handles branch names that themselves contain slashes (e.g. `claude/foo`).

Added a case to `branch-home-gate.test.sh` with a stubbed `gh pr list` returning only the stack head, asserting `pass` — plus updated the fake `gh` to distinguish the exact-head call from the broad one.

Fixes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)