### PR TITLE
grind: let the worker commit, and check what it claims

### DIFF
--- a/.local/bin/grind
+++ b/.local/bin/grind
@@ -20,11 +20,19 @@
 #   3. Parse the final result event for cost and tokens; print one line:
 #      item, model, cost, tokens, running total, percent of session budget.
 #      Crossing 25/50/75% prints a louder line, once each, per session.
-#   4. A worker that decides an item needs a human ruling ends its final
-#      message with the line "GRIND_STATUS: carded" (having filed the card
-#      itself, per this repo's card-write convention) instead of guessing.
-#      grind matches that line, logs "carded", and moves to the next item
-#      without treating it as a failure.
+#   4. The worker ends its final message with one of three status lines:
+#      "GRIND_STATUS: done" (the PR is open), "GRIND_STATUS: carded" (a
+#      ruling only the repo owner can make; the worker filed the card
+#      itself, per this repo's card-write convention), or
+#      "GRIND_STATUS: blocked" (the item cannot be worked at all). None of
+#      the first two is taken on trust: `done` is checked against a PR whose
+#      head is the item's branch, `carded` against the board file's mtime or
+#      a comment added to the issue while the worker ran. A claim that does
+#      not check out becomes status "unverified" -- loud on stderr, cost
+#      kept, worktree kept for inspection, retried on --resume. Run
+#      grind-20260912T210131Z spent $4.39 on three items that all reported
+#      success and left no PR, no card and no commit behind; that is the
+#      failure these checks exist to catch.
 #   5. Pause -- print a tally and the exact resume command, then exit 0 --
 #      when: the session budget is reached, one item costs more than twice
 #      the running median, or every N items. Nothing here waits on a
@@ -46,8 +54,13 @@
 # Output: one INFO line per unit of work started and finished, a heartbeat
 # every --heartbeat seconds (default 60, 0 disables) while a worker runs, WARN
 # for a skipped item, ERR when the run ends with skips (exit 1). The worker
-# gets --permission-mode (default acceptEdits) so it never waits on a
-# terminal; bypassPermissions is the caller's call, not the default. A
+# gets --permission-mode (default bypassPermissions) so it never waits on a
+# terminal. acceptEdits was the default until it turned out to deny every
+# Bash call -- git add, git commit and gh among them -- which makes finishing
+# an item impossible: the worker edits files and can then do nothing with
+# them. A worker runs unattended in a throwaway worktree it is meant to
+# commit and push, so that is the mode it needs; --permission-mode narrows it
+# again for a caller who wants that. A
 # heartbeat line carries a live, `~`-marked token/cost estimate once the
 # worker has emitted at least one assistant event, e.g.:
 #   still working on owner/repo#97 (3m elapsed, ~48k tokens, ~$0.90 so far)
@@ -82,7 +95,10 @@ dry_run=0
 repo=""
 resume_id=""
 heartbeat=60
