### PR TITLE
Document the $HOME-seeding dependency for #131's actual fix

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,6 +6,14 @@ name: Claude PR Review
 # workflow, the gate and the argument for both; this file is only the trigger
 # and this repository's brief for it.
 #
+# The reusable workflow's own "Seed $HOME" step (seed-home input, default
+# true) clones this repo again on the runner and runs cloud-session-setup.sh,
+# so the review agent's Bash calls are gated by our fail-closed hooks instead
+# of blanket-denied by none existing. If that step ever goes missing or its
+# marker check (public-issue-guard.sh under $HOME/.claude/hooks) starts
+# failing, the review's own PR comment says so under "HOME SEEDING" -- see
+# mark-brannan/dotfiles#131 and mark-brannan/.github#22.
+#
 # Auth: the CLAUDE_CODE_OAUTH_TOKEN secret (mint one with `claude setup-token`,
 # then `gh secret set CLAUDE_CODE_OAUTH_TOKEN`). Until it exists the review
 # skips with a warning rather than failing every pull request.


### PR DESCRIPTION
Closes #131.

## Why this PR has almost no diff

#131's actual fix lives entirely in the reusable workflow this repo calls,
not here: **mark-brannan/.github#22**. The `review / review` job's `$HOME`
seeding is the reusable `claude-review.yml` workflow's job — this repo's
`claude-code-review.yml` only supplies the trigger and the review brief
(see its own header comment) — so there is no code in this repo that needed
to change to fix the bug.

What this PR *does* add: a comment in `claude-code-review.yml` explaining
that dependency and cross-referencing both issues, so the next person
reading this repo's trigger file understands why the review agent's `Bash`
calls work at all, and where to look if they stop.

## Cross-reference

- Issue: #131
- Fix: mark-brannan/.github#22 (adds a `seed-home` input, a step that clones
  this repo and runs `cloud-session-setup.sh`, a marker-file verification
  against `public-issue-guard.sh`, and a `HOME SEEDING` line threaded into
  the review prompt so a degraded run says so in its own PR comment)

## In-flight, no conflict

#144 and #148 are open on this repo with merge priority. Neither touches
`.github/workflows/claude-code-review.yml`, so there's no ordering
constraint against this PR.

## Also found, filed separately (out of scope here)

`cloud-session-setup.sh`'s `INSTALL` list still references
`.claude/skills/resume/SKILL.md`, renamed to `pickup/` in #156 — predates
this work, unrelated to #131. Filed as its own issue rather than folded in
here: #169.

## Verification

No code changed here beyond a comment, so nothing to run. The actual fix
(mark-brannan/.github#22) is CI-verify-only, as a reusable `workflow_call`
workflow can't be executed standalone — see that PR's body for what was
checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
