### PR TITLE
A worktree belongs to one session

### DIFF
--- a/.claude/hooks/no-foreign-worktree.sh
+++ b/.claude/hooks/no-foreign-worktree.sh
@@ -62,8 +62,8 @@
 # Scanning is shared with no-git-footguns.sh/no-checkout-home.sh/
 # no-rm-tree.sh: lib-shell-words.awk (read its header).
 #
-# This is a GATE, so it fails closed: no jq, no awk, no library, unreadable
-# payload -> deny.
+# This is a GATE, so it fails closed: no jq, no awk, no sed, no git, no
+# library, unreadable payload -> deny.
 set -u
 
 # Parameter expansion, not `dirname`: this hook must still emit valid JSON
@@ -93,6 +93,7 @@ Worktree hygiene is the user's call, not a session's."
 command -v jq  >/dev/null 2>&1 || deny_literal 'jq is missing, so the command cannot be inspected.'
 command -v awk >/dev/null 2>&1 || deny_literal 'awk is missing, so the command cannot be inspected.'
 command -v sed >/dev/null 2>&1 || deny_literal 'sed is missing, so the command cannot be inspected.'
+command -v git >/dev/null 2>&1 || deny_literal 'git is missing, so worktree ownership cannot be checked.'
 [ -r "$LIB" ] || deny_literal 'lib-shell-words.awk is missing from the hooks directory, so the command cannot be inspected. Run dotsync (or cloud-session-setup.sh) and retry.'
 payload=$(cat) || deny_literal 'the hook payload could not be read.'
 tool=$(printf '%s' "$payload" | jq -r '.tool_name // empty' 2>/dev/null) || deny_literal 'the hook payload is unreadable.'

