### PR TITLE
grind: single-flight lock per repo

### DIFF
--- a/.local/bin/grind
+++ b/.local/bin/grind
@@ -201,7 +201,7 @@ write_lock() {
       exit_reason: (if $reason == "" then null else $reason end)}' > "$lock_meta" 2>/dev/null || true
   if [ -f "$state_file" ] && [ -f "$lock_meta" ]; then
     jq --slurpfile lk "$lock_meta" '.lock = $lk[0]' "$state_file" > "$state_file.tmp" \
-      && mv "$state_file.tmp" "$state_file"
+      && mv "$state_file.tmp" "$state_file" || true
   fi
 }
 
@@ -216,7 +216,16 @@ if [ "$dry_run" -eq 0 ]; then
     fi
     if [ "$stale" -eq 1 ]; then
       warn "reclaiming stale lock on $repo at $lock_dir (pid $other_pid on $other_host is not running)"
-      rm -rf "$lock_dir"
+      # Quarantine the observed-stale dir by renaming it first: rename is
+      # atomic, so if a second reclaimer is racing us, only one of us wins
+      # the rename and the other falls through to the "still held" branch
+      # below instead of deleting a lock a third process just created.
+      stale_dir="$lock_dir.stale.$$"
+      if ! mv "$lock_dir" "$stale_dir" 2>/dev/null; then
+        err "lock at $lock_dir changed while reclaiming it -- another grind won the race"
+        exit 1
+      fi
+      rm -rf "$stale_dir"
       mkdir "$lock_dir" || { err "could not reclaim lock $lock_dir"; exit 1; }
     else
       printf 'grind: another grind is already running against %s\n' "$repo" >&2
@@ -225,9 +234,9 @@ if [ "$dry_run" -eq 0 ]; then
       exit 1
     fi
   fi
-  write_lock
-  # Fires on every exit path -- normal completion, a pause's `exit 0`, an
-  # error under set -e, or a signal -- so the lock never outlives this process.
+  # Trap registered before write_lock, not after: a signal landing between
+  # mkdir succeeding and the trap being installed would otherwise leave the
+  # lock directory behind with nothing left to clean it up.
   trap 'rc=$?
     case $rc in
       0) reason=clean ;;
@@ -235,8 +244,10 @@ if [ "$dry_run" -eq 0 ]; then
       143) reason=terminated ;;
       *) reason="exited(rc=$rc)" ;;
     esac
-    write_lock "" "" "$reason"
-    rm -rf "$lock_dir"' EXIT
+    write_lock "" "" "$reason" || true
+    rm -rf "$lock_dir"
+    exit "$rc"' EXIT
+  write_lock
 fi
 
 # refs (owner/repo#N) already accounted for from a prior run of this session,

--- a/.local/bin/grind
+++ b/.local/bin/grind
@@ -37,11 +37,10 @@
 # State (resume bookkeeping only, never committed): a JSON file per grind
 # session under $XDG_STATE_HOME/grind holding the options and which item
 # refs are already done or carded. `--resume <session>` re-reads it, skips
-# what is already accounted for, and keeps appending to the same file. The
-# same file's "lock" key mirrors the mkdir-based single-flight lock at
-# $XDG_STATE_HOME/grind/locks/<repo>.lock (pid, host, current item, last
-# heartbeat) so the session file alone answers "is this still running, and
-# on what" -- one grind per repo at a time; a second invocation fails fast
+# what is already accounted for, and keeps appending to the same file.
+#
+# One grind per repo at a time: an mkdir-based lock at
+# $XDG_STATE_HOME/grind/locks/<repo>.lock. A second invocation fails fast
 # unless the recorded pid is confirmed dead on this host, in which case the
 # lock is reclaimed as stale.
 #
@@ -115,14 +114,9 @@ command -v gh >/dev/null 2>&1 || { echo "grind: needs gh" >&2; exit 1; }
 state_root=${XDG_STATE_HOME:-$HOME/.local/state}/grind
 mkdir -p "$state_root" 2>/dev/null || true
 
