### PR TITLE
grind: per-run diagnostics on top of the lock

### DIFF
--- a/.local/bin/grind
+++ b/.local/bin/grind
@@ -37,10 +37,11 @@
 # State (resume bookkeeping only, never committed): a JSON file per grind
 # session under $XDG_STATE_HOME/grind holding the options and which item
 # refs are already done or carded. `--resume <session>` re-reads it, skips
-# what is already accounted for, and keeps appending to the same file.
-#
-# One grind per repo at a time: an mkdir-based lock at
-# $XDG_STATE_HOME/grind/locks/<repo>.lock. A second invocation fails fast
+# what is already accounted for, and keeps appending to the same file. The
+# same file's "lock" key mirrors the mkdir-based single-flight lock at
+# $XDG_STATE_HOME/grind/locks/<repo>.lock (pid, host, current item, last
+# heartbeat) so the session file alone answers "is this still running, and
+# on what" -- one grind per repo at a time; a second invocation fails fast
 # unless the recorded pid is confirmed dead on this host, in which case the
 # lock is reclaimed as stale.
 #
@@ -114,9 +115,14 @@ command -v gh >/dev/null 2>&1 || { echo "grind: needs gh" >&2; exit 1; }
 state_root=${XDG_STATE_HOME:-$HOME/.local/state}/grind
 mkdir -p "$state_root" 2>/dev/null || true
 
-# This host's name, for the lock's stale-pid check below: a pid number only
-# means something on the host that assigned it.
+# Diagnostic identity, captured once regardless of dry-run: cheap, and it's
+# exactly what a human staring at a stuck lock or a stale state file needs.
 hostname_now=$(uname -n 2>/dev/null || echo unknown)
+whoami_now=$(id -un 2>/dev/null || whoami 2>/dev/null || echo unknown)
+tty_now=$(tty 2>/dev/null || echo none)
+grind_rev=$(git -C "$(dirname "$0")" rev-parse --short HEAD 2>/dev/null || echo unknown)
+invoked_cwd=$(pwd)
+claude_session=${CLAUDE_SESSION_ID:-${CLAUDE_CODE_SESSION_ID:-none}}
 
 # --- repo scope --------------------------------------------------------------
 cwd_repo() {
@@ -168,21 +174,35 @@ fi
 # --- single-flight lock, one grind per repo -----------------------------------
 # Two grinds against the same repo would fight over the same worktree paths
 # and branch names (grind-<n>): the second's `git branch -D` can delete a
-# worktree the first still has checked out. mkdir is the mutex (atomic, no
-# flock dependency); the lock directory's meta.json records just enough --
-# pid, host, when acquired -- to tell a live lock from a stale one.
+# worktree the first still has checked out. mkdir is the mutex (atomic,
+# no flock dependency); the lock directory's meta.json -- pid, host, current
+# item, last heartbeat -- is also folded into the state file's "lock" key so
+# a session file is self-diagnostic without needing to find the lock too.
 lock_root="$state_root/locks"
 mkdir -p "$lock_root" 2>/dev/null || true
 lock_dir="$lock_root/$(printf '%s' "$repo" | tr '/' '_').lock"
 lock_meta="$lock_dir/meta.json"
 
 write_lock() {
-  # $1 = exit_reason (or empty, set only by the release trap)
-  reason=${1:-}
-  jq -n --argjson pid "$$" --arg host "$hostname_now" --arg acquired "$lock_acquired_at" \
-        --arg reason "$reason" \
-    '{pid:$pid, hostname:$host, lock_acquired_at:$acquired,
+  # $1 = current item ref (or empty), $2 = its start unix ts (or empty),
+  # $3 = exit_reason (or empty, set only by the release trap)
+  item=${1:-}; item_started=${2:-}; reason=${3:-}
+  now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  jq -n --argjson pid "$$" --argjson ppid "${PPID:-0}" \
+        --arg host "$hostname_now" --arg user "$whoami_now" --arg tty "$tty_now" \
+        --arg cwd "$invoked_cwd" --arg rev "$grind_rev" --arg claude_session "$claude_session" \
+        --arg lock_path "$lock_dir" --arg acquired "$lock_acquired_at" --arg hb "$now" \
+        --arg item "$item" --arg item_started "$item_started" --arg reason "$reason" \
+    '{pid:$pid, ppid:$ppid, hostname:$host, user:$user, tty:$tty, invoked_cwd:$cwd,
+      grind_rev:$rev, claude_session_id:$claude_session, lock_path:$lock_path,
+      lock_acquired_at:$acquired, last_heartbeat_at:$hb,
+      current_item: (if $item == "" then null else $item end),
+      current_item_started_at: (if $item_started == "" then null else ($item_started|tonumber) end),
       exit_reason: (if $reason == "" then null else $reason end)}' > "$lock_meta" 2>/dev/null || true
+  if [ -f "$state_file" ] && [ -f "$lock_meta" ]; then
+    jq --slurpfile lk "$lock_meta" '.lock = $lk[0]' "$state_file" > "$state_file.tmp" \
+      && mv "$state_file.tmp" "$state_file" || true
+  fi
 }
 
 if [ "$dry_run" -eq 0 ]; then