-permission_mode=acceptEdits
+permission_mode=bypassPermissions
+# Where a `carded` worker is expected to have written: the global board.
+# Overridable for tests and for a machine that keeps the state repo elsewhere.
+board_file=${GRIND_BOARD:-$HOME/claude_prompts_scratch/state/global/kanban.md}
 
 while [ $# -gt 0 ]; do
   case $1 in
@@ -159,10 +175,11 @@ fi
 # refs (owner/repo#N) already accounted for from a prior run of this session,
 # delimited so a ref that is a prefix of another (e.g. #5 vs #50) can't
 # falsely match on a raw substring test.
-# Items recorded as failed keep their cost but are retried, so they are
-# excluded here.
+# Items recorded as failed or unverified keep their cost but are retried, so
+# they are excluded here. A blocked item is accounted for: a later grind run
+# picks it up once whatever blocks it is gone.
 done_refs="|"
-[ -f "$state_file" ] && done_refs="|$(jq -r '.items[] | select(.status != "failed") | .ref' "$state_file" | tr '\n' '|')"
+[ -f "$state_file" ] && done_refs="|$(jq -r '.items[] | select(.status != "failed" and .status != "unverified") | .ref' "$state_file" | tr '\n' '|')"
 
 is_done_ref() {
   case "$done_refs" in *"|$1|"*) return 0 ;; esac
@@ -203,15 +220,52 @@ finish() {
 # --- one worktree per item -----------------------------------------------------
 worktree_root=${TMPDIR:-/tmp}/grind-worktrees
 
+# build_prompt <issue body> <ref> <branch>
 build_prompt() {
-  body=$1
+  body=$1; p_ref=$2; p_branch=$3
   printf '%s\n\n---\n' "$body"
-  printf 'Grind orchestration contract: work this item to a mergeable PR and open\n'
-  printf 'it yourself; do not merge it. If finishing it requires a ruling only the\n'
-  printf 'repo owner can make, do not guess -- file the card per this repo'"'"'s\n'
-  printf 'card-write convention, then end your final message with exactly this\n'
-  printf 'line and nothing after it: GRIND_STATUS: carded\n'
-  printf 'Otherwise end your final message with exactly: GRIND_STATUS: done\n'
+  printf 'Grind orchestration contract for %s.\n\n' "$p_ref"
+  printf 'You are alone in a fresh worktree on branch %s. Work the item to a\n' "$p_branch"
+  printf 'mergeable PR: commit, push the branch, and open the PR yourself with gh.\n'
+  printf 'Do not merge it. The worktree is deleted when you exit, so anything you\n'
+  printf 'have not committed and pushed is lost.\n\n'
+  printf 'End your final message with exactly one of these lines, nothing after it:\n\n'
+  printf '  GRIND_STATUS: done     the PR is open. grind checks that a PR exists\n'
+  printf '                         with head branch %s and records the item\n' "$p_branch"
+  printf '                         unverified if none does.\n'
+  printf '  GRIND_STATUS: carded   finishing needs a ruling only the repo owner can\n'
+  printf '                         make. File the card first, per this repo'"'"'s\n'
+  printf '                         card-write convention. grind checks that the\n'
+  printf '                         board changed or the issue gained a comment, and\n'
+  printf '                         records the item unverified if neither did.\n'
+  printf '  GRIND_STATUS: blocked  the item cannot be worked at all -- a missing\n'
+  printf '                         dependency, an unmet precondition, work that\n'
+  printf '                         belongs to another item. Comment on the issue\n'
+  printf '                         saying why, so the reason outlives this session.\n'
+}
+
+# --- verifying the worker's claim ---------------------------------------------
+# A worker reporting success costs the same as one that did the work, so the
+# claim is checked against GitHub rather than believed. Both checks fail
+# closed: a gh call that errors leaves the item unverified.
+
+# verify_pr <branch> -- a PR in any state whose head is this item's branch
+verify_pr() {
+  n=$(gh pr list --repo "$repo" --head "$1" --state all --json number --jq 'length' 2>/dev/null) || return 1
+  case "$n" in ''|*[!0-9]*) return 1 ;; esac
+  [ "$n" -gt 0 ]
+}
+
+# verify_carded <issue number> <marker file> <worker start, ISO 8601>
+# Either the board file was written after the marker, or the issue gained a
+# comment at/after the worker started.
+verify_carded() {
+  # find -newer, not test -nt: -nt is not in POSIX sh (shellcheck SC3013).
+  if [ -f "$board_file" ] && [ -n "$(find "$board_file" -newer "$2" 2>/dev/null)" ]; then return 0; fi
+  c=$(gh issue view "$1" --repo "$repo" --json comments \
+        --jq "[.comments[] | select(.createdAt >= \"$3\")] | length" 2>/dev/null) || return 1
+  case "$c" in ''|*[!0-9]*) return 1 ;; esac
+  [ "$c" -gt 0 ]
 }
 
 # --- live cost estimate (heartbeat only; the final line uses the exact
