### PR TITLE
grind: heartbeat shows live token/cost spend

### DIFF
--- a/.local/bin/grind
+++ b/.local/bin/grind
@@ -9,12 +9,16 @@
 #
 # Per Ready item, top (lowest issue number) first:
 #   1. A fresh worktree on a new branch, named after the item.
-#   2. One `claude -p --output-format json --max-budget-usd <item cap>
-#      --model <m> --effort <e>` with the issue body (plus a short contract
-#      appended below) as the prompt. That session does the work and opens
-#      the PR. Merging stays the human's.
-#   3. Parse the JSON result for cost and tokens; print one line: item,
-#      model, cost, tokens, running total, percent of session budget.
+#   2. One `claude -p --output-format stream-json --verbose --max-budget-usd
+#      <item cap> --model <m> --effort <e>` with the issue body (plus a short
+#      contract appended below) as the prompt, read line by line. Each
+#      `assistant` event's `message.usage` is accumulated into a small state
+#      file so the heartbeat can show a running token/cost estimate; the
+#      worker's `result` event still carries the exact `total_cost_usd` and
+#      result text. That session does the work and opens the PR. Merging
+#      stays the human's.
+#   3. Parse the final result event for cost and tokens; print one line:
+#      item, model, cost, tokens, running total, percent of session budget.
 #      Crossing 25/50/75% prints a louder line, once each, per session.
 #   4. A worker that decides an item needs a human ruling ends its final
 #      message with the line "GRIND_STATUS: carded" (having filed the card
@@ -43,7 +47,13 @@
 # every --heartbeat seconds (default 60, 0 disables) while a worker runs, WARN
 # for a skipped item, ERR when the run ends with skips (exit 1). The worker
 # gets --permission-mode (default acceptEdits) so it never waits on a