@@ -224,7 +244,7 @@ if [ "$dry_run" -eq 0 ]; then
       143) reason=terminated ;;
       *) reason="exited(rc=$rc)" ;;
     esac
-    write_lock "$reason" || true
+    write_lock "" "" "$reason" || true
     rm -rf "$lock_dir"
     exit "$rc"' EXIT
   write_lock
@@ -389,6 +409,7 @@ while [ "$i" -lt "$count" ]; do
 
   prompt=$(build_prompt "$(printf '%s' "$item" | jq -r '.body')")
   started=$(date +%s)
+  write_lock "$ref" "$started"
   info "worker running: claude -p --model $model --effort $effort --max-budget-usd $item_budget --permission-mode $permission_mode (heartbeat every ${heartbeat}s)"
 
   # live_file holds "input output cache_read cache_creation" running totals,
@@ -408,6 +429,7 @@ while [ "$i" -lt "$count" ]; do
     ( trap 'kill "$sp" 2>/dev/null; exit 0' TERM
       while :; do
         sleep "$heartbeat" & sp=$!; wait "$sp" || exit 0
+        write_lock "$ref" "$started"
         elapsed_m=$(( ($(date +%s) - started) / 60 ))
         live=$(cat "$live_file" 2>/dev/null || printf '0 0 0 0')
         set -- $live
@@ -459,6 +481,7 @@ while [ "$i" -lt "$count" ]; do
 
   if [ -n "$hb_pid" ]; then kill "$hb_pid" 2>/dev/null; wait "$hb_pid" 2>/dev/null || true; fi
   info "worker exited $claude_rc after $(( $(date +%s) - started ))s"
+  write_lock
 
   git worktree remove -f "$wt_path" >/dev/null 2>&1 || true
 

--- a/.local/bin/grind.test.sh
+++ b/.local/bin/grind.test.sh
@@ -425,7 +425,7 @@ eq 'exit 1 outside a repo without --repo' 1 "$RC"
 has 'says so' 'not in a GitHub repo'
 cd "$S/repo" || exit 1
 
-# --- single-flight lock: pid/host land in the lock's own meta.json, and a
+# --- single-flight lock: pid/host diagnostics land in the state file, and a
 #     clean exit releases the lock directory ---------------------------------
 cat > "$S/ready.json" <<'JSON'
 [
@@ -437,47 +437,22 @@ rm -rf "$S/state/grind/locks"
 rm -f "$S/claude-replies"/*.json
 reply 0.10 "done" 1
 : > "$CLAUDE_LOG"
-lock_dir="$S/state/grind/locks/o_alpha.lock"
-# The lock directory is removed on exit, so its meta.json has to be caught
-# mid-run: have the fake claude snapshot it before replying.
-cat > "$S/bin/claude" <<GH
-#!/bin/sh
-cat > /dev/null
-cp "$lock_dir/meta.json" "$S/lock-meta-seen.json" 2>/dev/null || true
-n=\$(cat "$S/claude-next" 2>/dev/null || echo 1)
-echo "\$n \$*" >> "$CLAUDE_LOG"
-echo \$((n + 1)) > "$S/claude-next"
-reply="$S/claude-replies/\$n.json"
-if [ -f "\$reply" ]; then cat "\$reply"; else
-  echo '{"type":"assistant","message":{"usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}'
-  echo '{"type":"result","total_cost_usd":0.10,"usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":0,"cache_creation_input_tokens":0},"result":"GRIND_STATUS: done"}'
-fi
-GH
-chmod +x "$S/bin/claude"
 run --session-budget 100 --pause-every 10
+sess=$(latest_session)
 assert 'lock records a positive pid (the grind process, not the test harness)' \
-  bash -c '[ "$(jq -r ".pid" "'"$S"'/lock-meta-seen.json")" -gt 0 ]'
-eq 'lock records hostname' "$(uname -n)" "$(jq -r '.hostname' "$S/lock-meta-seen.json")"
+  bash -c '[ "$(jq -r ".lock.pid" "'"$sess"'")" -gt 0 ]'
+eq 'lock records hostname' "$(uname -n)" "$(jq -r '.lock.hostname' "$sess")"
+eq 'lock cleared exit_reason on clean exit' clean "$(jq -r '.lock.exit_reason' "$sess")"
+eq 'lock current_item cleared after the item finished' null "$(jq -r '.lock.current_item' "$sess")"
 assert 'lock directory released on clean exit' bash -c '! ls -d '"$S"'/state/grind/locks/*.lock >/dev/null 2>&1'
-# restore the plain shim for the rest of the suite
-cat > "$S/bin/claude" <<GH
-#!/bin/sh
-cat > /dev/null
-n=\$(cat "$S/claude-next" 2>/dev/null || echo 1)
-echo "\$n \$*" >> "$CLAUDE_LOG"
-echo \$((n + 1)) > "$S/claude-next"
-reply="$S/claude-replies/\$n.json"
-if [ -f "\$reply" ]; then cat "\$reply"; else
-  echo '{"type":"assistant","message":{"usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}'
-  echo '{"type":"result","total_cost_usd":0.10,"usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":0,"cache_creation_input_tokens":0},"result":"GRIND_STATUS: done"}'
-fi
-GH
-chmod +x "$S/bin/claude"
 
 # --- a live lock (pid still running) refuses a second grind ----------------------
+lock_dir="$S/state/grind/locks/o_alpha.lock"
 mkdir -p "$lock_dir"
 jq -n --argjson pid "$$" --arg host "$(uname -n)" \
-  '{pid:$pid, hostname:$host, lock_acquired_at:"x", exit_reason:null}' > "$lock_dir/meta.json"
+  '{pid:$pid, ppid:0, hostname:$host, user:"t", tty:"none", invoked_cwd:"/", grind_rev:"x",
+    claude_session_id:"none", lock_path:"x", lock_acquired_at:"x", last_heartbeat_at:"x",
+    current_item:null, current_item_started_at:null, exit_reason:null}' > "$lock_dir/meta.json"
 rm -f "$S/state/grind"/*.json
 : > "$CLAUDE_LOG"
 run --session-budget 100 --pause-every 10
@@ -489,7 +464,9 @@ rm -rf "$lock_dir"
 # --- a stale lock (recorded pid is dead) is reclaimed, run proceeds --------------
 mkdir -p "$lock_dir"
 jq -n --arg host "$(uname -n)" \
-  '{pid:999999999, hostname:$host, lock_acquired_at:"x", exit_reason:null}' > "$lock_dir/meta.json"
+  '{pid:999999999, ppid:0, hostname:$host, user:"t", tty:"none", invoked_cwd:"/", grind_rev:"x",
+    claude_session_id:"none", lock_path:"x", lock_acquired_at:"x", last_heartbeat_at:"x",
+    current_item:null, current_item_started_at:null, exit_reason:null}' > "$lock_dir/meta.json"
 rm -f "$S/state/grind"/*.json
 rm -f "$S/claude-replies"/*.json
 reply 0.10 "done" 1


### PR DESCRIPTION
## What

Second half of the split requested on #173. Builds on that PR's lock and
adds:

- richer identity captured once at startup: ppid, user, tty, invoked cwd,
  the grind script's own git rev, and the calling Claude session id;
- the lock's meta.json gains `current_item` / `current_item_started_at`
  (updated at item start and on every heartbeat, cleared when the item
  finishes) and `last_heartbeat_at`;
- all of it mirrored into the session state file's own `lock` key, so a
  state file alone answers "is this run still going, and on what" without
  needing to also find the lock directory.

## Why

Requested directly: a stuck lock or a crashed grind is much easier to
diagnose with "who, where, doing what, since when" already sitting in the
state file, even though most of it duplicates what's in the lock's own
meta.json.

## Base

Based on `claude/grind-script-github-usage-1b08c8` (#173), not `main` --
merge #173 first.

## Verification

`bash .local/bin/grind.test.sh` -- 88 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