--- a/.claude/hooks/no-foreign-worktree.sh
+++ b/.claude/hooks/no-foreign-worktree.sh
@@ -1,0 +1,223 @@
+#!/bin/sh
+# Refuses to let a session reach into a git worktree that is not its own.
+#
+# The scar (2026-09, PR #162): a session was handed nothing but "continue
+# <issue> see <PR>". It found the branch already checked out in a sibling
+# worktree, decided that working there with `git -C <that path>` was the
+# clean move, and did. When the session that actually owned that worktree
+# was archived -- correctly, by its own git state -- the directory went
+# away underneath the second session mid-turn. It survived only because its
+# commit happened to already be pushed.
+#
+# The mistake was not the pickup skill and not the archival check. It was
+# treating another session's working directory as a place to work. A
+# hand-off carries a branch, an issue and a PR; it does not carry a
+# directory. Everything a leaving session wants handed over is on the
+# remote -- if it isn't pushed, it isn't handed over, and reaching into
+# their worktree to get it is racing a process that is still running.
+#
+# So: any path inside a linked worktree other than this session's own is
+# refused, in any command, read or write. The alternatives are all local:
+#
+#   inspect a branch      git log/diff/show <branch>, git show <branch>:<path>
+#                         -- every worktree of a repo shares its objects and
+#                         refs, so nothing about another branch requires
+#                         standing in another directory.
+#   work on a branch      EnterWorktree(name=...) for your own worktree, then
+#                         `git checkout <branch>` inside it. If git refuses
+#                         because the branch is checked out elsewhere, that
+#                         is a live claim by another session: report it and
+#                         stop. Do not take it away from them.
+#   worktree hygiene      the user's, not a session's.
+#
+# `EnterWorktree(path=...)` is refused outright: the tool enters an existing
+# worktree with no ownership check of any kind (verified in its own
+# documentation -- the only requirement is that the path appear in `git
+# worktree list`), and every legitimate use of it is reachable via
+# `EnterWorktree(name=...)` plus a checkout.
+#
+# What counts as foreign: git is asked, nothing is assumed from the path.
+# A candidate resolves to a toplevel (`rev-parse --show-toplevel`) that
+#   - differs from this session's own toplevel, and
+#   - is a LINKED worktree -- its `.git` is a file, not a directory.
+# The second test is what keeps `~/dotfiles`, `$HOME` (yadm's own worktree)
+# and every other clone allowed: those are main worktrees, shared by every
+# session on the machine and no session's private space. Sibling worktrees
+# of the current repo sit *inside* the repo root by path
+# (`<repo>/.claude/worktrees/<name>`), so a textual "is it under my
+# toplevel" shortcut would wrongly allow exactly the case this exists for.
+# There is no shortcut here for that reason: every candidate path gets asked.
+#
+# Known gap, deliberate: the shared scanner drops redirections, so
+# `cmd > /other/worktree/file` is not seen. Words are seen, redirection
+# targets are not. Closing it means reimplementing redirection tracking for
+# one exotic spelling; the ordinary routes (a cd, a `-C`, an Edit, a
+# `sed -i`, a `cp`) are all words.
+#
+# Prose is not a command: a path mentioned inside a quoted string that holds
+# whitespace stays one unresolvable word, and the scanner only queues such a
+# string for a nested scan when its segment could execute it -- so a commit
+# message, an issue body or a card that names a worktree path passes.
+#
+# Scanning is shared with no-git-footguns.sh/no-checkout-home.sh/
+# no-rm-tree.sh: lib-shell-words.awk (read its header).
+#
+# This is a GATE, so it fails closed: no jq, no awk, no library, unreadable
+# payload -> deny.
+set -u
+
+# Parameter expansion, not `dirname`: this hook must still emit valid JSON
+# when PATH is broken, and that is when an external tool is least available.
+HERE=${0%/*}
+[ "$HERE" = "$0" ] && HERE=.
+LIB="$HERE/lib-shell-words.awk"
+# Asking git costs two processes per candidate path; a command with hundreds
+# of path-shaped words is pathological, not a use case. Cap and move on.
+MAX_CANDIDATES=48
+
+json_str() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g' | awk 'BEGIN{ORS="\\n"} {print}' | sed 's/\\n$//; s/^/"/; s/$/"/'; }
+deny() { printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$(json_str "$1")"; exit 0; }
+# The reasons that fire when a tool this hook needs is missing cannot go
+# through json_str -- it needs sed and awk, which is what may be missing.
+# printf is a shell builtin, so this one always emits valid JSON. Keep the
+# message free of double quotes, backslashes and newlines.
+deny_literal() { printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"no-foreign-worktree: %s This is a gate and fails closed."}}\n' "$1"; exit 0; }
+
+deny_path() {
+  deny "no-foreign-worktree: \`$1\` is inside $2, a git worktree this session does not own. A hand-off carries a branch, an issue and a PR -- never a directory; another session may still be running in there, and it may be archived out from under you mid-turn (that is how PR #162 lost its worktree).
+To read that branch, stay here: \`git log/diff/show <branch>\`, \`git show <branch>:<path>\` -- worktrees of a repo share objects and refs.
+To work on it, take your own worktree: EnterWorktree(name=<name>), then \`git checkout <branch>\` inside it. If git refuses because the branch is checked out elsewhere, another session holds it: report that and stop.
+Worktree hygiene is the user's call, not a session's."
+}
+
+command -v jq  >/dev/null 2>&1 || deny_literal 'jq is missing, so the command cannot be inspected.'
+command -v awk >/dev/null 2>&1 || deny_literal 'awk is missing, so the command cannot be inspected.'
+command -v sed >/dev/null 2>&1 || deny_literal 'sed is missing, so the command cannot be inspected.'
+[ -r "$LIB" ] || deny_literal 'lib-shell-words.awk is missing from the hooks directory, so the command cannot be inspected. Run dotsync (or cloud-session-setup.sh) and retry.'
+payload=$(cat) || deny_literal 'the hook payload could not be read.'
+tool=$(printf '%s' "$payload" | jq -r '.tool_name // empty' 2>/dev/null) || deny_literal 'the hook payload is unreadable.'
+
+payload_cwd=$(printf '%s' "$payload" | jq -r '.cwd // empty' 2>/dev/null)
+[ -n "$payload_cwd" ] || exit 0
+home=$(cd "$HOME" 2>/dev/null && pwd -P) || exit 0
+
+# This session's own worktree root. Empty when the cwd is not in a repo at
+# all -- then every linked worktree is someone else's, which is the answer
+# this hook would give anyway.
+own_top=$(git -C "$payload_cwd" rev-parse --show-toplevel 2>/dev/null)
+
+# EnterWorktree with a `path` is refused whatever the path: the tool does no
+# ownership check, and `name` plus a checkout covers every honest use.
+case "$tool" in
+  EnterWorktree)
+    p=$(printf '%s' "$payload" | jq -r '.tool_input.path // empty' 2>/dev/null)
+    [ -n "$p" ] || exit 0
+    deny "no-foreign-worktree: EnterWorktree(path=...) enters a worktree that already exists, with no check on whose it is -- the tool only requires that the path appear in \`git worktree list\`. That is how PR #162 lost its worktree mid-turn: the session that owned it was archived and the directory went away underneath the session that had attached to it.
+Take your own instead: EnterWorktree(name=<name>), then \`git checkout <branch>\` inside it to put the branch you are resuming in your own directory. If git refuses because the branch is checked out in another worktree, another session holds it: report that and stop.
+Nothing needs the other directory -- worktrees of a repo share objects and refs, so \`git log/diff/show <branch>\` and \`git show <branch>:<path>\` read it from here."
+    ;;
+esac
+
+# Resolves one raw word against $home/$payload_cwd the way the shell would
+# if the literal text were left unquoted, then walks up to its nearest
+# existing directory (a write to a file that does not exist yet still names
+# the worktree it would land in). Echoes that directory, or nothing.
+resolve_dir() {
+  raw=$1
+  # These case patterns match a literal leading "~"/"$HOME" -- nothing here
+  # expands one.
+  # shellcheck disable=SC2088
+  case "$raw" in
+    '$HOME'|'${HOME}'|'~') r="$home" ;;
+    '$HOME'/*) r="$home/${raw#\$HOME/}" ;;
+    '${HOME}'/*) r="$home/${raw#\$\{HOME\}/}" ;;
+    '~/'*) r="$home/${raw#\~/}" ;;
+    /*) r="$raw" ;;
+    *) r="$payload_cwd/$raw" ;;
+  esac
+  # An unexpandable word ($VAR, a brace expansion, a glob) can't be judged;
+  # the walk up would land on a real ancestor and answer about the wrong
+  # path, so refuse to resolve it at all.
+  case "$r" in *'$'*|*'*'*|*'?'*|*'{'*) return 0 ;; esac
+  while [ -n "$r" ] && [ "$r" != "/" ] && [ ! -d "$r" ]; do
+    case "$r" in */*) r=${r%/*}; [ -n "$r" ] || r=/ ;; *) return 0 ;; esac
+  done
+  [ -d "$r" ] || return 0
+  (cd "$r" 2>/dev/null && pwd -P)
+}
+
+# Prints the foreign worktree root a directory belongs to, or nothing.
+foreign_top() {
+  t=$(git -C "$1" rev-parse --show-toplevel 2>/dev/null)
+  [ -n "$t" ] || return 0
+  [ "$t" = "$own_top" ] && return 0
+  # A linked worktree keeps a `.git` FILE pointing at its admin dir; a main
+  # worktree (a clone, $HOME under yadm) keeps a directory. Only the former
+  # is a session's private space.
+  [ -f "$t/.git" ] || return 0
+  printf '%s' "$t"
+}
+
+check_word() {
+  d=$(resolve_dir "$1")
+  [ -n "$d" ] || return 0
+  ft=$(foreign_top "$d")
+  [ -n "$ft" ] && deny_path "$1" "$ft"
+}
+
+case "$tool" in
+  Edit|Write|MultiEdit|NotebookEdit)
+    fp=$(printf '%s' "$payload" | jq -r '.tool_input.file_path // .tool_input.notebook_path // empty' 2>/dev/null)
+    [ -n "$fp" ] || exit 0
+    check_word "$fp"
+    exit 0
+    ;;
+  Bash) ;;
+  *) exit 0 ;;
+esac
+
+cmd=$(printf '%s' "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null)
+[ -n "$cmd" ] || exit 0
+
+# awk prints every path-shaped word of the command, deduplicated: any word
+# holding a "/", plus `~`/`$HOME` on its own, with a leading `--flag=` or
+# `VAR=` stripped so `--work-tree=<path>` and `GIT_WORK_TREE=<path>` are
+# seen. Words are taken from the top-level text and from every quoted string
+# the scanner judges executable, in every position -- not just command
+# position: the target of the move this hook exists to stop is always an
+# argument (`cd <path>`, `git -C <path>`, `sed -i <path>`).
+words=$(printf '%s\n' "$cmd" | awk "$(cat "$LIB")"'
+function pathish(t) {
+  sub(/^--?[A-Za-z0-9][A-Za-z0-9-]*=/, "", t)
+  sub(/^[A-Za-z_][A-Za-z0-9_]*=/, "", t)
+  if (t == "~" || t == "$HOME" || t == "${HOME}") return t
+  return (index(t, "/") ? t : "")
+}
+{ buf = buf $0 "\n" }
+END {
+  buf = strip_heredocs(buf)
+  nt = texts_of(buf, texts, nested)
+  for (x = 1; x <= nt; x++) {
+    n = scan(texts[x], w, k, q)
+    for (i = 1; i <= n; i++) {
+      if (k[i] != "w") continue
+      t = pathish(w[i])
+      if (t == "" || t in seen) continue
+      seen[t] = 1
+      print t
+    }
+  }
+}') || deny "no-foreign-worktree: awk failed, cannot inspect the command"
+
+[ -n "$words" ] || exit 0
+
+seen_count=0
+while IFS= read -r word; do
+  [ -n "$word" ] || continue
+  seen_count=$((seen_count + 1))
+  [ "$seen_count" -gt "$MAX_CANDIDATES" ] && break
+  check_word "$word"
+done <<EOF
+$words
+EOF
+exit 0

--- a/.claude/hooks/no-foreign-worktree.test.sh
+++ b/.claude/hooks/no-foreign-worktree.test.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Tests for no-foreign-worktree.sh. Run: bash .claude/hooks/no-foreign-worktree.test.sh
+# Set AWK_PATH to a directory whose `awk` is another implementation (mawk,
+# nawk, busybox) to check portability; CI runs it under Ubuntu's mawk.
+#
+# The fixture is a throwaway repo with two linked worktrees, not this
+# machine's real ones: the hook asks git what a path is, so the checks are
+# only meaningful against paths git really answers about, and naming a
+# sibling worktree that exists today would rot the moment it is archived.
+set -uo pipefail
+
+HOOK="$(cd "$(dirname "$0")" && pwd)/no-foreign-worktree.sh"
+[ -n "${AWK_PATH:-}" ] && PATH="$AWK_PATH:$PATH"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+# `pwd -P` inside the hook resolves symlinks (/tmp is one on macOS), so the
+# fixture paths must be resolved here too or every comparison misses.
+TMP=$(cd "$TMP" && pwd -P)
+
+setup() (
+  set -e
+  cd "$TMP"
+  git init -q --initial-branch=main repo
+  cd repo
+  git -c user.email=t@e -c user.name=t commit -q --allow-empty -m init
+  mkdir -p .claude/worktrees
+  git worktree add -q --no-checkout -b mine .claude/worktrees/mine >/dev/null 2>&1 || git worktree add -q -b mine .claude/worktrees/mine
+  git -C .claude/worktrees/mine checkout -q mine 2>/dev/null || true
+  git worktree add -q -b theirs .claude/worktrees/theirs
+  mkdir -p .claude/worktrees/theirs/sub
+  : > .claude/worktrees/theirs/sub/file.txt
+  # A second, unrelated clone: a MAIN worktree, shared by every session and
+  # nobody's private space, so it must stay allowed.
+  cd "$TMP"
+  git clone -q repo other-clone
+)
+setup || { echo "fixture setup failed"; exit 1; }
+
+REPO="$TMP/repo"
+MINE="$REPO/.claude/worktrees/mine"
+THEIRS="$REPO/.claude/worktrees/theirs"
+CLONE="$TMP/other-clone"
+
+pass=0
+fail=0
+
+# check <deny|allow> <description> <json payload>
+check_json() {
+  local want=$1 desc=$2 json=$3 out got
+  out=$(printf '%s' "$json" | bash "$HOOK" 2>&1)
+  if printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then got=deny; else got=allow; fi
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    printf 'FAIL (want %s, got %s): %s\n' "$want" "$got" "$desc"
+    [ -n "$out" ] && printf '  hook output: %s\n' "$out"
+  fi
+}
+
+# bash <deny|allow> <description> <command> [cwd]
+bash_check() {
+  check_json "$1" "$3" "$(jq -n --arg c "$3" --arg d "${4:-$MINE}" \
+    '{tool_name:"Bash",tool_input:{command:$c},cwd:$d}')"
+}
+
+# --- must deny: attaching to another session's worktree --------------------
+bash_check deny 'git -C <foreign worktree>'        "git -C $THEIRS status"
+bash_check deny 'git -C a subdir of one'           "git -C $THEIRS/sub log"
+bash_check deny 'cd into one'                      "cd $THEIRS && git commit -m x"
+bash_check deny '--work-tree=<foreign>'            "git --work-tree=$THEIRS status"
+bash_check deny 'GIT_WORK_TREE=<foreign>'          "GIT_WORK_TREE=$THEIRS git status"
+bash_check deny 'a relative path into one'         "git -C ../theirs status"
+bash_check deny 'writing a file in one'            "sed -i s/a/b/ $THEIRS/sub/file.txt"
+bash_check deny 'a file that does not exist yet'   "echo hi | tee $THEIRS/sub/new.txt"
+bash_check deny 'reading a file in one'            "cat $THEIRS/sub/file.txt"
+bash_check deny 'removing one'                     "git worktree remove $THEIRS"
+bash_check deny 'inside sh -c'                     "sh -c \"cd $THEIRS && ls\""
+bash_check deny 'from the main worktree'           "git -C $THEIRS status" "$REPO"
+bash_check deny 'from an unrelated cwd'            "git -C $THEIRS status" /tmp
+
+# --- must allow: everywhere that is not a private working directory --------
+bash_check allow 'the main worktree of the repo'   "git -C $REPO status"
+bash_check allow 'an unrelated clone'              "git -C $CLONE status"
+bash_check allow 'this session own worktree'       "git -C $MINE status"
+bash_check allow 'a path inside own worktree'      "cat $MINE/nothing-here.txt"
+bash_check allow 'a plain relative path'           'cat README.md'
+bash_check allow 'the worktrees parent directory'  "ls $REPO/.claude/worktrees/"
+bash_check allow 'a ref, not a path'               'git log origin/main'
+bash_check allow 'no path at all'                  'git status --porcelain'
+# The whole point of the alternative the deny message offers.
+bash_check allow 'reading a branch from here'      'git show theirs:sub/file.txt'
+
+# --- must allow: prose that mentions a foreign path -----------------------
+# A quoted string holding whitespace is one unresolvable word, and the
+# scanner only queues it for a nested scan when the segment could execute
+# it -- git and gh are prose consumers, so a message or an issue body passes.
+bash_check allow 'a commit message naming one'     "git commit -m \"worktree $THEIRS is stale\""
+bash_check allow 'an issue body naming one'        "gh issue comment 1 -b \"old work is in $THEIRS\""
+bash_check allow 'an echo naming one'              "echo \"see $THEIRS for the old work\""
+
+# --- must allow: an unresolvable word is not judged ------------------------
+bash_check allow 'an unexpanded variable'          'git -C "$SOME_DIR" status'
+bash_check allow 'a glob'                          "ls $REPO/.claude/worktrees/*/"
+
+# --- file-editing tools ---------------------------------------------------
+for tool in Edit Write MultiEdit; do
+  check_json deny "$tool into a foreign worktree" \
+    "$(jq -n --arg p "$THEIRS/sub/file.txt" --arg d "$MINE" --arg t "$tool" \
+      '{tool_name:$t,tool_input:{file_path:$p},cwd:$d}')"
+  check_json allow "$tool inside own worktree" \
+    "$(jq -n --arg p "$MINE/file.txt" --arg d "$MINE" --arg t "$tool" \
+      '{tool_name:$t,tool_input:{file_path:$p},cwd:$d}')"
+done
+check_json deny 'NotebookEdit into a foreign worktree' \
+  "$(jq -n --arg p "$THEIRS/sub/nb.ipynb" --arg d "$MINE" \
+    '{tool_name:"NotebookEdit",tool_input:{notebook_path:$p},cwd:$d}')"
+
+# --- EnterWorktree -------------------------------------------------------
+# `path` is refused whatever it names: the tool does no ownership check, so
+# there is no path value that makes it safe. `name` creates a fresh one.
+check_json deny 'EnterWorktree(path=foreign)' \
+  "$(jq -n --arg p "$THEIRS" --arg d "$MINE" '{tool_name:"EnterWorktree",tool_input:{path:$p},cwd:$d}')"
+check_json deny 'EnterWorktree(path=own)' \
+  "$(jq -n --arg p "$MINE" --arg d "$MINE" '{tool_name:"EnterWorktree",tool_input:{path:$p},cwd:$d}')"
+check_json allow 'EnterWorktree(name=...)' \
+  "$(jq -n --arg d "$MINE" '{tool_name:"EnterWorktree",tool_input:{name:"fresh"},cwd:$d}')"
+
+# --- other tools are none of this hook business --------------------------
+check_json allow 'Read of a foreign path is not gated here' \
+  "$(jq -n --arg p "$THEIRS/sub/file.txt" --arg d "$MINE" '{tool_name:"Read",tool_input:{file_path:$p},cwd:$d}')"
+
+# --- fails closed --------------------------------------------------------
+check_json deny 'unreadable payload' 'not json at all'
+# An absolute interpreter, since PATH is what is being taken away. The
+# fail-closed reasons must not need sed or awk to be serialised, so this
+# checks the output is valid JSON, not merely that it says deny.
+out=$(printf '%s' "$(jq -n --arg c "git -C $THEIRS status" --arg d "$MINE" '{tool_name:"Bash",tool_input:{command:$c},cwd:$d}')" \
+  | env -i PATH=/nonexistent HOME="$HOME" /bin/sh "$HOOK" 2>/dev/null)
+if printf '%s' "$out" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' >/dev/null 2>&1; then
+  pass=$((pass + 1))
+else
+  fail=$((fail + 1))
+  printf 'FAIL: no jq/awk on PATH must fail closed with valid JSON\n  hook output: %s\n' "$out"
+fi
+
+printf '%s\n' "no-foreign-worktree: $pass passed, $fail failed"
+[ "$fail" -eq 0 ] || exit 1

--- a/.claude/hooks/no-foreign-worktree.test.sh
+++ b/.claude/hooks/no-foreign-worktree.test.sh
@@ -145,5 +145,23 @@ else
   printf 'FAIL: no jq/awk on PATH must fail closed with valid JSON\n  hook output: %s\n' "$out"
 fi
 
+# jq/awk/sed present, git absent -- this is the case the header's own
+# invariant would miss if only jq/awk/sed were checked: git is what every
+# foreignness decision is asked of, so its absence must deny too, not
+# silently treat every path as non-foreign.
+no_git_dir=$(mktemp -d)
+for t in jq awk sed; do
+  p=$(command -v "$t") && ln -s "$p" "$no_git_dir/$t"
+done
+out=$(printf '%s' "$(jq -n --arg c "git -C $THEIRS status" --arg d "$MINE" '{tool_name:"Bash",tool_input:{command:$c},cwd:$d}')" \
+  | env -i PATH="$no_git_dir" HOME="$HOME" /bin/sh "$HOOK" 2>/dev/null)
+if printf '%s' "$out" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' >/dev/null 2>&1; then
+  pass=$((pass + 1))
+else
+  fail=$((fail + 1))
+  printf 'FAIL: jq/awk/sed present but no git on PATH must fail closed\n  hook output: %s\n' "$out"
+fi
+rm -rf "$no_git_dir"
+
 printf '%s\n' "no-foreign-worktree: $pass passed, $fail failed"
 [ "$fail" -eq 0 ] || exit 1

--- a/.claude/rules/code.md
+++ b/.claude/rules/code.md
@@ -22,6 +22,14 @@ project-specific facts belong in that project's own CLAUDE.md.
   surgery; it may have moved since session start.
 - Prefer `rm` or an edit over `git rm` for files being replaced, so deletions
   stay unstaged until I commit them.
+- **Work in your own worktree; fork one. Never work in another session's.**
+  A hand-off carries a branch, an issue and a PR, never a directory — the
+  owning session may still be running and may be archived out from under you
+  mid-turn. Read another branch from where you stand (`git log/show <branch>`,
+  `git show <branch>:<path>`); to work it, fork your own worktree and check it
+  out there. If git says the branch is checked out elsewhere, that is a live
+  claim: report it and stop. Enforced by
+  `~/.claude/hooks/no-foreign-worktree.sh`.
 - **Work on main by default. Branch-vs-main is a rule, not a judgment
   call — don't ask.** Commit straight to main in small, verified commits,
   pushed early and often, unless one of these triggers:

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -127,6 +127,11 @@
             "type": "command",
             "command": "h=\"$HOME/.claude/hooks/no-rm-tree.sh\"; { [ -f \"$h\" ] && sh \"$h\"; } || printf '%s\\n' '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"no-rm-tree.sh is missing from $HOME/.claude/hooks or crashed, so recursive rm could not be checked. This is a gate and fails closed: run dotsync (or cloud-session-setup.sh) and retry.\"}}'",
             "statusMessage": "Checking for rm -r on a working directory"
+          },
+          {
+            "type": "command",
+            "command": "h=\"$HOME/.claude/hooks/no-foreign-worktree.sh\"; { [ -f \"$h\" ] && sh \"$h\"; } || printf '%s\\n' '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"no-foreign-worktree.sh is missing from $HOME/.claude/hooks or crashed, so a reach into a worktree owned by another session could not be checked. This is a gate and fails closed: run dotsync (or cloud-session-setup.sh) and retry.\"}}'",
+            "statusMessage": "Checking for a reach into another worktree"
           }
         ]
       },
