### PR TITLE
gitignore: cover .claude/state/ fallback path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,10 @@
 .claude/journal/
 .claude/session-notes/
 .claude/checkpoints/
+# state_dir() falls back to .claude/state/global when the private state
+# repo isn't cloned; without this, that fallback path is untracked and
+# unignored on machines without claude_prompts_scratch. (#130)
+.claude/state/
 boards/
 *.local.json
 *.local.yml


### PR DESCRIPTION
Fixes #130.

`state_dir()` falls back to `.claude/state/global` when the private state repo (`claude_prompts_scratch`) isn't cloned — a fresh clone, or a cloud VM whose seed didn't include it. That path wasn't covered by `.gitignore`, so checkpoints, the board, metrics and crossings could land in an untracked, unignored path under a worktree that is `$HOME` on a public repo.

Adds `.claude/state/` to the same "this repo is PUBLIC" block as the other session-state entries, with a one-line comment explaining the fallback.

## Verification

Before the change, nothing was tracked under `.claude/state/` (confirmed with `git ls-files .claude/state/` — empty). After the change:

```
$ git check-ignore -v .claude/state/global/metrics/sitting.json
.gitignore:74:.claude/state/	.claude/state/global/metrics/sitting.json
exit: 0

$ git ls-files .claude/state/
(empty — nothing tracked is dropped)
```

## Note

PRs #144 and #148 are in flight and have merge priority. This one doesn't touch the same files, so it should be independent, but may need a rebase if either lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)