@@ -303,8 +357,11 @@ while [ "$i" -lt "$count" ]; do
 
   info "[$i/$count] starting $ref -- $title"
   mkdir -p "$worktree_root"
-  git worktree prune >/dev/null 2>&1 || true
+  # Remove the directory first, then prune: a worktree kept from a previous
+  # unverified attempt is still registered, and git refuses to delete a
+  # branch a registered worktree holds.
   rm -rf "$wt_path"
+  git worktree prune >/dev/null 2>&1 || true
   git branch -D "$branch" >/dev/null 2>&1 || true
   if ! wt_err=$(git worktree add -q -b "$branch" "$wt_path" 2>&1 >/dev/null); then
     warn "skipping $ref -- could not create worktree $wt_path on branch $branch: $wt_err"
@@ -313,8 +370,13 @@ while [ "$i" -lt "$count" ]; do
   fi
   info "worktree $wt_path on branch $branch"
 
-  prompt=$(build_prompt "$(printf '%s' "$item" | jq -r '.body')")
+  prompt=$(build_prompt "$(printf '%s' "$item" | jq -r '.body')" "$ref" "$branch")
   started=$(date +%s)
+  # Reference points for the carded check: a marker the board file must be
+  # newer than, and the wall-clock instant a new issue comment must follow.
+  started_iso=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  marker="$state_root/${session_id}.marker"
+  : > "$marker"
   info "worker running: claude -p --model $model --effort $effort --max-budget-usd $item_budget --permission-mode $permission_mode (heartbeat every ${heartbeat}s)"
 
   # live_file holds "input output cache_read cache_creation" running totals,
@@ -386,11 +448,11 @@ while [ "$i" -lt "$count" ]; do
   if [ -n "$hb_pid" ]; then kill "$hb_pid" 2>/dev/null; wait "$hb_pid" 2>/dev/null || true; fi
   info "worker exited $claude_rc after $(( $(date +%s) - started ))s"
 
-  git worktree remove -f "$wt_path" >/dev/null 2>&1 || true
-
   # Unparseable/empty JSON means the worker never produced a result, so its
   # spend is unknown: don't record it, and let --resume retry it.
   if ! printf '%s' "$result_json" | jq -e . >/dev/null 2>&1; then
+    git worktree remove -f "$wt_path" >/dev/null 2>&1 || true
+    rm -f "$marker"
     printf 'FAILED: %s -- %s -- claude invocation did not complete; not recorded, will retry on --resume\n' \
       "$ref" "$title" >&2
     continue
@@ -408,8 +470,38 @@ while [ "$i" -lt "$count" ]; do
   # spent money: record the cost so the session budget stays honest, but mark
   # it failed so --resume retries it instead of skipping it forever.
   status=done
-  case "$text" in *"GRIND_STATUS: carded"*) status=carded ;; esac
+  case "$text" in
+    *"GRIND_STATUS: carded"*)  status=carded ;;
+    *"GRIND_STATUS: blocked"*) status=blocked ;;
+  esac
   if [ "$claude_rc" -ne 0 ] || [ "$is_error" = true ]; then status=failed; fi
+
+  # Check the claim. `blocked` asserts nothing about the world, so there is
+  # nothing to check; `failed` is already a failure.
+  unverified_why=""
+  case "$status" in
+    done)
+      if ! verify_pr "$branch"; then
+        unverified_why="no PR with head branch $branch"
+        status=unverified
+      fi
+      ;;
+    carded)
+      if ! verify_carded "$number" "$marker" "$started_iso"; then
+        unverified_why="board file unchanged and no new comment on the issue"
+        status=unverified
+      fi
+      ;;
+  esac
+  rm -f "$marker"
+
+  # An unverified item keeps its worktree: it is the only remaining record of
+  # what the worker did, and the next attempt at this item clears it anyway.
+  if [ "$status" = unverified ]; then
+    warn "keeping worktree $wt_path on branch $branch for inspection"
+  else
+    git worktree remove -f "$wt_path" >/dev/null 2>&1 || true
+  fi
 
   running_total=$(awk -v a="$running_total" -v b="$cost" 'BEGIN { printf "%.4f", a + b }')
   processed_this_run=$((processed_this_run + 1))