-# terminal; bypassPermissions is the caller's call, not the default.
+# terminal; bypassPermissions is the caller's call, not the default. A
+# heartbeat line carries a live, `~`-marked token/cost estimate once the
+# worker has emitted at least one assistant event, e.g.:
+#   still working on owner/repo#97 (3m elapsed, ~48k tokens, ~$0.90 so far)
+# `--output-format json` was dropped rather than kept behind a flag: the
+# worker is always read as a stream now, and the two paths would otherwise
+# duplicate all of the cost/status parsing below for no user-visible gain.
 set -eu
 
 usage() {
@@ -57,6 +67,7 @@ usage() {
 # to stderr. All three are always on; there is no quiet mode.
 pct() { awk -v a="$1" -v b="$2" 'BEGIN { if (b == 0) { print 0 } else { printf "%.0f", (a / b) * 100 } }'; }
 fmt_usd() { awk -v v="$1" 'BEGIN { printf "$%.2f", v }'; }
+fmt_tokens() { awk -v t="$1" 'BEGIN { if (t + 0 >= 1000) { printf "%dk", (t / 1000) + 0.5 } else { printf "%d", t } }'; }
 ts()   { date -u +%H:%M:%SZ; }
 info() { printf '%s INFO  %s\n' "$(ts)" "$*"; }
 warn() { printf '%s WARN  %s\n' "$(ts)" "$*" >&2; }
@@ -203,6 +214,35 @@ build_prompt() {
   printf 'Otherwise end your final message with exactly: GRIND_STATUS: done\n'
 }
 
+# --- live cost estimate (heartbeat only; the final line uses the exact
+# total_cost_usd from the result event) --------------------------------------
+# List price in USD per 1M tokens, by model alias/name substring. Cache
+# write/read aren't looked up per model here -- they use Anthropic's
+# standard ratios off the base input price (1.25x for a cache write, 0.1x
+# for a cache read). Unrecognized names fall back to Sonnet pricing.
+model_price_in() {
+  case "$1" in
+    *opus*) printf '5.00' ;;
+    *fable*|*mythos*) printf '10.00' ;;
+    *haiku*) printf '1.00' ;;
+    *) printf '2.00' ;;
+  esac
+}
+model_price_out() {
+  case "$1" in
+    *opus*) printf '25.00' ;;
+    *fable*|*mythos*) printf '50.00' ;;
+    *haiku*) printf '5.00' ;;
+    *) printf '10.00' ;;
+  esac
+}
+# estimate_cost <model> <input> <output> <cache_read> <cache_creation>
+estimate_cost() {
+  ip=$(model_price_in "$1"); op=$(model_price_out "$1")
+  awk -v ip="$ip" -v op="$op" -v i="$2" -v o="$3" -v cr="$4" -v cc="$5" \
+    'BEGIN { printf "%.4f", (i*ip + o*op + cr*(ip*0.1) + cc*(ip*1.25)) / 1000000 }'
+}
+
 # median <space-separated numbers> -> prints 0 when the list is empty
 median() {
   if [ -z "$1" ]; then printf '0\n'; return; fi
@@ -252,7 +292,7 @@ while [ "$i" -lt "$count" ]; do
   branch="grind-$number"
   wt_path="$worktree_root/$number"
 
-  cmd_display="claude -p <issue $ref body> --output-format json --max-budget-usd $item_budget --model $model --effort $effort"
+  cmd_display="claude -p <issue $ref body> --output-format stream-json --verbose --max-budget-usd $item_budget --model $model --effort $effort"
 
   if [ "$dry_run" -eq 1 ]; then
     printf '[%d/%d] %s -- %s\n' "$((i))" "$count" "$ref" "$title"
@@ -276,21 +316,73 @@ while [ "$i" -lt "$count" ]; do
   prompt=$(build_prompt "$(printf '%s' "$item" | jq -r '.body')")
   started=$(date +%s)
   info "worker running: claude -p --model $model --effort $effort --max-budget-usd $item_budget --permission-mode $permission_mode (heartbeat every ${heartbeat}s)"
+
+  # live_file holds "input output cache_read cache_creation" running totals,
+  # rewritten by the reader loop below on every assistant event; the
+  # heartbeat subshell only reads it. One file per grind session -- items
+  # run sequentially, so it's reset (truncated) at the start of each item.
+  live_file="$state_root/${session_id}.live"
+  result_file="$state_root/${session_id}.result"
+  rc_file="$state_root/${session_id}.rc"
+  printf '0 0 0 0\n' > "$live_file"
+  : > "$result_file"
+  : > "$rc_file"
+
   hb_pid=""
   if [ "$heartbeat" -gt 0 ]; then
     # The sleep child would otherwise outlive the kill and hold stdout open.
     ( trap 'kill "$sp" 2>/dev/null; exit 0' TERM
       while :; do
         sleep "$heartbeat" & sp=$!; wait "$sp" || exit 0
-        info "still working on $ref ($(( ($(date +%s) - started) / 60 ))m elapsed)"
+        elapsed_m=$(( ($(date +%s) - started) / 60 ))
+        live=$(cat "$live_file" 2>/dev/null || printf '0 0 0 0')
+        set -- $live
+        li=${1:-0}; lo=${2:-0}; lcr=${3:-0}; lcc=${4:-0}
+        ltotal=$((li + lo + lcr + lcc))
+        if [ "$ltotal" -gt 0 ]; then
+          lcost=$(estimate_cost "$model" "$li" "$lo" "$lcr" "$lcc")
+          info "still working on $ref (${elapsed_m}m elapsed, ~$(fmt_tokens "$ltotal") tokens, ~$(fmt_usd "$lcost") so far)"
+        else
+          info "still working on $ref (${elapsed_m}m elapsed)"
+        fi
       done ) &
     hb_pid=$!
   fi
-  claude_rc=0
-  result_json=$( (cd "$wt_path" && printf '%s' "$prompt" | \
-    claude -p --output-format json --max-budget-usd "$item_budget" --model "$model" --effort "$effort" \
-      --permission-mode "$permission_mode") ) \
-    || claude_rc=$?
+
+  # Read the worker's stream-json output line by line, accumulating each
+  # assistant event's usage into live_file for the heartbeat above, and
+  # keeping the final result event for the cost/status parsing below.
+  # claude's own exit code can't come from $? after the pipeline (that
+  # would be the while loop's), so it's relayed through rc_file instead.
+  ( cd "$wt_path" \
+      && printf '%s' "$prompt" | claude -p --output-format stream-json --verbose \
+           --max-budget-usd "$item_budget" --model "$model" --effort "$effort" \
+           --permission-mode "$permission_mode"
+    echo $? > "$rc_file"
+  ) | while IFS= read -r line; do
+      etype=$(printf '%s' "$line" | jq -r '.type // empty' 2>/dev/null) || continue
+      case "$etype" in
+        assistant)
+          usage=$(printf '%s' "$line" | jq -c '.message.usage // empty' 2>/dev/null)
+          [ -n "$usage" ] && [ "$usage" != "null" ] || continue
+          cur=$(cat "$live_file" 2>/dev/null || printf '0 0 0 0')
+          set -- $cur
+          ci=${1:-0}; co=${2:-0}; ccr=${3:-0}; ccc=${4:-0}
+          di=$(printf '%s' "$usage" | jq -r '.input_tokens // 0')
+          do_=$(printf '%s' "$usage" | jq -r '.output_tokens // 0')
+          dcr=$(printf '%s' "$usage" | jq -r '.cache_read_input_tokens // 0')
+          dcc=$(printf '%s' "$usage" | jq -r '.cache_creation_input_tokens // 0')
+          printf '%s %s %s %s\n' "$((ci + di))" "$((co + do_))" "$((ccr + dcr))" "$((ccc + dcc))" > "$live_file"
+          ;;
+        result)
+          printf '%s\n' "$line" > "$result_file"
+          ;;
+      esac
+    done
+  claude_rc=$(cat "$rc_file" 2>/dev/null || echo 1)
+  result_json=$(cat "$result_file" 2>/dev/null || echo "")
+  rm -f "$live_file" "$result_file" "$rc_file"
+
   if [ -n "$hb_pid" ]; then kill "$hb_pid" 2>/dev/null; wait "$hb_pid" 2>/dev/null || true; fi
   info "worker exited $claude_rc after $(( $(date +%s) - started ))s"
 