-# Diagnostic identity, captured once regardless of dry-run: cheap, and it's
-# exactly what a human staring at a stuck lock or a stale state file needs.
+# This host's name, for the lock's stale-pid check below: a pid number only
+# means something on the host that assigned it.
 hostname_now=$(uname -n 2>/dev/null || echo unknown)
-whoami_now=$(id -un 2>/dev/null || whoami 2>/dev/null || echo unknown)
-tty_now=$(tty 2>/dev/null || echo none)
-grind_rev=$(git -C "$(dirname "$0")" rev-parse --short HEAD 2>/dev/null || echo unknown)
-invoked_cwd=$(pwd)
-claude_session=${CLAUDE_SESSION_ID:-${CLAUDE_CODE_SESSION_ID:-none}}
 
 # --- repo scope --------------------------------------------------------------
 cwd_repo() {
@@ -174,35 +168,21 @@ fi
 # --- single-flight lock, one grind per repo -----------------------------------
 # Two grinds against the same repo would fight over the same worktree paths
 # and branch names (grind-<n>): the second's `git branch -D` can delete a
-# worktree the first still has checked out. mkdir is the mutex (atomic,
-# no flock dependency); the lock directory's meta.json -- pid, host, current
-# item, last heartbeat -- is also folded into the state file's "lock" key so
-# a session file is self-diagnostic without needing to find the lock too.
+# worktree the first still has checked out. mkdir is the mutex (atomic, no
+# flock dependency); the lock directory's meta.json records just enough --
+# pid, host, when acquired -- to tell a live lock from a stale one.
 lock_root="$state_root/locks"
 mkdir -p "$lock_root" 2>/dev/null || true
 lock_dir="$lock_root/$(printf '%s' "$repo" | tr '/' '_').lock"
 lock_meta="$lock_dir/meta.json"
 
 write_lock() {
-  # $1 = current item ref (or empty), $2 = its start unix ts (or empty),
-  # $3 = exit_reason (or empty, set only by the release trap)
-  item=${1:-}; item_started=${2:-}; reason=${3:-}
-  now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-  jq -n --argjson pid "$$" --argjson ppid "${PPID:-0}" \
-        --arg host "$hostname_now" --arg user "$whoami_now" --arg tty "$tty_now" \
-        --arg cwd "$invoked_cwd" --arg rev "$grind_rev" --arg claude_session "$claude_session" \
-        --arg lock_path "$lock_dir" --arg acquired "$lock_acquired_at" --arg hb "$now" \
-        --arg item "$item" --arg item_started "$item_started" --arg reason "$reason" \
-    '{pid:$pid, ppid:$ppid, hostname:$host, user:$user, tty:$tty, invoked_cwd:$cwd,
-      grind_rev:$rev, claude_session_id:$claude_session, lock_path:$lock_path,
-      lock_acquired_at:$acquired, last_heartbeat_at:$hb,
-      current_item: (if $item == "" then null else $item end),
-      current_item_started_at: (if $item_started == "" then null else ($item_started|tonumber) end),
+  # $1 = exit_reason (or empty, set only by the release trap)
+  reason=${1:-}
+  jq -n --argjson pid "$$" --arg host "$hostname_now" --arg acquired "$lock_acquired_at" \
+        --arg reason "$reason" \
+    '{pid:$pid, hostname:$host, lock_acquired_at:$acquired,
       exit_reason: (if $reason == "" then null else $reason end)}' > "$lock_meta" 2>/dev/null || true
-  if [ -f "$state_file" ] && [ -f "$lock_meta" ]; then
-    jq --slurpfile lk "$lock_meta" '.lock = $lk[0]' "$state_file" > "$state_file.tmp" \
-      && mv "$state_file.tmp" "$state_file" || true
-  fi
 }
 
 if [ "$dry_run" -eq 0 ]; then
@@ -244,7 +224,7 @@ if [ "$dry_run" -eq 0 ]; then
       143) reason=terminated ;;
       *) reason="exited(rc=$rc)" ;;
     esac
-    write_lock "" "" "$reason" || true
+    write_lock "$reason" || true
     rm -rf "$lock_dir"
     exit "$rc"' EXIT
   write_lock