@@ -421,8 +513,14 @@ while [ "$i" -lt "$count" ]; do
   if [ "$status" = failed ]; then
     printf 'FAILED: %s -- %s -- worker reported an error (%s, %s tokens, running %s / %s -- %s%%); will retry on --resume\n' \
       "$ref" "$title" "$(fmt_usd "$cost")" "$tokens" "$(fmt_usd "$running_total")" "$(fmt_usd "$session_budget")" "$percent" >&2
+  elif [ "$status" = unverified ]; then
+    printf 'UNVERIFIED: %s -- %s -- worker claimed success but %s (%s, %s tokens, running %s / %s -- %s%%); will retry on --resume\n' \
+      "$ref" "$title" "$unverified_why" "$(fmt_usd "$cost")" "$tokens" "$(fmt_usd "$running_total")" "$(fmt_usd "$session_budget")" "$percent" >&2
   elif [ "$status" = carded ]; then
     printf 'carded: %s -- %s (%s, %s tokens, running %s / %s -- %s%%)\n' \
+      "$ref" "$title" "$(fmt_usd "$cost")" "$tokens" "$(fmt_usd "$running_total")" "$(fmt_usd "$session_budget")" "$percent"
+  elif [ "$status" = blocked ]; then
+    printf 'blocked: %s -- %s (%s, %s tokens, running %s / %s -- %s%%)\n' \
       "$ref" "$title" "$(fmt_usd "$cost")" "$tokens" "$(fmt_usd "$running_total")" "$(fmt_usd "$session_budget")" "$percent"
   else
     printf '%s: %s -- %s, %s, %s tokens -- running %s / %s -- %s%%\n' \

--- a/.local/bin/grind.test.sh
+++ b/.local/bin/grind.test.sh
@@ -5,9 +5,12 @@
 # command per item without spending anything; a real run parses cost/tokens
 # out of the worker's JSON, prints the running-total/percent line, and pauses
 # -- with the exact resume command -- on session budget, an outlier item cost,
-# or the pause-every cadence; a carded worker is logged and not treated as a
-# failure; --resume skips what a prior run already accounted for. gh and
-# claude are both faked; no real `claude -p` is ever invoked.
+# or the pause-every cadence; a carded or blocked worker is logged and not
+# treated as a failure; a done or carded claim that GitHub does not bear out
+# is UNVERIFIED, keeps its worktree and retries; the worker gets a permission
+# mode that can run git and gh; --resume skips what a prior run already
+# accounted for. gh and claude are both faked; no real `claude -p` is ever
+# invoked.
 set -uo pipefail
 
 GRIND="$(cd "$(dirname "$0")" && pwd)/grind"
@@ -39,11 +42,31 @@ cat > "$S/ready.json" <<'JSON'
 ]
 JSON
 
+# What grind's verification asks gh for, canned. `pr list` answers the
+# `done` check (a PR whose head is the item's branch), `issue view` the
+# `carded` one (a comment added while the worker ran). Both are queried with
+# a --jq filter, so the shim applies whatever filter grind passed to the
+# canned document rather than second-guessing it.
+cat > "$S/pr-list.json" <<'JSON'
+[{"number": 300}]
+JSON
+cat > "$S/issue-comments.json" <<'JSON'
+{"comments": []}
+JSON
+
 cat > "$S/bin/gh" <<GH
 #!/bin/sh
 echo "\$*" >> "$GH_LOG"
+filter=""; prev=""
+for a in "\$@"; do
+  [ "\$prev" = "--jq" ] && filter=\$a
+  prev=\$a
+done
+[ -n "\$filter" ] || filter="."
 case "\$1 \$2" in
   "issue list") cat "$S/ready.json" ;;