--- a/.local/bin/grind.test.sh
+++ b/.local/bin/grind.test.sh
@@ -49,9 +49,12 @@ esac
 GH
 chmod +x "$S/bin/gh"
 
-# fake claude -- reads the prompt from stdin (unused), writes a canned JSON
-# result read from $CLAUDE_MODE for the current item (matched by title in the
-# piped prompt) via $S/claude-replies/<n>.json, defaulting to a $1 flat reply.
+# fake claude -- reads the prompt from stdin (unused), writes canned
+# stream-json lines read from $S/claude-replies/<n>.json for the current
+# item (an assistant event followed by a result event, one per line, as the
+# real worker now streams), defaulting to a flat two-line reply. grind reads
+# claude's stdout line by line now, so the shim must emit newline-delimited
+# JSON, never one blob.
 mkdir -p "$S/claude-replies"
 cat > "$S/bin/claude" <<GH
 #!/bin/sh
@@ -60,10 +63,21 @@ n=\$(cat "$S/claude-next" 2>/dev/null || echo 1)
 echo "\$n \$*" >> "$CLAUDE_LOG"
 echo \$((n + 1)) > "$S/claude-next"
 reply="$S/claude-replies/\$n.json"
-if [ -f "\$reply" ]; then cat "\$reply"; else echo '{"total_cost_usd":0.10,"usage":{"input_tokens":100,"output_tokens":50},"result":"GRIND_STATUS: done"}'; fi
+if [ -f "\$reply" ]; then cat "\$reply"; else
+  echo '{"type":"assistant","message":{"usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}'
+  echo '{"type":"result","total_cost_usd":0.10,"usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":0,"cache_creation_input_tokens":0},"result":"GRIND_STATUS: done"}'
+fi
 GH
 chmod +x "$S/bin/claude"
-reply() { jq -nc --argjson cost "$1" --arg status "$2" '{total_cost_usd:$cost, usage:{input_tokens:100,output_tokens:50}, result:("done work\nGRIND_STATUS: " + $status)}' > "$S/claude-replies/$3.json"; }
+# reply <cost> <status> <n> -- writes the two-line stream-json shape above
+# (one assistant usage event, one result event) to $S/claude-replies/<n>.json.
+reply() {
+  jq -nc '{type:"assistant", message:{usage:{input_tokens:100,output_tokens:50,cache_read_input_tokens:0,cache_creation_input_tokens:0}}}' \
+    > "$S/claude-replies/$3.json"
+  jq -nc --argjson cost "$1" --arg status "$2" \
+    '{type:"result", total_cost_usd:$cost, usage:{input_tokens:100,output_tokens:50,cache_read_input_tokens:0,cache_creation_input_tokens:0}, result:("done work\nGRIND_STATUS: " + $status)}' \
+    >> "$S/claude-replies/$3.json"
+}
 
 ok()   { pass=$((pass + 1)); }
 bad()  { fail=$((fail + 1)); printf 'FAIL: %s\n' "$1"; [ -n "${2:-}" ] && printf '%s\n' "$2" | sed 's/^/    /'; }
@@ -84,7 +98,7 @@ has 'first item is the lower-numbered one' '^\[1/2\] o/alpha#5 -- First item$'
 has 'second item follows' '^\[2/2\] o/alpha#20 -- Second item$'
 lacks 'blocked item excluded' 'alpha#9'
 has 'a worktree command is shown' 'git worktree add -b grind-5'