@@ -409,7 +389,6 @@ while [ "$i" -lt "$count" ]; do
 
   prompt=$(build_prompt "$(printf '%s' "$item" | jq -r '.body')")
   started=$(date +%s)
-  write_lock "$ref" "$started"
   info "worker running: claude -p --model $model --effort $effort --max-budget-usd $item_budget --permission-mode $permission_mode (heartbeat every ${heartbeat}s)"
 
   # live_file holds "input output cache_read cache_creation" running totals,
@@ -429,7 +408,6 @@ while [ "$i" -lt "$count" ]; do
     ( trap 'kill "$sp" 2>/dev/null; exit 0' TERM
       while :; do
         sleep "$heartbeat" & sp=$!; wait "$sp" || exit 0
-        write_lock "$ref" "$started"
         elapsed_m=$(( ($(date +%s) - started) / 60 ))
         live=$(cat "$live_file" 2>/dev/null || printf '0 0 0 0')
         set -- $live
@@ -481,7 +459,6 @@ while [ "$i" -lt "$count" ]; do
 
   if [ -n "$hb_pid" ]; then kill "$hb_pid" 2>/dev/null; wait "$hb_pid" 2>/dev/null || true; fi
   info "worker exited $claude_rc after $(( $(date +%s) - started ))s"
-  write_lock
 
   git worktree remove -f "$wt_path" >/dev/null 2>&1 || true
 

--- a/.local/bin/grind
+++ b/.local/bin/grind
@@ -37,7 +37,13 @@
 # State (resume bookkeeping only, never committed): a JSON file per grind
 # session under $XDG_STATE_HOME/grind holding the options and which item
 # refs are already done or carded. `--resume <session>` re-reads it, skips
-# what is already accounted for, and keeps appending to the same file.
+# what is already accounted for, and keeps appending to the same file. The
+# same file's "lock" key mirrors the mkdir-based single-flight lock at
+# $XDG_STATE_HOME/grind/locks/<repo>.lock (pid, host, current item, last
+# heartbeat) so the session file alone answers "is this still running, and
+# on what" -- one grind per repo at a time; a second invocation fails fast
+# unless the recorded pid is confirmed dead on this host, in which case the
+# lock is reclaimed as stale.
 #
 #   grind [--dry-run] [--repo owner/name] [--model <m>] [--effort <e>]
 #         [--item-budget <usd>] [--session-budget <usd>] [--pause-every <n>]
@@ -109,6 +115,15 @@ command -v gh >/dev/null 2>&1 || { echo "grind: needs gh" >&2; exit 1; }
 state_root=${XDG_STATE_HOME:-$HOME/.local/state}/grind
 mkdir -p "$state_root" 2>/dev/null || true
 
+# Diagnostic identity, captured once regardless of dry-run: cheap, and it's
+# exactly what a human staring at a stuck lock or a stale state file needs.
+hostname_now=$(uname -n 2>/dev/null || echo unknown)
+whoami_now=$(id -un 2>/dev/null || whoami 2>/dev/null || echo unknown)
+tty_now=$(tty 2>/dev/null || echo none)
+grind_rev=$(git -C "$(dirname "$0")" rev-parse --short HEAD 2>/dev/null || echo unknown)
+invoked_cwd=$(pwd)
+claude_session=${CLAUDE_SESSION_ID:-${CLAUDE_CODE_SESSION_ID:-none}}
+
 # --- repo scope --------------------------------------------------------------
 cwd_repo() {
   u=$(git remote get-url origin 2>/dev/null) || return 1
@@ -154,6 +169,74 @@ if [ "$dry_run" -eq 0 ]; then
   [ "$here" = "$repo" ] \
     || { printf 'grind: current directory is not a checkout of %s (found: %s); cd there first\n' \
            "$repo" "${here:-no GitHub remote}" >&2; exit 1; }
+fi
+
+# --- single-flight lock, one grind per repo -----------------------------------
+# Two grinds against the same repo would fight over the same worktree paths
+# and branch names (grind-<n>): the second's `git branch -D` can delete a
+# worktree the first still has checked out. mkdir is the mutex (atomic,
+# no flock dependency); the lock directory's meta.json -- pid, host, current
+# item, last heartbeat -- is also folded into the state file's "lock" key so
+# a session file is self-diagnostic without needing to find the lock too.
+lock_root="$state_root/locks"
+mkdir -p "$lock_root" 2>/dev/null || true
+lock_dir="$lock_root/$(printf '%s' "$repo" | tr '/' '_').lock"
+lock_meta="$lock_dir/meta.json"
+
+write_lock() {
+  # $1 = current item ref (or empty), $2 = its start unix ts (or empty),
+  # $3 = exit_reason (or empty, set only by the release trap)
+  item=${1:-}; item_started=${2:-}; reason=${3:-}
+  now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  jq -n --argjson pid "$$" --argjson ppid "${PPID:-0}" \
+        --arg host "$hostname_now" --arg user "$whoami_now" --arg tty "$tty_now" \
+        --arg cwd "$invoked_cwd" --arg rev "$grind_rev" --arg claude_session "$claude_session" \
+        --arg lock_path "$lock_dir" --arg acquired "$lock_acquired_at" --arg hb "$now" \
+        --arg item "$item" --arg item_started "$item_started" --arg reason "$reason" \
+    '{pid:$pid, ppid:$ppid, hostname:$host, user:$user, tty:$tty, invoked_cwd:$cwd,
+      grind_rev:$rev, claude_session_id:$claude_session, lock_path:$lock_path,
+      lock_acquired_at:$acquired, last_heartbeat_at:$hb,
+      current_item: (if $item == "" then null else $item end),
+      current_item_started_at: (if $item_started == "" then null else ($item_started|tonumber) end),
+      exit_reason: (if $reason == "" then null else $reason end)}' > "$lock_meta" 2>/dev/null || true
+  if [ -f "$state_file" ] && [ -f "$lock_meta" ]; then
+    jq --slurpfile lk "$lock_meta" '.lock = $lk[0]' "$state_file" > "$state_file.tmp" \
+      && mv "$state_file.tmp" "$state_file"
+  fi
+}
+
+if [ "$dry_run" -eq 0 ]; then
+  lock_acquired_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  if ! mkdir "$lock_dir" 2>/dev/null; then
+    other_pid=$(jq -r '.pid // empty' "$lock_meta" 2>/dev/null || true)
+    other_host=$(jq -r '.hostname // empty' "$lock_meta" 2>/dev/null || true)
+    stale=0
+    if [ -n "$other_pid" ] && [ "$other_host" = "$hostname_now" ] && ! kill -0 "$other_pid" 2>/dev/null; then
+      stale=1
+    fi
+    if [ "$stale" -eq 1 ]; then
+      warn "reclaiming stale lock on $repo at $lock_dir (pid $other_pid on $other_host is not running)"
+      rm -rf "$lock_dir"
+      mkdir "$lock_dir" || { err "could not reclaim lock $lock_dir"; exit 1; }
+    else
+      printf 'grind: another grind is already running against %s\n' "$repo" >&2
+      [ -f "$lock_meta" ] && cat "$lock_meta" >&2
+      printf 'grind: if that is stale (crashed, or from a host that is no longer running), remove %s and retry\n' "$lock_dir" >&2
+      exit 1
+    fi
+  fi
+  write_lock
+  # Fires on every exit path -- normal completion, a pause's `exit 0`, an
+  # error under set -e, or a signal -- so the lock never outlives this process.
+  trap 'rc=$?
+    case $rc in
+      0) reason=clean ;;
+      130) reason=interrupted ;;
+      143) reason=terminated ;;
+      *) reason="exited(rc=$rc)" ;;
+    esac
+    write_lock "" "" "$reason"
+    rm -rf "$lock_dir"' EXIT
 fi
 
 # refs (owner/repo#N) already accounted for from a prior run of this session,