+  "pr list")    jq -r "\$filter" "$S/pr-list.json" ;;
+  "issue view") jq -r "\$filter" "$S/issue-comments.json" ;;
   *) echo "gh shim: unexpected \$*" >&2; exit 1 ;;
 esac
 GH
@@ -58,7 +81,7 @@ chmod +x "$S/bin/gh"
 mkdir -p "$S/claude-replies"
 cat > "$S/bin/claude" <<GH
 #!/bin/sh
-cat > /dev/null
+cat > "$S/prompt.txt"
 n=\$(cat "$S/claude-next" 2>/dev/null || echo 1)
 echo "\$n \$*" >> "$CLAUDE_LOG"
 echo \$((n + 1)) > "$S/claude-next"
@@ -118,11 +141,35 @@ has 'second item line: running total accumulates' '^o/alpha#20: Second item -- s
 has 'queue exhausted, final tally' '^done: Ready queue exhausted\. Running total \$3\.00 / \$20\.00\. 0 skipped\.$'
 has 'INFO: session line names repo, count, model, caps' 'INFO  session grind-.* on o/alpha: 2 Ready item\(s\), sonnet/medium, cap \$5\.00/item \$20\.00/session'
 has 'INFO: item start line' 'INFO  \[1/2\] starting o/alpha#5 -- First item'
-has 'INFO: worker line names the permission mode' 'INFO  worker running: .*--permission-mode acceptEdits'
+has 'INFO: worker line names the permission mode' 'INFO  worker running: .*--permission-mode bypassPermissions'
 has 'INFO: worker exit line' 'INFO  worker exited 0 after [0-9]+s'
-has 'worker gets --permission-mode' '--permission-mode acceptEdits' 
 sess=$(latest_session)
 eq 'two items recorded in state' 2 "$(jq '.items | length' "$sess")"