-has 'the claude command is shown, with defaults' 'claude -p <issue o/alpha#5 body> --output-format json --max-budget-usd 5 --model sonnet --effort medium'
+has 'the claude command is shown, with defaults' 'claude -p <issue o/alpha#5 body> --output-format stream-json --verbose --max-budget-usd 5 --model sonnet --effort medium'
 assert 'dry-run wrote no state file' bash -c '! ls '"$S"'/state/grind/*.json >/dev/null 2>&1'
 
 # --- --dry-run respects override flags -----------------------------------------
@@ -109,6 +123,56 @@ has 'INFO: worker exit line' 'INFO  worker exited 0 after [0-9]+s'
 has 'worker gets --permission-mode' '--permission-mode acceptEdits' 
 sess=$(latest_session)
 eq 'two items recorded in state' 2 "$(jq '.items | length' "$sess")"
+
+# --- heartbeat: shows a live, ~-marked token/cost estimate before the item
+# finishes, accumulated from two assistant events; the final line still uses
+# the exact total_cost_usd -----------------------------------------------------
+cat > "$S/ready.json" <<'JSON'
+[
+  {"number": 5, "title": "First item", "body": "do the first thing", "url": "https://github.com/o/alpha/issues/5", "labels": [{"name": "ready"}]}
+]
+JSON
+rm -f "$S/state/grind"/*.json
+cat > "$S/bin/claude" <<GH
+#!/bin/sh
+cat > /dev/null
+echo "\$*" >> "$CLAUDE_LOG"
+echo '{"type":"assistant","message":{"usage":{"input_tokens":10000,"output_tokens":5000,"cache_read_input_tokens":20000,"cache_creation_input_tokens":3000}}}'
+sleep 0.3
+echo '{"type":"assistant","message":{"usage":{"input_tokens":5000,"output_tokens":5000,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}'
+sleep 2
+echo '{"type":"result","total_cost_usd":0.90,"usage":{"input_tokens":15000,"output_tokens":10000,"cache_read_input_tokens":20000,"cache_creation_input_tokens":3000},"result":"GRIND_STATUS: done"}'
+GH
+chmod +x "$S/bin/claude"
+: > "$CLAUDE_LOG"
+run --session-budget 100 --pause-every 10 --heartbeat 1
+eq 'exit 0' 0 "$RC"
+has 'heartbeat line carries elapsed time, a token count, and a ~$ estimate -- both assistant events accumulated (15000+10000+20000+3000=48000 -> 48k)' \
+  'still working on o/alpha#5 \([0-9]+m elapsed, ~48k tokens, ~\$[0-9]+\.[0-9]{2} so far\)'
+has 'the final line still uses the exact total_cost_usd, not the estimate' '^o/alpha#5: First item -- sonnet, \$0\.90,'
+
+# restore the multi-item ready queue and the reply-driven claude shim
+cat > "$S/ready.json" <<'JSON'
+[
+  {"number": 20, "title": "Second item", "body": "do the second thing", "url": "https://github.com/o/alpha/issues/20", "labels": [{"name": "ready"}]},
+  {"number": 5, "title": "First item", "body": "do the first thing", "url": "https://github.com/o/alpha/issues/5", "labels": [{"name": "ready"}]},
+  {"number": 9, "title": "Blocked item", "body": "not yet", "url": "https://github.com/o/alpha/issues/9", "labels": [{"name": "ready"}, {"name": "blocked"}]}
+]
+JSON
+rm -f "$S/state/grind"/*.json
+cat > "$S/bin/claude" <<GH
+#!/bin/sh
+cat > /dev/null
+n=\$(cat "$S/claude-next" 2>/dev/null || echo 1)
+echo "\$n \$*" >> "$CLAUDE_LOG"
+echo \$((n + 1)) > "$S/claude-next"
+reply="$S/claude-replies/\$n.json"
+if [ -f "\$reply" ]; then cat "\$reply"; else
+  echo '{"type":"assistant","message":{"usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}'
+  echo '{"type":"result","total_cost_usd":0.10,"usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":0,"cache_creation_input_tokens":0},"result":"GRIND_STATUS: done"}'
+fi
+GH
+chmod +x "$S/bin/claude"
 
 # --- threshold lines: each fires once, even when one item crosses several ------
 # Only two Ready items exist, so item 1 crosses 25%, item 2 jumps straight to
@@ -289,7 +353,10 @@ n=\$(cat "$S/claude-next" 2>/dev/null || echo 1)
 echo "\$n \$*" >> "$CLAUDE_LOG"
 echo \$((n + 1)) > "$S/claude-next"
 reply="$S/claude-replies/\$n.json"
-if [ -f "\$reply" ]; then cat "\$reply"; else echo '{"total_cost_usd":0.10,"usage":{"input_tokens":100,"output_tokens":50},"result":"GRIND_STATUS: done"}'; fi
+if [ -f "\$reply" ]; then cat "\$reply"; else
+  echo '{"type":"assistant","message":{"usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}'
+  echo '{"type":"result","total_cost_usd":0.10,"usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":0,"cache_creation_input_tokens":0},"result":"GRIND_STATUS: done"}'
+fi
 GH
 chmod +x "$S/bin/claude"
 session_id=$(basename "$sess" .json)
@@ -307,7 +374,7 @@ cat > /dev/null
 n=\$(cat "$S/claude-next" 2>/dev/null || echo 1)
 echo "\$n \$*" >> "$CLAUDE_LOG"
 echo \$((n + 1)) > "$S/claude-next"
-echo '{"is_error":true,"total_cost_usd":5.00,"usage":{"input_tokens":100,"output_tokens":50},"result":"Budget exceeded"}'
+echo '{"type":"result","is_error":true,"total_cost_usd":5.00,"usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":0,"cache_creation_input_tokens":0},"result":"Budget exceeded"}'
 exit 1
 GH
 chmod +x "$S/bin/claude"
@@ -331,7 +398,10 @@ n=\$(cat "$S/claude-next" 2>/dev/null || echo 1)
 echo "\$n \$*" >> "$CLAUDE_LOG"
 echo \$((n + 1)) > "$S/claude-next"
 reply="$S/claude-replies/\$n.json"
-if [ -f "\$reply" ]; then cat "\$reply"; else echo '{"total_cost_usd":0.10,"usage":{"input_tokens":100,"output_tokens":50},"result":"GRIND_STATUS: done"}'; fi
+if [ -f "\$reply" ]; then cat "\$reply"; else
+  echo '{"type":"assistant","message":{"usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}'
+  echo '{"type":"result","total_cost_usd":0.10,"usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":0,"cache_creation_input_tokens":0},"result":"GRIND_STATUS: done"}'
+fi
 GH
 chmod +x "$S/bin/claude"
 


### PR DESCRIPTION
Fixes #127.

## What changed

- `.local/bin/grind`'s worker invocation switches to `claude -p --output-format stream-json --verbose` (no `--include-partial-messages`), read line by line instead of captured as one JSON blob.
- Each `assistant` event's `message.usage` (input, output, cache-read, cache-creation tokens) is accumulated into a small per-session state file (`$state_root/<session>.live`), written by the reader loop and read by the heartbeat subshell.
- The heartbeat now prints e.g. `still working on owner/repo#97 (3m elapsed, ~48k tokens, ~$0.90 so far)`. The live estimate is marked `~` (accumulated tokens priced at the model's list price, with Anthropic's standard cache write/read ratios off the base input price, since per-model cache rates aren't published separately). The final per-item line is unchanged -- it still uses the exact `total_cost_usd` from the worker's `result` event.
- Verified the stream-json event shape against a real `claude -p --output-format stream-json --verbose` invocation before coding (per the issue's own instruction not to trust its field-name description). The `result` event's fields (`total_cost_usd`, `usage.*`, `result`, `is_error`) match the old `--output-format json` shape exactly, so the existing cost/status parsing needed **no changes**.

## `--output-format json`

**Dropped, not kept behind a flag.** The worker is always read as a stream now; keeping the old path would duplicate the cost/status parsing for no user-visible benefit -- the CLI's `--output-format json` is still available for any other caller, this script just no longer offers a switch to it.

## Tests

`grind.test.sh`'s `claude` shim now emits newline-delimited stream-json (one `assistant` usage event, then a `result` event) instead of a single JSON blob, matching what the real worker streams. Added a heartbeat test case: two `assistant` events carrying usage, `--heartbeat 1`, asserting the captured output has a heartbeat line with both a token count and a `~$` figure, and that the final per-item line still carries the exact cost.

```
$ bash .local/bin/grind.test.sh
75 passed, 0 failed
```

Note: #144 and #148 are in flight with merge priority. Checked their diffs (`gh pr diff 144`/`148` filenames) -- both touch only `.claude/hooks/metrics-live*`, unrelated to `.local/bin/grind` and `grind.test.sh` here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