@@ -315,6 +398,7 @@ while [ "$i" -lt "$count" ]; do
 
   prompt=$(build_prompt "$(printf '%s' "$item" | jq -r '.body')")
   started=$(date +%s)
+  write_lock "$ref" "$started"
   info "worker running: claude -p --model $model --effort $effort --max-budget-usd $item_budget --permission-mode $permission_mode (heartbeat every ${heartbeat}s)"
 
   # live_file holds "input output cache_read cache_creation" running totals,
@@ -334,6 +418,7 @@ while [ "$i" -lt "$count" ]; do
     ( trap 'kill "$sp" 2>/dev/null; exit 0' TERM
       while :; do
         sleep "$heartbeat" & sp=$!; wait "$sp" || exit 0
+        write_lock "$ref" "$started"
         elapsed_m=$(( ($(date +%s) - started) / 60 ))
         live=$(cat "$live_file" 2>/dev/null || printf '0 0 0 0')
         set -- $live
@@ -385,6 +470,7 @@ while [ "$i" -lt "$count" ]; do
 
   if [ -n "$hb_pid" ]; then kill "$hb_pid" 2>/dev/null; wait "$hb_pid" 2>/dev/null || true; fi
   info "worker exited $claude_rc after $(( $(date +%s) - started ))s"
+  write_lock
 
   git worktree remove -f "$wt_path" >/dev/null 2>&1 || true
 

--- a/.local/bin/grind.test.sh
+++ b/.local/bin/grind.test.sh
@@ -425,5 +425,57 @@ eq 'exit 1 outside a repo without --repo' 1 "$RC"
 has 'says so' 'not in a GitHub repo'
 cd "$S/repo" || exit 1
 
+# --- single-flight lock: pid/host diagnostics land in the state file, and a
+#     clean exit releases the lock directory ---------------------------------
+cat > "$S/ready.json" <<'JSON'
+[
+  {"number": 1, "title": "A", "body": "b", "url": "https://github.com/o/alpha/issues/1", "labels": [{"name": "ready"}]}
+]
+JSON
+rm -f "$S/state/grind"/*.json
+rm -rf "$S/state/grind/locks"
+rm -f "$S/claude-replies"/*.json
+reply 0.10 "done" 1
+: > "$CLAUDE_LOG"
+run --session-budget 100 --pause-every 10
+sess=$(latest_session)
+assert 'lock records a positive pid (the grind process, not the test harness)' \
+  bash -c '[ "$(jq -r ".lock.pid" "'"$sess"'")" -gt 0 ]'
+eq 'lock records hostname' "$(uname -n)" "$(jq -r '.lock.hostname' "$sess")"
+eq 'lock cleared exit_reason on clean exit' clean "$(jq -r '.lock.exit_reason' "$sess")"
+eq 'lock current_item cleared after the item finished' null "$(jq -r '.lock.current_item' "$sess")"
+assert 'lock directory released on clean exit' bash -c '! ls -d '"$S"'/state/grind/locks/*.lock >/dev/null 2>&1'
+
+# --- a live lock (pid still running) refuses a second grind ----------------------
+lock_dir="$S/state/grind/locks/o_alpha.lock"
+mkdir -p "$lock_dir"
+jq -n --argjson pid "$$" --arg host "$(uname -n)" \
+  '{pid:$pid, ppid:0, hostname:$host, user:"t", tty:"none", invoked_cwd:"/", grind_rev:"x",
+    claude_session_id:"none", lock_path:"x", lock_acquired_at:"x", last_heartbeat_at:"x",
+    current_item:null, current_item_started_at:null, exit_reason:null}' > "$lock_dir/meta.json"
+rm -f "$S/state/grind"/*.json
+: > "$CLAUDE_LOG"
+run --session-budget 100 --pause-every 10
+eq 'exit 1 when another grind holds the lock' 1 "$RC"
+has 'says another grind is running' 'another grind is already running against o/alpha'
+eq 'no claude invocation while locked out' 0 "$(calls_claude)"
+rm -rf "$lock_dir"
+
+# --- a stale lock (recorded pid is dead) is reclaimed, run proceeds --------------
+mkdir -p "$lock_dir"
+jq -n --arg host "$(uname -n)" \
+  '{pid:999999999, ppid:0, hostname:$host, user:"t", tty:"none", invoked_cwd:"/", grind_rev:"x",
+    claude_session_id:"none", lock_path:"x", lock_acquired_at:"x", last_heartbeat_at:"x",
+    current_item:null, current_item_started_at:null, exit_reason:null}' > "$lock_dir/meta.json"
+rm -f "$S/state/grind"/*.json
+rm -f "$S/claude-replies"/*.json
+reply 0.10 "done" 1
+: > "$CLAUDE_LOG"
+run --session-budget 100 --pause-every 10
+eq 'exit 0, the stale lock did not block the run' 0 "$RC"
+has 'WARN about reclaiming the stale lock' 'WARN  reclaiming stale lock on o/alpha'
+eq 'the item still ran' 1 "$(calls_claude)"
+assert 'lock directory released again after this clean exit' bash -c '! ls -d '"$S"'/state/grind/locks/*.lock >/dev/null 2>&1'
+
 printf '%d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/.local/bin/grind.test.sh
+++ b/.local/bin/grind.test.sh
@@ -425,7 +425,7 @@ eq 'exit 1 outside a repo without --repo' 1 "$RC"
 has 'says so' 'not in a GitHub repo'
 cd "$S/repo" || exit 1
 
-# --- single-flight lock: pid/host diagnostics land in the state file, and a
+# --- single-flight lock: pid/host land in the lock's own meta.json, and a
 #     clean exit releases the lock directory ---------------------------------
 cat > "$S/ready.json" <<'JSON'
 [
@@ -437,22 +437,47 @@ rm -rf "$S/state/grind/locks"
 rm -f "$S/claude-replies"/*.json
 reply 0.10 "done" 1
 : > "$CLAUDE_LOG"
+lock_dir="$S/state/grind/locks/o_alpha.lock"
+# The lock directory is removed on exit, so its meta.json has to be caught
+# mid-run: have the fake claude snapshot it before replying.
+cat > "$S/bin/claude" <<GH
+#!/bin/sh
+cat > /dev/null
+cp "$lock_dir/meta.json" "$S/lock-meta-seen.json" 2>/dev/null || true
+n=\$(cat "$S/claude-next" 2>/dev/null || echo 1)
+echo "\$n \$*" >> "$CLAUDE_LOG"
+echo \$((n + 1)) > "$S/claude-next"
+reply="$S/claude-replies/\$n.json"
+if [ -f "\$reply" ]; then cat "\$reply"; else
+  echo '{"type":"assistant","message":{"usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}'
+  echo '{"type":"result","total_cost_usd":0.10,"usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":0,"cache_creation_input_tokens":0},"result":"GRIND_STATUS: done"}'
+fi
+GH
+chmod +x "$S/bin/claude"
 run --session-budget 100 --pause-every 10
-sess=$(latest_session)
 assert 'lock records a positive pid (the grind process, not the test harness)' \
-  bash -c '[ "$(jq -r ".lock.pid" "'"$sess"'")" -gt 0 ]'
-eq 'lock records hostname' "$(uname -n)" "$(jq -r '.lock.hostname' "$sess")"
-eq 'lock cleared exit_reason on clean exit' clean "$(jq -r '.lock.exit_reason' "$sess")"
-eq 'lock current_item cleared after the item finished' null "$(jq -r '.lock.current_item' "$sess")"
+  bash -c '[ "$(jq -r ".pid" "'"$S"'/lock-meta-seen.json")" -gt 0 ]'
+eq 'lock records hostname' "$(uname -n)" "$(jq -r '.hostname' "$S/lock-meta-seen.json")"
 assert 'lock directory released on clean exit' bash -c '! ls -d '"$S"'/state/grind/locks/*.lock >/dev/null 2>&1'
+# restore the plain shim for the rest of the suite
+cat > "$S/bin/claude" <<GH
+#!/bin/sh
+cat > /dev/null
+n=\$(cat "$S/claude-next" 2>/dev/null || echo 1)
+echo "\$n \$*" >> "$CLAUDE_LOG"
+echo \$((n + 1)) > "$S/claude-next"
+reply="$S/claude-replies/\$n.json"
+if [ -f "\$reply" ]; then cat "\$reply"; else
+  echo '{"type":"assistant","message":{"usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}'
+  echo '{"type":"result","total_cost_usd":0.10,"usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":0,"cache_creation_input_tokens":0},"result":"GRIND_STATUS: done"}'
+fi
+GH
+chmod +x "$S/bin/claude"
 
 # --- a live lock (pid still running) refuses a second grind ----------------------
-lock_dir="$S/state/grind/locks/o_alpha.lock"
 mkdir -p "$lock_dir"
 jq -n --argjson pid "$$" --arg host "$(uname -n)" \
-  '{pid:$pid, ppid:0, hostname:$host, user:"t", tty:"none", invoked_cwd:"/", grind_rev:"x",
-    claude_session_id:"none", lock_path:"x", lock_acquired_at:"x", last_heartbeat_at:"x",
-    current_item:null, current_item_started_at:null, exit_reason:null}' > "$lock_dir/meta.json"
+  '{pid:$pid, hostname:$host, lock_acquired_at:"x", exit_reason:null}' > "$lock_dir/meta.json"
 rm -f "$S/state/grind"/*.json
 : > "$CLAUDE_LOG"
 run --session-budget 100 --pause-every 10
@@ -464,9 +489,7 @@ rm -rf "$lock_dir"
 # --- a stale lock (recorded pid is dead) is reclaimed, run proceeds --------------
 mkdir -p "$lock_dir"
 jq -n --arg host "$(uname -n)" \
-  '{pid:999999999, ppid:0, hostname:$host, user:"t", tty:"none", invoked_cwd:"/", grind_rev:"x",
-    claude_session_id:"none", lock_path:"x", lock_acquired_at:"x", last_heartbeat_at:"x",
-    current_item:null, current_item_started_at:null, exit_reason:null}' > "$lock_dir/meta.json"
+  '{pid:999999999, hostname:$host, lock_acquired_at:"x", exit_reason:null}' > "$lock_dir/meta.json"
 rm -f "$S/state/grind"/*.json
 rm -f "$S/claude-replies"/*.json
 reply 0.10 "done" 1

--- a/.local/bin/grind.test.sh
+++ b/.local/bin/grind.test.sh
@@ -476,6 +476,8 @@ eq 'exit 0, the stale lock did not block the run' 0 "$RC"
 has 'WARN about reclaiming the stale lock' 'WARN  reclaiming stale lock on o/alpha'
 eq 'the item still ran' 1 "$(calls_claude)"
 assert 'lock directory released again after this clean exit' bash -c '! ls -d '"$S"'/state/grind/locks/*.lock >/dev/null 2>&1'
+assert 'the rename-based reclaim leaves no quarantined .stale.* dir behind' \
+  bash -c '! ls -d '"$S"'/state/grind/locks/*.stale.* >/dev/null 2>&1'
 
 printf '%d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
## What

One `grind` per repo at a time: an mkdir-based lock (no `flock` dependency)
at `$XDG_STATE_HOME/grind/locks/<repo>.lock`, reclaimed only when the
recorded pid is confirmed dead on this host -- otherwise fails fast and
prints the held lock's meta (pid, host, when acquired).

Split per request into two PRs for easier review: this one is the lock
mechanism alone. A follow-up PR (based on this branch) adds the richer
per-run diagnostics (extra identity fields, current-item tracking,
mirrored into the session state file's own `lock` key).

## Why

Two grind invocations against the same repo would race over the same
worktree paths and branch names (`grind-<n>`) -- the second's
`git branch -D` can delete a worktree the first still has checked out.

## Note on the churn gate

This diff is 74 changed lines in `.local/bin/grind` against the 20-line
budget (dotfiles#149). Splitting made it smaller, not compliant -- the lock
mechanism itself (mkdir/reclaim/trap, all one cohesive concern) doesn't
divide further without becoming harder to review, not easier. Needs the
`churn-ok` label or your call on how to proceed.

## Verification

`bash .local/bin/grind.test.sh` -- 86 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