@@ -137,6 +142,16 @@
             "type": "command",
             "command": "h=\"$HOME/.claude/hooks/no-unsigned-push.sh\"; { [ -f \"$h\" ] && sh \"$h\"; } || printf '%s\\n' '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"no-unsigned-push.sh is missing from $HOME/.claude/hooks or crashed, so unsigned commits could not be checked. This is a gate and fails closed: run dotsync (or cloud-session-setup.sh) and retry.\"}}'",
             "statusMessage": "Checking for unsigned commits"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit|NotebookEdit|EnterWorktree",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "h=\"$HOME/.claude/hooks/no-foreign-worktree.sh\"; { [ -f \"$h\" ] && sh \"$h\"; } || printf '%s\\n' '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"no-foreign-worktree.sh is missing from $HOME/.claude/hooks or crashed, so a write into a worktree owned by another session could not be checked. This is a gate and fails closed: run dotsync (or cloud-session-setup.sh) and retry.\"}}'",
+            "statusMessage": "Checking the edit stays in this worktree"
           }
         ]
       },

--- a/.claude/skills/pickup/SKILL.md
+++ b/.claude/skills/pickup/SKILL.md
@@ -42,7 +42,32 @@ Then read the link — the PR, issue or card — for live state. The block
 names where the work is; it does not carry its state, which is stale the
 moment it is written.
 