+
+# --- the worker's permission mode lets it run git and gh -------------------------
+# acceptEdits, the old default, denies every Bash call: a worker could edit
+# files and then neither commit them nor open a PR, which is how run
+# grind-20260912T210131Z spent $4.39 and produced nothing.
+eq 'the default mode is bypassPermissions, not acceptEdits' 2 \
+  "$(grep -c -- '--permission-mode bypassPermissions' "$CLAUDE_LOG")"
+lacks 'acceptEdits is never passed by default' 'permission-mode acceptEdits'
+: > "$CLAUDE_LOG"
+rm -f "$S/state/grind"/*.json "$S/claude-replies"/*.json
+run --session-budget 100 --pause-every 1 --permission-mode acceptEdits
+assert '--permission-mode still overrides the default' \
+  grep -q -- '--permission-mode acceptEdits' "$CLAUDE_LOG"
+
+# --- the prompt contract names the branch and all three statuses -----------------
+PROMPT=$(cat "$S/prompt.txt")
+prompt_has() { if printf '%s\n' "$PROMPT" | grep -Fq -- "$2"; then ok; else bad "$1 (missing [$2])"; fi; }
+prompt_has 'the issue body is the prompt' 'do the first thing'
+prompt_has 'the contract names the item' 'Grind orchestration contract for o/alpha#5'
+prompt_has 'it names the branch the worker is on' 'branch grind-5'
+prompt_has 'it tells the worker to commit, push and open the PR' 'open the PR yourself with gh'
+prompt_has 'done is offered' 'GRIND_STATUS: done'
+prompt_has 'carded is offered' 'GRIND_STATUS: carded'
+prompt_has 'blocked is offered' 'GRIND_STATUS: blocked'
+prompt_has 'it warns that the claim is checked' 'records the item'
 
 # --- heartbeat: shows a live, ~-marked token/cost estimate before the item
 # finishes, accumulated from two assistant events; the final line still uses
@@ -135,7 +182,7 @@ JSON
 rm -f "$S/state/grind"/*.json
 cat > "$S/bin/claude" <<GH
 #!/bin/sh
-cat > /dev/null
+cat > "$S/prompt.txt"
 echo "\$*" >> "$CLAUDE_LOG"
 echo '{"type":"assistant","message":{"usage":{"input_tokens":10000,"output_tokens":5000,"cache_read_input_tokens":20000,"cache_creation_input_tokens":3000}}}'
 sleep 0.3
@@ -162,7 +209,7 @@ JSON
 rm -f "$S/state/grind"/*.json
 cat > "$S/bin/claude" <<GH
 #!/bin/sh
-cat > /dev/null
+cat > "$S/prompt.txt"
 n=\$(cat "$S/claude-next" 2>/dev/null || echo 1)
 echo "\$n \$*" >> "$CLAUDE_LOG"
 echo \$((n + 1)) > "$S/claude-next"
@@ -242,6 +289,10 @@ lacks 'exactly 2x median does not trip the outlier pause' '^pause: o/alpha#20 co
 has 'runs to completion instead' '^done: Ready queue exhausted'
 
 # --- carded: logged, not a failure, item still counted toward pause-every -------
+# The card is verified: the issue gained a comment while the worker ran.
+cat > "$S/issue-comments.json" <<'JSON'
+{"comments": [{"createdAt": "2999-01-01T00:00:00Z"}]}
+JSON
 rm -f "$S/state/grind"/*.json
 rm -f "$S/claude-replies"/*.json
 reply 0.50 "carded" 1
@@ -252,6 +303,101 @@ has 'carded item logged distinctly' '^carded: o/alpha#5 -- First item'
 sess=$(latest_session)
 eq 'carded status recorded' 'carded' "$(jq -r '.items[0].status' "$sess")"
 has 'pauses on cadence after two items (one carded)' '^pause: 2 items processed this run'
+
+# --- verification: a claim that does not check out is UNVERIFIED ----------------
+# Run grind-20260912T210131Z reported "carded" twice and "done" once and left
+# no card, no issue comment and no PR behind. Both claims are now checked.
+
+# `done` with no PR on the item's branch
+cat > "$S/pr-list.json" <<'JSON'
+[]
+JSON
+rm -f "$S/state/grind"/*.json "$S/claude-replies"/*.json
+reply 0.50 "done" 1
+: > "$CLAUDE_LOG"
+run --session-budget 100 --pause-every 1
+has 'a done claim with no PR is UNVERIFIED, and says why' \
+  '^UNVERIFIED: o/alpha#5 -- First item -- worker claimed success but no PR with head branch grind-5 \(\$0\.50, 150 tokens, running \$0.50 / \$100.00 -- 0%\); will retry on --resume'
+lacks 'no success line for an unverified item' '^o/alpha#5: First item --'
+assert 'gh was asked for a PR whose head is the item branch' \
+  grep -q -- 'pr list --repo o/alpha --head grind-5 --state all' "$GH_LOG"
+has 'the worktree is kept for inspection' 'WARN  keeping worktree .*grind-worktrees/5 on branch grind-5 for inspection'
+assert 'and it really is still on disk' test -d "$TMPDIR/grind-worktrees/5"
+sess=$(latest_session)
+eq 'recorded as unverified' unverified "$(jq -r '.items[0].status' "$sess")"
+eq 'its cost is still counted' 0.50 "$(jq -r '.items[0].cost' "$sess")"
+
+# ...and --resume retries it, reusing the branch the kept worktree holds
+session_id=$(basename "$sess" .json)
+cat > "$S/pr-list.json" <<'JSON'
+[{"number": 300}]
+JSON
+rm -f "$S/claude-replies"/*.json
+reply 0.50 "done" 1
+: > "$CLAUDE_LOG"
+run --resume "$session_id" --pause-every 1
+eq 'an unverified item is retried on resume' 1 "$(calls_claude)"
+has 'the retry, with a PR this time, is a plain success line' '^o/alpha#5: First item -- sonnet, \$0\.50,'
+
+# `carded` with an untouched board and no new comment on the issue
+cat > "$S/issue-comments.json" <<'JSON'
+{"comments": [{"createdAt": "2001-01-01T00:00:00Z"}]}
+JSON
+rm -f "$S/state/grind"/*.json "$S/claude-replies"/*.json
+reply 0.50 "carded" 1
+: > "$CLAUDE_LOG"
+run --session-budget 100 --pause-every 1
+has 'a carded claim with nothing written is UNVERIFIED, and says why' \
+  '^UNVERIFIED: o/alpha#5 -- First item -- worker claimed success but board file unchanged and no new comment on the issue'
+lacks 'not logged as carded' '^carded: o/alpha#5'
+
+# a card written to the board file counts too, without any issue comment
+export GRIND_BOARD="$S/kanban.md"
+: > "$GRIND_BOARD"
+cat > "$S/bin/claude" <<GH
+#!/bin/sh
+cat > "$S/prompt.txt"
+echo "\$*" >> "$CLAUDE_LOG"
+sleep 1.1
+printf -- '- [ ] a card\n' >> "$GRIND_BOARD"
+echo '{"type":"result","total_cost_usd":0.50,"usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":0,"cache_creation_input_tokens":0},"result":"GRIND_STATUS: carded"}'
+GH
+chmod +x "$S/bin/claude"
+rm -f "$S/state/grind"/*.json
+: > "$CLAUDE_LOG"
+run --session-budget 100 --pause-every 1
+has 'a board file written during the run verifies the card' '^carded: o/alpha#5 -- First item'
+unset GRIND_BOARD
+
+# --- blocked: a third status, logged, recorded, not retried ---------------------
+cat > "$S/bin/claude" <<GH
+#!/bin/sh
+cat > "$S/prompt.txt"
+n=\$(cat "$S/claude-next" 2>/dev/null || echo 1)
+echo "\$n \$*" >> "$CLAUDE_LOG"
+echo \$((n + 1)) > "$S/claude-next"
+reply="$S/claude-replies/\$n.json"
+if [ -f "\$reply" ]; then cat "\$reply"; else
+  echo '{"type":"assistant","message":{"usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}'
+  echo '{"type":"result","total_cost_usd":0.10,"usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":0,"cache_creation_input_tokens":0},"result":"GRIND_STATUS: done"}'
+fi
+GH
+chmod +x "$S/bin/claude"
+rm -f "$S/state/grind"/*.json "$S/claude-replies"/*.json
+reply 0.50 "blocked" 1
+reply 0.50 "done" 2
+: > "$CLAUDE_LOG"
+run --session-budget 100 --pause-every 2
+has 'blocked item logged distinctly' '^blocked: o/alpha#5 -- First item \(\$0\.50, 150 tokens, running \$0.50 / \$100.00 -- 0%\)'
+lacks 'a blocked item is not a failure' '^FAILED: o/alpha#5'
+lacks 'nor an unverified claim -- blocked asserts nothing to check' '^UNVERIFIED: o/alpha#5'
+sess=$(latest_session)
+eq 'blocked status recorded' blocked "$(jq -r '.items[0].status' "$sess")"
+eq 'the next item still runs' 2 "$(calls_claude)"
+session_id=$(basename "$sess" .json)
+: > "$CLAUDE_LOG"
+run --resume "$session_id"
+eq 'a blocked item is accounted for, not retried on resume' 0 "$(calls_claude)"
 
 # --- pause-every cadence, exact count ---------------------------------------------
 rm -f "$S/state/grind"/*.json
@@ -331,7 +477,7 @@ rm -f "$S/state/grind"/*.json
 rm -f "$S/claude-replies"/*.json
 cat > "$S/bin/claude" <<GH
 #!/bin/sh
-cat > /dev/null
+cat > "$S/prompt.txt"
 n=\$(cat "$S/claude-next" 2>/dev/null || echo 1)
 echo "\$n \$*" >> "$CLAUDE_LOG"
 echo \$((n + 1)) > "$S/claude-next"
@@ -348,7 +494,7 @@ eq 'failed item is not recorded in state' 0 "$(jq '.items | length' "$sess")"
 # restore the real claude shim and confirm --resume retries the failed item
 cat > "$S/bin/claude" <<GH
 #!/bin/sh
-cat > /dev/null
+cat > "$S/prompt.txt"
 n=\$(cat "$S/claude-next" 2>/dev/null || echo 1)
 echo "\$n \$*" >> "$CLAUDE_LOG"
 echo \$((n + 1)) > "$S/claude-next"
@@ -370,7 +516,7 @@ eq 'now recorded in state' 1 "$(jq '.items | length' "$sess")"
 rm -f "$S/state/grind"/*.json
 cat > "$S/bin/claude" <<GH
 #!/bin/sh
-cat > /dev/null
+cat > "$S/prompt.txt"
 n=\$(cat "$S/claude-next" 2>/dev/null || echo 1)
 echo "\$n \$*" >> "$CLAUDE_LOG"
 echo \$((n + 1)) > "$S/claude-next"
@@ -393,7 +539,7 @@ eq 'failed-with-cost item retried on resume' 1 "$(calls_claude)"
 # restore the real claude shim
 cat > "$S/bin/claude" <<GH
 #!/bin/sh
-cat > /dev/null
+cat > "$S/prompt.txt"
 n=\$(cat "$S/claude-next" 2>/dev/null || echo 1)
 echo "\$n \$*" >> "$CLAUDE_LOG"
 echo \$((n + 1)) > "$S/claude-next"


### PR DESCRIPTION
Run `grind-20260912T210131Z` spent $4.39 and 11.0M tokens on three items and
produced nothing: #96 and #100 reported `carded` with no card and no issue
comment, #97 reported `done` with no PR, and all three branches were 0 commits
ahead of main. Two causes.

## The worker could not run git or gh

It was launched with `--permission-mode acceptEdits`, which denies every Bash
call. A worker in that mode edits files in its worktree and can then do nothing
with them — no commit, no push, no `gh pr create`, no card. The default is now
`bypassPermissions`. The worker is unattended in a throwaway worktree it is
meant to push; `--permission-mode` still narrows it for a caller who wants that.

## grind believed whatever the worker said

It now checks the claim, and both checks fail closed:

| claim | check |
|---|---|
| `GRIND_STATUS: done` | a PR exists whose head is the item's branch |
| `GRIND_STATUS: carded` | the board file was written, or the issue gained a comment, while the worker ran |
| `GRIND_STATUS: blocked` | nothing — it asserts nothing about the world |

A claim that does not check out becomes status `unverified`: loud on stderr with
the reason, cost kept so the session budget stays honest, **worktree kept** so
the work is still there to look at, and retried on `--resume`. (Retrying a kept
worktree needed one ordering fix — `rm -rf` before `git worktree prune`, since
git refuses to delete a branch a registered worktree holds.)

`blocked` is the new third status, for an item that cannot be worked at all — a
missing dependency, an unmet precondition. Logged, recorded, not retried; the
worker is told to comment on the issue saying why.

The prompt contract was rewritten to say all of this to the worker, including
that grind checks and that the worktree is deleted when it exits.

## Tests

`grind.test.sh`: 103 assertions, all passing. New coverage for the permission
mode (default and override), the prompt contract, `done` with no PR, `carded`
with nothing written, `carded` verified two ways (issue comment, board mtime),
`blocked`, and the retry-on-resume behaviour of an unverified item. `gh pr list`
and `gh issue view` are faked alongside the existing shims; no real `claude -p`
runs.

## This needs `churn-ok`

One gated script, 149 changed lines against a budget of 20. Splitting helps
less than it looks: the permission fix alone would pass, but the verification
half is ~110 lines however it is cut, and the two are one repair — the mode fix
lets a worker finish, the checks prove it did. Say the word and I'll restack it
as two PRs instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