-## 3. Mark it consumed
+## 3. Take your own worktree
+
+The block hands over a branch, an issue and a PR. It does **not** hand over a
+directory, and the previous session's worktree is not yours to work in even
+when it is sitting right there with the branch already checked out —
+`no-foreign-worktree.sh` refuses it, and the reason it refuses is that the
+owning session may still be running and may be archived out from under you
+mid-turn (PR #162).
+
+So fork one: `EnterWorktree(name=<short-name>)`, then inside it
+
+```
+git fetch origin
+git checkout <the branch the block names>
+```
+
+If git refuses because the branch is checked out in another worktree, that is
+a live claim by a session that has not released it. Say so — name the branch
+and the worktree git named — and stop. Don't take it away from them, and
+don't work anywhere else on the same branch.
+
+Everything the previous session wanted handed over is on the remote. If it
+isn't pushed, it isn't handed over: work from the pushed state and say in one
+line what you found missing.
+
+## 4. Mark it consumed
 
 Do this **as you start**, not at the end: a session that dies mid-work
 should not hand the same block to the next one as if nothing happened, and a
@@ -59,7 +84,7 @@ branch's checkpoint, append one line inside the `## Resume` block:
 consumed line included, into every later rewrite of that checkpoint, so it
 stays as a record of who took it.
 
-## 4. Then work
+## 5. Then work
 
 Nothing else belongs to this skill. Blocks are dropped on their own when the
 branch goes level with the default branch or its PR merges, so there is no
@@ -80,6 +105,12 @@ house hand-off spec, under a `## Resume` heading:
 - model: <opus | sonnet | haiku>
 - effort: <low | medium | high>
 ```
+
+Push before you write it — the block points at a branch, and a branch that
+only exists in your worktree hands over nothing. A session that is *finished*
+(pushed, PR open) also releases its worktree, so the branch is free for
+whoever picks it up; one that is pausing mid-work keeps it, and the branch
+stays claimed until it comes back.
 
 One block per checkpoint; the newest replaces. `next` is a step, not a
 status — "add the fixture for a consumed block", never "resume-list is

--- a/.local/bin/cloud-session-setup.sh
+++ b/.local/bin/cloud-session-setup.sh
@@ -58,7 +58,7 @@ INSTALL="
 .claude/skills/wrapup/SKILL.md
 .claude/skills/worklist/SKILL.md
 .claude/skills/sweep/SKILL.md
-.claude/skills/resume/SKILL.md
+.claude/skills/pickup/SKILL.md
 .claude/hooks/lib-state.sh
 .claude/hooks/session-metrics.jq
 .claude/hooks/lib-metrics-fmt.jq
@@ -75,6 +75,7 @@ INSTALL="
 .claude/hooks/no-git-footguns.sh
 .claude/hooks/no-checkout-home.sh
 .claude/hooks/no-rm-tree.sh
+.claude/hooks/no-foreign-worktree.sh
 .claude/hooks/lib-shell-words.awk
 .claude/hooks/session-start-seed-refresh.sh
 .claude/hooks/guard-add-repo.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,11 @@ happen to be tracked here, but they are not *about* this repo. This file is.
   alternate only when a whole file genuinely differs per OS, and then use
   `##default`, never `##os.Linux` — yadm reports `WSL` under WSL2.
 - Branch work: `yadm worktree add -b <branch> ~/.claude/worktrees/<name> main`. Never `yadm checkout <branch>` in `$HOME` (enforced by `no-checkout-home.sh`). Also never `git checkout <branch>` in `~/dotfiles` — not enforced by any hook, just don't.
+- **A worktree belongs to one session.** Never work in another session's,
+  whatever route offers itself — `EnterWorktree(path=...)`, `git -C`, an edit
+  by absolute path (enforced by `no-foreign-worktree.sh`). A session that is
+  *finished* pushes, opens the PR and then releases its worktree, so the
+  branch it held is free for whoever picks the work up.
 
 ## Shell scripts here
 


### PR DESCRIPTION
Closes the board card about pickup reusing another session's worktree, and
the general case behind it.

## Why a gate, not skill prose

The session that lost its worktree on #162 wasn't following the pickup skill
— it was handed nothing but "continue `<issue>` see `<PR>`". It found the
branch already checked out in a sibling worktree and used it directly with
`git -C <that path>`. When the session that actually owned that directory
was archived — correctly, by its own git state — the directory went away
underneath the second session mid-turn. It survived only because the commit
happened to already be pushed.

Prose in one skill can't close this: the mistake is available from any
command, in any session, whether or not it ever reads a skill. So the fix is
`no-foreign-worktree.sh`, a `PreToolUse` gate wired to `Bash` and to
`Edit|Write|MultiEdit|NotebookEdit|EnterWorktree`, plus the hand-off doctrine
in `rules/code.md`, `CLAUDE.md` and pickup's new step 3 for the cases where
prose is still the right layer (what to do instead).

## How foreignness is decided

Every candidate path is asked of git, nothing is inferred from the string:

- `git -C <path> rev-parse --show-toplevel` gives the repo root the path
  resolves to.
- If that root is this session's own toplevel, it's allowed.
- Otherwise it's foreign only if it's a **linked** worktree — its `.git` is
  a file, not a directory. A main checkout (`~/dotfiles`, `$HOME` under
  yadm, any other clone) keeps a `.git` directory and stays allowed; those
  are shared by every session on the machine, not one session's private
  space.

That second test is why there's no path-prefix shortcut: sibling worktrees
of this repo live *inside* the repo root by path
(`<repo>/.claude/worktrees/<name>`), so "is it under my toplevel" would
wrongly allow exactly the case this gate exists to stop. `EnterWorktree(path=...)`
is refused outright, separately from the path-scanning logic — that tool
attaches to any existing worktree with no ownership check at all (confirmed
in its own documentation), and every legitimate use is reachable via
`EnterWorktree(name=...)` plus a `git checkout` once inside.

## The deliberate gap

The shared word-scanner (`lib-shell-words.awk`) drops shell redirections —
`cmd > /other/worktree/file` is not seen, because the scanner sees words,
not redirection targets. Every ordinary route into a foreign worktree (`cd`,
`git -C`, `--work-tree`, `GIT_WORK_TREE`, `sed -i`, `cp`, an `Edit`/`Write`
by `file_path`) is a word and is caught; closing the redirection spelling
too means reimplementing redirection tracking for one exotic case. Left as a
documented gap rather than a silent one.

## cloud-session-setup.sh fix

`INSTALL` still named the pre-rename `.claude/skills/resume/SKILL.md`, so
`pickup` — the skill that replaced it — has never actually been seeded into
a cloud session. Fixed to `.claude/skills/pickup/SKILL.md`, and
`no-foreign-worktree.sh` added to the list alongside it so the new gate
isn't cloud-session-shaped vaporware on day one.

## Tests

41 cases in `no-foreign-worktree.test.sh` (40 plus one added in review — a
missing `git` on `PATH` with jq/awk/sed present must still deny), covering:
own worktree/main checkout/other clones allowed; sibling linked worktrees
denied via `cd`, `git -C`, `--work-tree=`, `GIT_WORK_TREE=`, `sed -i`,
`Edit`/`Write` by `file_path`; `EnterWorktree(path=...)` denied
unconditionally, `EnterWorktree(name=...)` untouched; missing-tool and
missing-payload fail closed.

## CI

`hook-tests` is red on an unrelated pre-existing flake:
`metrics-live.test.sh` fails when the wall clock is at or past hour 23 UTC
(mark-brannan/dotfiles#163, filed before this branch). This branch touches
neither `metrics-live.sh` nor its test; `no-foreign-worktree.test.sh` itself
passes 41/41 under every awk variant in the same CI run. Not mine to fix
here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

